### PR TITLE
:rocket: Release: borrow conflict detection, GDPR, banned card list, localization docs

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -192,3 +192,38 @@ See [PDF Label Card](technicalities/pdf_label.md) for full technical details.
 | Visibility  | Deck owner only                                                       |
 | Placement   | Deck detail action bar (alongside edit, retire, etc.)                 |
 | Behavior    | Opens the PDF (`/deck/{id}/label.pdf`) in a new tab for browser print dialog |
+
+---
+
+## Localization & Internationalization
+
+> **@see** docs/features.md F9 — Localization & Internationalization
+
+### Locale Switcher
+
+A `Select` or `SegmentedControl` component in the user profile/settings page allows the user to choose their preferred UI language. The selection is persisted to `User.preferredLocale` (F9.1).
+
+For **unauthenticated pages** (login, registration), the locale falls back to the browser's `Accept-Language` header.
+
+### Translation Infrastructure
+
+| Layer    | Library                  | Catalogue format | Locale source |
+|----------|--------------------------|------------------|---------------|
+| Backend  | Symfony Translation      | YAML (`.yaml`)   | `User.preferredLocale` via locale listener, or `Accept-Language` fallback |
+| Frontend | `react-i18next`          | JSON (`.json`)   | `data-locale` attribute on the root HTML element, set by Twig |
+
+- Translation keys use **dot notation** (e.g. `app.deck.status.available`) matching the project convention
+- Catalogue files live in `translations/` (Symfony) and `assets/translations/` (React)
+- Initial languages: **en** (default), **fr**
+
+### Datetime Display
+
+| Context                   | Timezone used            | Format helper                    | Example |
+|---------------------------|--------------------------|----------------------------------|---------|
+| Event dates               | Event's `timezone`       | `Intl.DateTimeFormat` / `date-fns-tz` | "Sat 15 Mar 2026, 10:00 CET" |
+| Event dates (user hint)   | User's `timezone` (F9.2) | Same, appended                   | "(16:00 your time)" |
+| Borrow timestamps         | User's `timezone`        | `Intl.DateTimeFormat`            | "Requested 2 Mar 2026, 14:30" |
+| Notification timestamps   | User's `timezone`        | Relative or absolute             | "3 hours ago" / "2 Mar, 09:00" |
+
+- Mantine date components (`@mantine/dates`) are configured with the active locale for calendar labels and day names
+- The `data-timezone` attribute on the root HTML element carries the user's timezone to React

--- a/docs/models/event.md
+++ b/docs/models/event.md
@@ -44,6 +44,7 @@ Represents a recurring Pokemon TCG organized play location — typically a local
 | `format`               | `string(30)`       | No       | Play format. Default: `"Expanded"`. Could also be `"Standard"`, `"Unlimited"`, etc. |
 | `date`                 | `DateTimeImmutable` | No      | Event date (start). |
 | `endDate`              | `DateTimeImmutable` | Yes     | Event end date. Defaults to same as `date` for single-day events. Used for overdue tracking (F4.6). |
+| `timezone`             | `string(50)`       | No       | IANA timezone for the event's local time (e.g. `"Europe/Paris"`). Default: `"UTC"`. Event dates are stored in UTC and displayed in this timezone. See F9.4. |
 | `location`             | `string(255)`      | Yes      | Venue name and/or address. Nullable — can be derived from the league's address when a league is linked. |
 | `description`          | `text`             | Yes      | Optional free-text description or notes about the event. |
 | `organizer`            | `User`             | No       | The user who created the event (must have `ROLE_ORGANIZER` or `ROLE_ADMIN`). |
@@ -85,6 +86,7 @@ Represents a recurring Pokemon TCG organized play location — typically a local
 - `topCutRoundDuration`: optional, >= 1, only valid when `tournamentStructure` is `swiss_top_cut`
 - `entryFeeAmount` and `entryFeeCurrency`: both null (free) or both set (paid). `entryFeeAmount` >= 0.
 - `cancelledAt`: once set, cannot be cleared (cancellation is irreversible). A cancelled event cannot be edited further (F3.10).
+- `timezone`: required, must be a valid IANA timezone identifier. Default: `"UTC"`.
 
 ### Cancellation Behavior
 
@@ -103,6 +105,14 @@ The `eventId` field is **free text** intended to hold the official Pokemon sanct
 - Potential future integration with Pokemon tournament APIs
 
 > **Future consideration (F3.6):** Investigate whether the Pokemon tournament system exposes an API to verify that the organizer creating the event is the actual owner/TO of the referenced tournament ID. This would prevent unauthorized event creation with someone else's tournament ID.
+
+### Timezone Display
+
+> **@see** docs/features.md F9.4 — UTC datetime storage
+
+- Event times are displayed in the event's `timezone` for **all users**, regardless of their personal timezone setting
+- When the user's timezone (F9.2) differs from the event's timezone, an optional user-relative hint is appended — e.g. "10:00 CET (16:00 your time)"
+- The event creation form defaults the timezone picker to the user's own timezone (`User.timezone`, F9.2), which the organizer can override
 
 ### Relations
 


### PR DESCRIPTION
## Summary

Merge `develop` into `main` — documentation batch adding four new feature areas and two improvement notes.

- **F1.8** — Account deletion & data export (GDPR)
- **F4.11** — Borrow conflict detection with temporal overlap rule
- **F6.5** — Banned card list management
- **F9.1–F9.4** — Localization & internationalization
- **F2.6** — Archetype specification note
- **F5** — PrintNode technicality future note

### PRs included

- #13 — :memo: Docs: borrow conflict detection, GDPR, banned card list, localization

## Test plan

- [ ] All feature IDs sequential (F1.1–F1.8, F4.1–F4.11, F6.1–F6.5, F9.1–F9.4)
- [ ] Internal cross-links resolve across all modified docs
- [ ] No code files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)