### PR TITLE
:white_check_mark: Test: functional test coverage improvements

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,3 +4,4 @@ APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 DATABASE_URL="mysql://expanded_decks:expanded_decks@127.0.0.1:3342/expanded_decks_test?serverVersion=8.0&charset=utf8mb4"
 MESSENGER_TRANSPORT_DSN=sync://
+MAILER_DSN=null://null

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -35,7 +35,9 @@ class DevFixtures extends Fixture
     public function load(ObjectManager $manager): void
     {
         $admin = $this->createAdmin($manager);
+        $this->createOrganizer($manager);
         $this->createBorrower($manager);
+        $this->createUnverifiedUser($manager);
         $league = $this->createLeague($manager);
         $this->createEventToday($manager, $admin, $league);
         $this->createEventInTwoMonths($manager, $admin, $league);
@@ -65,6 +67,24 @@ class DevFixtures extends Fixture
         return $admin;
     }
 
+    private function createOrganizer(ObjectManager $manager): User
+    {
+        $organizer = new User();
+        $organizer->setEmail('organizer@example.com');
+        $organizer->setFirstName('Bob');
+        $organizer->setLastName('Martin');
+        $organizer->setScreenName('Organizer');
+        $organizer->setPassword($this->passwordHasher->hashPassword($organizer, 'password'));
+        $organizer->setRoles(['ROLE_ORGANIZER']);
+        $organizer->setIsVerified(true);
+        $organizer->setPreferredLocale('en');
+        $organizer->setTimezone('Europe/Paris');
+
+        $manager->persist($organizer);
+
+        return $organizer;
+    }
+
     private function createBorrower(ObjectManager $manager): User
     {
         $borrower = new User();
@@ -80,6 +100,25 @@ class DevFixtures extends Fixture
         $manager->persist($borrower);
 
         return $borrower;
+    }
+
+    private function createUnverifiedUser(ObjectManager $manager): User
+    {
+        $user = new User();
+        $user->setEmail('unverified@example.com');
+        $user->setFirstName('Charlie');
+        $user->setLastName('Pending');
+        $user->setScreenName('Unverified');
+        $user->setPassword($this->passwordHasher->hashPassword($user, 'password'));
+        $user->setIsVerified(false);
+        $user->setVerificationToken('test-verification-token');
+        $user->setTokenExpiresAt(new \DateTimeImmutable('+1 day', new \DateTimeZone('UTC')));
+        $user->setPreferredLocale('en');
+        $user->setTimezone('UTC');
+
+        $manager->persist($user);
+
+        return $user;
     }
 
     private function createLeague(ObjectManager $manager): League

--- a/tests/Functional/AuthControllerTest.php
+++ b/tests/Functional/AuthControllerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Repository\UserRepository;
+use Symfony\Component\Mime\Email;
+
+/**
+ * @see docs/features.md F1.1 — Register a new account
+ * @see docs/features.md F1.2 — Email verification
+ */
+class AuthControllerTest extends AbstractFunctionalTest
+{
+    // ---------------------------------------------------------------
+    // Login
+    // ---------------------------------------------------------------
+
+    public function testLoginPageRedirectsWhenLoggedIn(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/login');
+
+        self::assertResponseRedirects('/dashboard');
+    }
+
+    public function testLoginWithValidCredentials(): void
+    {
+        $this->client->request('GET', '/login');
+        $this->client->submitForm('Login', [
+            '_email' => 'admin@example.com',
+            '_password' => 'password',
+        ]);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testLoginWithWrongPassword(): void
+    {
+        $this->client->request('GET', '/login');
+        $this->client->submitForm('Login', [
+            '_email' => 'admin@example.com',
+            '_password' => 'wrong-password',
+        ]);
+
+        self::assertResponseRedirects('/login');
+        $this->client->followRedirect();
+
+        self::assertSelectorExists('.alert-danger');
+    }
+
+    public function testUnverifiedUserCannotLogin(): void
+    {
+        $this->client->request('GET', '/login');
+        $this->client->submitForm('Login', [
+            '_email' => 'unverified@example.com',
+            '_password' => 'password',
+        ]);
+
+        self::assertResponseRedirects('/login');
+        $this->client->followRedirect();
+
+        self::assertSelectorExists('.alert-danger');
+    }
+
+    // ---------------------------------------------------------------
+    // Registration
+    // ---------------------------------------------------------------
+
+    public function testRegistrationPageRedirectsWhenLoggedIn(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/register');
+
+        self::assertResponseRedirects('/dashboard');
+    }
+
+    public function testRegistrationFormPersistsUser(): void
+    {
+        $this->client->request('GET', '/register');
+        $this->client->submitForm('Register', [
+            'registration_form[email]' => 'new-user@example.com',
+            'registration_form[screenName]' => 'NewPlayer',
+            'registration_form[firstName]' => 'New',
+            'registration_form[lastName]' => 'Player',
+            'registration_form[plainPassword][first]' => 'SecurePass123!',
+            'registration_form[plainPassword][second]' => 'SecurePass123!',
+            'registration_form[agreeTerms]' => true,
+        ]);
+
+        self::assertResponseRedirects('/login');
+
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+        $user = $repo->findOneBy(['email' => 'new-user@example.com']);
+
+        self::assertNotNull($user);
+        self::assertSame('NewPlayer', $user->getScreenName());
+        self::assertFalse($user->isVerified());
+        self::assertNotNull($user->getVerificationToken());
+    }
+
+    public function testRegistrationSendsVerificationEmail(): void
+    {
+        $this->client->request('GET', '/register');
+        $this->client->submitForm('Register', [
+            'registration_form[email]' => 'email-check@example.com',
+            'registration_form[screenName]' => 'EmailCheck',
+            'registration_form[firstName]' => 'Email',
+            'registration_form[lastName]' => 'Check',
+            'registration_form[plainPassword][first]' => 'SecurePass123!',
+            'registration_form[plainPassword][second]' => 'SecurePass123!',
+            'registration_form[agreeTerms]' => true,
+        ]);
+
+        self::assertResponseRedirects('/login');
+        self::assertEmailCount(1);
+
+        /** @var Email $email */
+        $email = self::getMailerMessage();
+        self::assertNotNull($email);
+        self::assertEmailAddressContains($email, 'to', 'email-check@example.com');
+    }
+
+    // ---------------------------------------------------------------
+    // LastLoginListener
+    // ---------------------------------------------------------------
+
+    public function testLoginUpdatesLastLoginAt(): void
+    {
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+        $user = $repo->findOneBy(['email' => 'admin@example.com']);
+        self::assertNotNull($user);
+        $previousLogin = $user->getLastLoginAt();
+
+        $this->loginAs('admin@example.com');
+
+        // Refresh from DB
+        /** @var UserRepository $freshRepo */
+        $freshRepo = static::getContainer()->get(UserRepository::class);
+        $updated = $freshRepo->findOneBy(['email' => 'admin@example.com']);
+        self::assertNotNull($updated);
+        self::assertNotNull($updated->getLastLoginAt());
+
+        if (null !== $previousLogin) {
+            self::assertGreaterThanOrEqual($previousLogin, $updated->getLastLoginAt());
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Homepage redirect
+    // ---------------------------------------------------------------
+
+    public function testHomepageRedirectsWhenLoggedIn(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/');
+
+        self::assertResponseRedirects('/dashboard');
+    }
+}

--- a/tests/Functional/EventControllerTest.php
+++ b/tests/Functional/EventControllerTest.php
@@ -270,6 +270,17 @@ class EventControllerTest extends AbstractFunctionalTest
         self::assertResponseStatusCodeSame(403);
     }
 
+    public function testEditEventDeniedForOtherOrganizer(): void
+    {
+        $event = $this->getFixtureEvent();
+
+        $this->loginAs('organizer@example.com');
+
+        $this->client->request('GET', \sprintf('/event/%d/edit', $event->getId()));
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
     public function testEditCancelledEventRedirectsWithWarning(): void
     {
         $event = $this->getFixtureEvent();
@@ -385,6 +396,17 @@ class EventControllerTest extends AbstractFunctionalTest
         $event = $this->getFixtureEvent();
 
         $this->loginAs('borrower@example.com');
+
+        $this->client->request('POST', \sprintf('/event/%d/cancel', $event->getId()));
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testCancelEventDeniedForOtherOrganizer(): void
+    {
+        $event = $this->getFixtureEvent();
+
+        $this->loginAs('organizer@example.com');
 
         $this->client->request('POST', \sprintf('/event/%d/cancel', $event->getId()));
 

--- a/tests/Functional/PasswordResetControllerTest.php
+++ b/tests/Functional/PasswordResetControllerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F1.7 — Password reset
+ */
+class PasswordResetControllerTest extends AbstractFunctionalTest
+{
+    // ---------------------------------------------------------------
+    // Forgot password
+    // ---------------------------------------------------------------
+
+    public function testForgotPasswordPageRendersForm(): void
+    {
+        $this->client->request('GET', '/forgot-password');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testForgotPasswordSendsEmail(): void
+    {
+        $this->client->request('POST', '/forgot-password', [
+            'email' => 'admin@example.com',
+        ]);
+
+        self::assertResponseRedirects('/login');
+        self::assertEmailCount(1);
+
+        // User should now have a reset token
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+        $user = $repo->findOneBy(['email' => 'admin@example.com']);
+        self::assertNotNull($user);
+        self::assertNotNull($user->getResetToken());
+        self::assertNotNull($user->getResetTokenExpiresAt());
+    }
+
+    public function testForgotPasswordAntiEnumeration(): void
+    {
+        $this->client->request('POST', '/forgot-password', [
+            'email' => 'doesnotexist@example.com',
+        ]);
+
+        self::assertResponseRedirects('/login');
+        $this->client->followRedirect();
+
+        // Same message regardless of whether the email exists
+        self::assertSelectorTextContains('.alert-success', 'If an account exists');
+        self::assertEmailCount(0);
+    }
+
+    public function testForgotPasswordIgnoresUnverifiedUser(): void
+    {
+        $this->client->request('POST', '/forgot-password', [
+            'email' => 'unverified@example.com',
+        ]);
+
+        self::assertResponseRedirects('/login');
+        self::assertEmailCount(0);
+    }
+
+    // ---------------------------------------------------------------
+    // Reset password
+    // ---------------------------------------------------------------
+
+    public function testResetPasswordWithValidTokenShowsForm(): void
+    {
+        $token = $this->requestResetTokenForAdmin();
+
+        $this->client->request('GET', \sprintf('/reset-password/%s', $token));
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('form');
+    }
+
+    public function testResetPasswordChangesPassword(): void
+    {
+        $token = $this->requestResetTokenForAdmin();
+
+        $this->client->request('GET', \sprintf('/reset-password/%s', $token));
+        $this->client->submitForm('Reset password', [
+            'reset_password_form[plainPassword][first]' => 'NewSecurePass123!',
+            'reset_password_form[plainPassword][second]' => 'NewSecurePass123!',
+        ]);
+
+        self::assertResponseRedirects('/login');
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-success', 'Your password has been reset.');
+
+        // Token should be cleared
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+        $user = $repo->findOneBy(['email' => 'admin@example.com']);
+        self::assertNotNull($user);
+        self::assertNull($user->getResetToken());
+        self::assertNull($user->getResetTokenExpiresAt());
+
+        // Can login with new password
+        $this->client->request('GET', '/login');
+        $this->client->submitForm('Login', [
+            '_email' => 'admin@example.com',
+            '_password' => 'NewSecurePass123!',
+        ]);
+
+        self::assertResponseRedirects();
+    }
+
+    public function testResetPasswordWithInvalidTokenShowsError(): void
+    {
+        $this->client->request('GET', '/reset-password/nonexistent-token');
+
+        self::assertResponseRedirects('/login');
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-danger', 'Invalid password reset link.');
+    }
+
+    public function testResetPasswordWithExpiredTokenShowsError(): void
+    {
+        $token = $this->requestResetTokenForAdmin();
+
+        // Expire the token
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+        $user = $repo->findOneBy(['email' => 'admin@example.com']);
+        self::assertNotNull($user);
+
+        $user->setResetTokenExpiresAt(new \DateTimeImmutable('-1 hour', new \DateTimeZone('UTC')));
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->flush();
+
+        $this->client->request('GET', \sprintf('/reset-password/%s', $token));
+
+        self::assertResponseRedirects('/forgot-password');
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-danger', 'This password reset link has expired.');
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    /**
+     * Triggers the forgot-password flow and returns the generated reset token.
+     */
+    private function requestResetTokenForAdmin(): string
+    {
+        $this->client->request('POST', '/forgot-password', [
+            'email' => 'admin@example.com',
+        ]);
+
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+        $user = $repo->findOneBy(['email' => 'admin@example.com']);
+        self::assertNotNull($user);
+
+        $token = $user->getResetToken();
+        self::assertNotNull($token);
+
+        return $token;
+    }
+}

--- a/tests/Functional/VerificationControllerTest.php
+++ b/tests/Functional/VerificationControllerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F1.2 — Email verification
+ */
+class VerificationControllerTest extends AbstractFunctionalTest
+{
+    // ---------------------------------------------------------------
+    // Verify token
+    // ---------------------------------------------------------------
+
+    public function testVerifyWithValidTokenActivatesUser(): void
+    {
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+        $user = $repo->findOneBy(['email' => 'unverified@example.com']);
+        self::assertNotNull($user);
+        self::assertFalse($user->isVerified());
+
+        $this->client->request('GET', '/verify/test-verification-token');
+
+        self::assertResponseRedirects('/login');
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-success', 'Your email has been verified.');
+
+        // Refresh from DB
+        /** @var UserRepository $freshRepo */
+        $freshRepo = static::getContainer()->get(UserRepository::class);
+        $verified = $freshRepo->findOneBy(['email' => 'unverified@example.com']);
+        self::assertNotNull($verified);
+        self::assertTrue($verified->isVerified());
+        self::assertNull($verified->getVerificationToken());
+    }
+
+    public function testVerifyWithInvalidTokenShowsError(): void
+    {
+        $this->client->request('GET', '/verify/nonexistent-token');
+
+        self::assertResponseRedirects('/login');
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-danger', 'Invalid verification link.');
+    }
+
+    public function testVerifyWithExpiredTokenShowsError(): void
+    {
+        // Set the token expiry to the past
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+        $user = $repo->findOneBy(['email' => 'unverified@example.com']);
+        self::assertNotNull($user);
+
+        $user->setTokenExpiresAt(new \DateTimeImmutable('-1 hour', new \DateTimeZone('UTC')));
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->flush();
+
+        $this->client->request('GET', '/verify/test-verification-token');
+
+        self::assertResponseRedirects('/verify/resend');
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-danger', 'This verification link has expired.');
+    }
+
+    // ---------------------------------------------------------------
+    // Resend verification
+    // ---------------------------------------------------------------
+
+    public function testResendVerificationPageRendersForm(): void
+    {
+        $this->client->request('GET', '/verify/resend');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testResendVerificationSendsEmail(): void
+    {
+        $this->client->request('POST', '/verify/resend', [
+            'email' => 'unverified@example.com',
+        ]);
+
+        self::assertResponseRedirects('/login');
+        self::assertEmailCount(1);
+    }
+
+    public function testResendVerificationAntiEnumeration(): void
+    {
+        // Nonexistent email should show the same success message (no email sent)
+        $this->client->request('POST', '/verify/resend', [
+            'email' => 'doesnotexist@example.com',
+        ]);
+
+        self::assertResponseRedirects('/login');
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-success', 'If an account exists');
+        self::assertEmailCount(0);
+    }
+
+    public function testResendVerificationIgnoresAlreadyVerifiedUser(): void
+    {
+        $this->client->request('POST', '/verify/resend', [
+            'email' => 'admin@example.com',
+        ]);
+
+        self::assertResponseRedirects('/login');
+        self::assertEmailCount(0);
+    }
+}


### PR DESCRIPTION
## Summary
- **2 new fixture users**: `organizer@example.com` (ROLE_ORGANIZER), `unverified@example.com` (unverified account)
- **26 new functional tests** covering auth security flows:
  - EventController: `denyAccessUnlessOrganizer` throw path (edit + cancel)
  - Login: valid/invalid credentials, unverified user blocked, redirect when logged in
  - Registration: form submission, email sending, redirect when logged in
  - Email verification: valid/invalid/expired token, resend, anti-enumeration
  - Password reset: forgot-password email, reset with valid/invalid/expired token, anti-enumeration
  - LastLoginListener: login updates `lastLoginAt`
  - HomeController: homepage redirect when logged in
- **Test mailer fix**: `MAILER_DSN=null://null` in `.env.test` for CI compatibility

Total: 92 tests, 347 assertions

## Test plan
- [x] `make cs-fix` — clean
- [x] `make phpstan` — no errors (level 10)
- [x] `make test` — 92 tests, 347 assertions, 0 failures
- [x] CI: all checks pass including codecov/patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)