### PR TITLE
:memo: docs: introduce deck versioning model

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -24,12 +24,14 @@ The frontend is built with **React.js** (via Symfony UX / Webpack Encore) for al
 | ID     | Feature                              | Priority | Description |
 |--------|--------------------------------------|----------|-------------|
 | F2.1   | Register a deck                      | High     | A user registers a physical deck they own, assigning it a name, archetype, and format (Expanded). |
-| F2.2   | Import deck list (copy-paste)        | High     | User pastes a deck list in standard PTCG text format. The system parses it (`ptcgo-parser`), validates each card against TCGdex, checks Expanded legality (Black & White onward + banned list), and stores the parsed cards. The raw text is preserved for reference. |
-| F2.3   | Deck detail view                     | Medium   | Display deck info: owner, archetype, card list (categorized: Pokemon / Trainer by subtype / Energy, sorted by quantity then name), availability status, languages, borrow history. Mouse over a card name shows the card image (from TCGdex). |
+| F2.2   | Import deck list (copy-paste)        | High     | User pastes a deck list in standard PTCG text format. The system parses it (`ptcgo-parser`), validates each card against TCGdex, checks Expanded legality (Black & White onward + banned list), and creates a new `DeckVersion` with the parsed cards. The raw text is preserved on the version for reference. `Deck.currentVersion` is updated to the newly created version. |
+| F2.3   | Deck detail view                     | Medium   | Display deck info: owner, current version's archetype and card list (categorized: Pokemon / Trainer by subtype / Energy, sorted by quantity then name), availability status, languages, borrow history, and version history with the ability to view past versions. Mouse over a card name shows the card image (from TCGdex). |
 | F2.4   | Deck catalog (browse & search)       | Medium   | List all registered decks with filters: archetype, owner, availability, format. |
 | F2.5   | Deck availability status             | High     | Each deck has a real-time status: available, lent, reserved, retired. |
 | F2.6   | Deck archetype management            | Low      | Admin-managed list of archetypes (e.g. "Lugia VSTAR", "Mew VMAX") for consistent categorization. |
 | F2.7   | Retire / reactivate a deck           | Low      | Owner can mark a deck as retired (no longer available) or reactivate it. |
+| F2.8   | Update deck list (new version)       | High     | Owner pastes an updated deck list → creates a new `DeckVersion`. `Deck.currentVersion` moves to the new version. Previous versions are preserved for history. Archetype, languages, and estimated value can be updated per version. |
+| F2.9   | Deck version history                 | Medium   | View all past versions of a deck: version number, archetype, creation date, and card list. Compare versions to see what changed (cards added/removed/quantity changed). |
 
 ## F3 — Event Management
 
@@ -41,6 +43,7 @@ The frontend is built with **React.js** (via Symfony UX / Webpack Encore) for al
 | F3.4   | Register participation to an event   | Medium   | A player declares they intend to attend an event (prerequisite to requesting a borrow). |
 | F3.5   | Assign event staff team              | High     | An organizer assigns staff members to an event. Staff role is **per event** (not a global role). Staff can then act as intermediaries for deck lending at that event only. |
 | F3.6   | Tournament ID verification (to investigate) | Low | Investigate whether the Pokemon tournament system exposes an API to verify that the organizer is the actual TO of the referenced tournament ID. |
+| F3.7   | Register played deck for event       | Medium   | A player (deck owner or borrower) records which deck version they played at an event, creating an `EventDeckEntry`. This is separate from borrowing — it tracks tournament deck registration for history and traceability. |
 
 ## F4 — Borrow Workflow
 

--- a/docs/models/borrow.md
+++ b/docs/models/borrow.md
@@ -13,7 +13,8 @@ Represents the full lifecycle of a deck borrow request — from request to retur
 | Field              | Type               | Nullable | Description |
 |--------------------|--------------------|----------|-------------|
 | `id`               | `int` (auto)       | No       | Primary key |
-| `deck`             | `Deck`             | No       | The deck being borrowed. |
+| `deck`             | `Deck`             | No       | The physical deck being borrowed. |
+| `deckVersion`      | `DeckVersion`      | No       | The version of the deck at the time of the borrow. Records the exact card list. |
 | `borrower`         | `User`             | No       | The user requesting to borrow the deck. |
 | `event`            | `Event`            | No       | The event this borrow is for. |
 | `status`           | `string(30)`       | No       | Current borrow status. See Status enum below. Default: `"pending"`. |
@@ -90,7 +91,8 @@ lent ──(event end + grace period)──→ overdue → returned
 
 | Relation           | Type         | Target entity  | Description |
 |--------------------|--------------|----------------|-------------|
-| `deck`             | ManyToOne    | `Deck`         | The borrowed deck |
+| `deck`             | ManyToOne    | `Deck`         | The physical deck being borrowed |
+| `deckVersion`      | ManyToOne    | `DeckVersion`  | The exact card list version at borrow time |
 | `borrower`         | ManyToOne    | `User`         | Who is borrowing |
 | `event`            | ManyToOne    | `Event`        | For which event |
 | `approvedBy`       | ManyToOne    | `User`         | Who approved |

--- a/docs/models/deck.md
+++ b/docs/models/deck.md
@@ -6,7 +6,7 @@
 
 ## Entity: `App\Entity\Deck`
 
-Represents a physical Pokemon TCG deck owned by a user.
+Represents a **physical** Pokemon TCG deck — the deck box with a label. A deck evolves over time: the owner may swap cards, shift archetypes, or change value. The card-level data lives on `DeckVersion`; `Deck` only tracks identity, ownership, and availability.
 
 ### Fields
 
@@ -15,14 +15,10 @@ Represents a physical Pokemon TCG deck owned by a user.
 | `id`               | `int` (auto)       | No       | Primary key |
 | `name`             | `string(100)`      | No       | Owner-given name for this deck (e.g. "My Lugia VSTAR"). |
 | `owner`            | `User`             | No       | The user who owns this physical deck. |
-| `archetype`        | `string(80)`       | Yes      | Archetype identifier (e.g. `"lugia-vstar"`). Manually set by the owner. |
-| `archetypeName`    | `string(100)`      | Yes      | Human-readable archetype name (e.g. `"Lugia VSTAR"`). |
 | `format`           | `string(30)`       | No       | Play format. Default: `"Expanded"`. |
-| `languages`        | `json`             | No       | Array of ISO 639-1 language codes present in the deck (e.g. `["en", "ja"]`). A deck can contain cards in mixed languages. |
-| `estimatedValue`   | `decimal(8,2)`     | Yes      | Owner-provided estimated monetary value of the deck (in EUR). Visible to the owner, organizers, and event staff. Helps inform delegation decisions for costly decks. |
 | `status`           | `string(20)`       | No       | Current availability status. See Status enum below. Default: `"available"`. |
 | `notes`            | `text`             | Yes      | Owner's private notes about the deck (e.g. sleeve color, missing cards, condition). |
-| `rawList`          | `text`             | Yes      | The original PTCG text format pasted by the owner. Preserved for reference and re-import. |
+| `currentVersion`   | `DeckVersion`      | Yes      | The latest/active version of this deck. Null only before the first list import. |
 | `createdAt`        | `DateTimeImmutable` | No      | Deck registration timestamp. |
 | `updatedAt`        | `DateTimeImmutable` | Yes     | Last modification timestamp. |
 
@@ -34,6 +30,41 @@ Represents a physical Pokemon TCG deck owned by a user.
 | `reserved`  | A borrow request has been approved but the deck hasn't been handed off yet. |
 | `lent`      | Deck is currently lent to a borrower (or held by event staff). |
 | `retired`   | Owner has retired this deck. Not available for borrowing. |
+
+### Constraints
+
+- `name`: required, 2–100 characters
+- `owner`: required, must be a verified user
+- `status`: required, must be a valid `DeckStatus` value
+
+### Relations
+
+| Relation           | Type         | Target entity  | Description |
+|--------------------|--------------|----------------|-------------|
+| `owner`            | ManyToOne    | `User`         | User who owns this deck |
+| `versions`         | OneToMany    | `DeckVersion`  | All versions of this deck (card list snapshots) |
+| `currentVersion`   | ManyToOne    | `DeckVersion`  | Pointer to the active version |
+| `borrows`          | OneToMany    | `Borrow`       | Borrow history for this deck |
+
+---
+
+## Entity: `App\Entity\DeckVersion`
+
+A **card list snapshot** — one point-in-time version of a deck. Created when the owner first imports a deck list, and again each time they paste an updated list (F2.8). Previous versions are preserved for history and traceability.
+
+### Fields
+
+| Field              | Type               | Nullable | Description |
+|--------------------|--------------------|----------|-------------|
+| `id`               | `int` (auto)       | No       | Primary key |
+| `deck`             | `Deck`             | No       | The deck this version belongs to. |
+| `versionNumber`    | `int`              | No       | Sequential version number (1, 2, 3…). Auto-incremented per deck. |
+| `archetype`        | `string(80)`       | Yes      | Archetype identifier (e.g. `"lugia-vstar"`). Manually set by the owner. |
+| `archetypeName`    | `string(100)`      | Yes      | Human-readable archetype name (e.g. `"Lugia VSTAR"`). |
+| `languages`        | `json`             | No       | Array of ISO 639-1 language codes present in this version (e.g. `["en", "ja"]`). |
+| `estimatedValue`   | `decimal(8,2)`     | Yes      | Owner-provided estimated monetary value (in EUR). Visible to the owner, organizers, and event staff. |
+| `rawList`          | `text`             | Yes      | The original PTCG text format pasted by the owner. Preserved for reference and re-import. |
+| `createdAt`        | `DateTimeImmutable` | No      | When this version was created. |
 
 ### Languages
 
@@ -51,36 +82,33 @@ The `languages` field is a JSON array of ISO 639-1 codes. Common values:
 | `ko` | Korean |
 | `zh` | Chinese |
 
-A deck can contain cards in multiple languages (e.g. `["en", "ja"]` for a mixed English/Japanese deck). This helps borrowers know if they'll be able to read the cards.
+A deck version can contain cards in multiple languages (e.g. `["en", "ja"]` for a mixed English/Japanese deck). This helps borrowers know if they'll be able to read the cards.
 
 ### Constraints
 
-- `name`: required, 2–100 characters
-- `owner`: required, must be a verified user
+- Unique constraint on (`deck`, `versionNumber`) — no duplicate version numbers per deck
 - `languages`: required, at least one language code
 - `estimatedValue`: optional, >= 0 when provided
-- `status`: required, must be a valid `DeckStatus` value
 
 ### Relations
 
 | Relation           | Type         | Target entity  | Description |
 |--------------------|--------------|----------------|-------------|
-| `owner`            | ManyToOne    | `User`         | User who owns this deck |
-| `cards`            | OneToMany    | `DeckCard`     | Cards in this deck (the list) |
-| `borrows`          | OneToMany    | `Borrow`       | Borrow history for this deck |
+| `deck`             | ManyToOne    | `Deck`         | Parent deck |
+| `cards`            | OneToMany    | `DeckCard`     | Cards in this version (the list) |
 
 ---
 
 ## Entity: `App\Entity\DeckCard`
 
-A single card entry in a deck list. Parsed from PTCG text format via `ptcgo-parser`, validated against TCGdex.
+A single card entry in a deck version's card list. Parsed from PTCG text format via `ptcgo-parser`, validated against TCGdex.
 
 ### Fields
 
 | Field              | Type               | Nullable | Description |
 |--------------------|--------------------|----------|-------------|
 | `id`               | `int` (auto)       | No       | Primary key |
-| `deck`             | `Deck`             | No       | The deck this card belongs to. |
+| `deckVersion`      | `DeckVersion`      | No       | The deck version this card belongs to. |
 | `cardName`         | `string(100)`      | No       | Card name (e.g. `"Lugia VSTAR"`). |
 | `setCode`          | `string(20)`       | No       | Set abbreviation (e.g. `"SIT"`, `"BRS"`). |
 | `cardNumber`       | `string(20)`       | No       | Card number within the set (e.g. `"186"`, `"TG1"`). |
@@ -91,10 +119,39 @@ A single card entry in a deck list. Parsed from PTCG text format via `ptcgo-pars
 
 ### Constraints
 
-- Unique constraint on (`deck`, `setCode`, `cardNumber`) — no duplicate card entries per deck
+- Unique constraint on (`deckVersion`, `setCode`, `cardNumber`) — no duplicate card entries per version
 - `quantity`: required, >= 1
 - `cardType`: required, one of `"pokemon"`, `"trainer"`, `"energy"`
 - `trainerSubtype`: required when `cardType` is `"trainer"`, null otherwise
+
+---
+
+## Entity: `App\Entity\EventDeckEntry`
+
+Records which deck version a player played at a specific event. Separate from borrowing — this tracks tournament deck registration regardless of whether the deck was borrowed or owner-played.
+
+### Fields
+
+| Field              | Type               | Nullable | Description |
+|--------------------|--------------------|----------|-------------|
+| `id`               | `int` (auto)       | No       | Primary key |
+| `event`            | `Event`            | No       | The event/tournament. |
+| `player`           | `User`             | No       | The player who played this deck. |
+| `deckVersion`      | `DeckVersion`      | No       | The specific version that was played. |
+| `createdAt`        | `DateTimeImmutable` | No      | When this entry was recorded. |
+
+### Constraints
+
+- Unique constraint on (`event`, `player`, `deckVersion`) — a player can't register the same version twice for the same event
+- `player` must be a participant of the event (F3.4)
+
+### Relations
+
+| Relation           | Type         | Target entity  | Description |
+|--------------------|--------------|----------------|-------------|
+| `event`            | ManyToOne    | `Event`        | The event this entry is for |
+| `player`           | ManyToOne    | `User`         | The player who played the deck |
+| `deckVersion`      | ManyToOne    | `DeckVersion`  | The version that was played |
 
 ---
 
@@ -115,7 +172,10 @@ The system:
 1. **Parses** the text using `ptcgo-parser` (npm) → structured card objects
 2. **Validates** each card against TCGdex → confirms card exists, resolves card type and trainer subtype
 3. **Validates Expanded legality** → checks that all cards are from Black & White series onward and not on the banned list
-4. **Stores** the parsed cards as `DeckCard` entities + preserves the raw text in `Deck.rawList`
+4. **Creates a new `DeckVersion`** with the parsed cards as `DeckCard` entities + preserves the raw text in `DeckVersion.rawList`
+5. **Updates `Deck.currentVersion`** to point to the newly created version
+
+On first import, this creates version 1. On subsequent imports (F2.8), a new version is created and `currentVersion` is updated — previous versions are preserved.
 
 ### Display: Categorized List
 

--- a/docs/models/event.md
+++ b/docs/models/event.md
@@ -46,6 +46,7 @@ The `eventId` field is **free text** intended to hold the official Pokemon sanct
 | `participants`     | ManyToMany   | `User`         | Players registered to attend |
 | `staff`            | OneToMany    | `EventStaff`   | Staff members assigned to this event |
 | `borrows`          | OneToMany    | `Borrow`       | Borrow requests linked to this event |
+| `deckEntries`      | OneToMany    | [`EventDeckEntry`](deck.md#entity-appentityeventdeckentry) | Deck versions registered for this event (F3.7) |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Split `Deck` / `DeckVersion`**: Card-level data (`archetype`, `archetypeName`, `languages`, `estimatedValue`, `rawList`, `cards`) moves from `Deck` to a new `DeckVersion` entity. `Deck` keeps only identity, ownership, and availability.
- **`DeckCard` re-parented**: Now belongs to `DeckVersion` instead of `Deck`. Unique constraint updated accordingly.
- **`Borrow` gains `deckVersion`**: Each borrow records the exact card list version at the time of lending, alongside the existing physical `deck` reference.
- **New `EventDeckEntry` entity**: Records which deck version a player played at a specific event (F3.7), separate from the borrow workflow.
- **New features**: F2.8 (update deck list — new version), F2.9 (deck version history), F3.7 (register played deck for event). Updated F2.2 and F2.3 to reflect versioning.

## Test plan

- [ ] Review `docs/models/deck.md` — Deck, DeckVersion, DeckCard, EventDeckEntry entities are consistent
- [ ] Review `docs/models/borrow.md` — `deckVersion` field and relation added correctly
- [ ] Review `docs/models/event.md` — `deckEntries` relation references EventDeckEntry
- [ ] Review `docs/features.md` — F2.2/F2.3 updated, F2.8/F2.9/F3.7 added with sequential IDs
- [ ] Verify all bidirectional relations match across model docs
- [ ] Confirm no dangling references to removed fields (`Deck.archetype`, `Deck.rawList`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)