### PR TITLE
:wrench: Chore: add README badges and Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
 
   php-coverage:
     name: PHP Coverage
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -126,7 +125,13 @@ jobs:
         env:
           DATABASE_URL: "mysql://expanded_decks:expanded_decks@127.0.0.1:3306/expanded_decks?serverVersion=8.0&charset=utf8mb4"
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: var/coverage/clover.xml
+
       - name: Coverage comment
+        if: github.event_name == 'pull_request'
         uses: lucassabreu/comment-coverage-clover@main
         with:
           file: var/coverage/clover.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Expanded Decks
 
+[![CI](https://github.com/jbourdin/expandedDecks/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/jbourdin/expandedDecks/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/jbourdin/expandedDecks/graph/badge.svg)](https://codecov.io/gh/jbourdin/expandedDecks)
+[![PHP 8.5+](https://img.shields.io/badge/PHP-≥8.5-777BB4?logo=php&logoColor=white)](https://www.php.net/)
+[![Symfony 7.2](https://img.shields.io/badge/Symfony-7.2-000000?logo=symfony&logoColor=white)](https://symfony.com/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 > **Audience:** Developer, Player, Organizer · **Scope:** Overview
 
 A web application for managing a shared library of physical Pokemon TCG decks in the **Expanded format**. It enables a community of players to register their decks, declare upcoming events, request to borrow decks, and track the full lending lifecycle — from request to return.


### PR DESCRIPTION
## Summary

- Add 5 badges to README: CI status, Codecov coverage, PHP 8.5+, Symfony 7.2, Apache 2.0 license
- Add `codecov/codecov-action@v5` upload step to `php-coverage` CI job
- Run `php-coverage` on all pushes (not just PRs) so the Codecov badge stays current; PR comment step remains conditional

## Test plan

- [x] CI workflow passes on this PR
- [x] Codecov upload step succeeds and badge appears on codecov.io
- [x] All 5 badge URLs render correctly in GitHub README preview
- [x] PR coverage comment still appears on pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)