### PR TITLE
:sparkles: Feature: assign event staff team (F3.5)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,11 +68,11 @@ Each feature carries a **State** that must be kept up to date as work progresses
 |------|------------------------------------|----------|-------------|------------|
 | F3.1 | Create an event                    | High     | Done        | F1.4       |
 | F3.9 | Edit an event                      | High     | Done        | F3.1       |
-| F3.5 | Assign event staff team            | High     | Partial     | F3.1, F1.4 |
+| F3.5 | Assign event staff team            | High     | Done        | F3.1, F1.4 |
 | F3.4 | Register participation to an event | Medium   | Done        | F3.1, F1.1 |
 | F3.8 | League/Store management            | Medium   | Partial     | —          |
 
-**Progress: 3/5 done · 2 partial · 0 not started**
+**Progress: 4/5 done · 1 partial · 0 not started**
 
 **Deliverable:** Organizers can create/edit events, assign staff, and link leagues. Players can register participation (playing or spectating).
 
@@ -275,7 +275,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 |-------|-----------------------------------|------|---------|-------------|-------|
 | 1     | Auth & Foundation                 | 5    | 0       | 0           | 5     |
 | 2     | Deck Registration & Card Pipeline | 7    | 0       | 0           | 7     |
-| 3     | Events & Staff                    | 3    | 2       | 0           | 5     |
+| 3     | Events & Staff                    | 4    | 1       | 0           | 5     |
 | 4     | Borrow Workflow & Notifications   | 0    | 6       | 1           | 7     |
 | 5     | Core Views & Navigation           | 4    | 0       | 5           | 9     |
 | 6     | Localization                      | 0    | 2       | 3           | 5     |
@@ -283,6 +283,6 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 8     | Admin, Homepage & Polish          | 0    | 3       | 4           | 7     |
 | 9     | Content, Archetypes & Low Priority | 0   | 1       | 20          | 21    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
-|       | **Total**                         | **19** | **15** | **47**      | **81** |
+|       | **Total**                         | **20** | **14** | **47**      | **81** |
 
 All 81 features from [features.md](features.md) are represented exactly once.

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -18,6 +18,7 @@ use App\Entity\DeckCard;
 use App\Entity\DeckVersion;
 use App\Entity\Event;
 use App\Entity\EventEngagement;
+use App\Entity\EventStaff;
 use App\Entity\League;
 use App\Entity\User;
 use App\Enum\DeckStatus;
@@ -39,10 +40,10 @@ class DevFixtures extends Fixture
     {
         $admin = $this->createAdmin($manager);
         $this->createOrganizer($manager);
-        $this->createBorrower($manager);
+        $borrower = $this->createBorrower($manager);
         $this->createUnverifiedUser($manager);
         $league = $this->createLeague($manager);
-        $this->createEventToday($manager, $admin, $league);
+        $this->createEventToday($manager, $admin, $borrower, $league);
         $this->createEventInTwoMonths($manager, $admin, $league);
         $ironThorns = $this->createDeck($manager, $admin, 'Iron Thorns');
         $this->createIronThornsDeckVersion($manager, $ironThorns);
@@ -136,7 +137,7 @@ class DevFixtures extends Fixture
         return $league;
     }
 
-    private function createEventToday(ObjectManager $manager, User $organizer, League $league): void
+    private function createEventToday(ObjectManager $manager, User $organizer, User $borrower, League $league): void
     {
         $event = new Event();
         $event->setName('Expanded Weekly #42');
@@ -157,6 +158,12 @@ class DevFixtures extends Fixture
         $engagement->setState(EngagementState::RegisteredPlaying);
         $engagement->setParticipationMode(ParticipationMode::Playing);
         $manager->persist($engagement);
+
+        $staff = new EventStaff();
+        $staff->setEvent($event);
+        $staff->setUser($borrower);
+        $staff->setAssignedBy($organizer);
+        $manager->persist($staff);
     }
 
     private function createEventInTwoMonths(ObjectManager $manager, User $organizer, League $league): void

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -24,6 +24,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @see docs/features.md F3.1 — Create a new event
+ * @see docs/features.md F3.5 — Assign event staff team
  * @see docs/features.md F3.10 — Cancel an event
  */
 #[ORM\Entity(repositoryClass: EventRepository::class)]
@@ -431,6 +432,20 @@ class Event
     public function getStaff(): Collection
     {
         return $this->staff;
+    }
+
+    /**
+     * @see docs/features.md F3.5 — Assign event staff team
+     */
+    public function getStaffFor(User $user): ?EventStaff
+    {
+        foreach ($this->staff as $staffMember) {
+            if ($staffMember->getUser()->getId() === $user->getId()) {
+                return $staffMember;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/templates/event/show.html.twig
+++ b/templates/event/show.html.twig
@@ -122,6 +122,37 @@
         </div>
     </div>
 
+    {% if isOrganizer and not event.cancelledAt %}
+        <div class="card shadow-sm mb-3">
+            <div class="card-header card-header-themed">
+                <h6 class="mb-0">Staff Team</h6>
+            </div>
+            <div class="card-body">
+                {% if event.staff is not empty %}
+                    <ul class="list-group list-group-flush mb-3">
+                        {% for staffMember in event.staff %}
+                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                {{ staffMember.user.screenName }}
+                                <form method="post" action="{{ path('app_event_remove_staff', {id: event.id, staffId: staffMember.id}) }}" class="d-inline">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('remove-staff-' ~ staffMember.id) }}">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">Remove</button>
+                                </form>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="text-muted mb-3">No staff assigned yet.</p>
+                {% endif %}
+
+                <form method="post" action="{{ path('app_event_assign_staff', {id: event.id}) }}" class="d-flex gap-2">
+                    <input type="hidden" name="_token" value="{{ csrf_token('assign-staff-' ~ event.id) }}">
+                    <input type="text" name="screen_name" class="form-control form-control-sm" placeholder="Screen name" required>
+                    <button type="submit" class="btn btn-sm btn-primary text-nowrap">Add Staff</button>
+                </form>
+            </div>
+        </div>
+    {% endif %}
+
     {% if not event.cancelledAt %}
         <div class="card shadow-sm mb-3">
             <div class="card-header card-header-themed">

--- a/tests/Entity/EventStaffTest.php
+++ b/tests/Entity/EventStaffTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Entity;
+
+use App\Entity\Event;
+use App\Entity\EventStaff;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class EventStaffTest extends TestCase
+{
+    public function testNewStaffHasNullId(): void
+    {
+        $staff = new EventStaff();
+        self::assertNull($staff->getId());
+    }
+
+    public function testSetAndGetEvent(): void
+    {
+        $staff = new EventStaff();
+        $event = new Event();
+
+        $result = $staff->setEvent($event);
+
+        self::assertSame($event, $staff->getEvent());
+        self::assertSame($staff, $result);
+    }
+
+    public function testSetAndGetUser(): void
+    {
+        $staff = new EventStaff();
+        $user = new User();
+
+        $result = $staff->setUser($user);
+
+        self::assertSame($user, $staff->getUser());
+        self::assertSame($staff, $result);
+    }
+
+    public function testSetAndGetAssignedBy(): void
+    {
+        $staff = new EventStaff();
+        $assigner = new User();
+
+        $result = $staff->setAssignedBy($assigner);
+
+        self::assertSame($assigner, $staff->getAssignedBy());
+        self::assertSame($staff, $result);
+    }
+
+    public function testAssignedAtSetOnConstruction(): void
+    {
+        $before = new \DateTimeImmutable();
+        $staff = new EventStaff();
+        $after = new \DateTimeImmutable();
+
+        self::assertGreaterThanOrEqual($before, $staff->getAssignedAt());
+        self::assertLessThanOrEqual($after, $staff->getAssignedAt());
+    }
+
+    public function testOnPrePersistResetsAssignedAt(): void
+    {
+        $staff = new EventStaff();
+        $originalAssignedAt = $staff->getAssignedAt();
+
+        usleep(1000);
+        $staff->onPrePersist();
+
+        self::assertGreaterThanOrEqual($originalAssignedAt, $staff->getAssignedAt());
+    }
+}

--- a/tests/Functional/EventStaffTest.php
+++ b/tests/Functional/EventStaffTest.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\Event;
+use App\Repository\EventRepository;
+use App\Repository\EventStaffRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F3.5 — Assign event staff team
+ */
+class EventStaffTest extends AbstractFunctionalTest
+{
+    // ---------------------------------------------------------------
+    // Assign staff
+    // ---------------------------------------------------------------
+
+    public function testAssignStaff(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $event = $this->getFixtureEvent();
+
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $csrfToken = $this->getAssignStaffCsrfToken($crawler, $event->getId());
+
+        $this->client->request('POST', \sprintf('/event/%d/assign-staff', $event->getId()), [
+            '_token' => $csrfToken,
+            'screen_name' => 'Organizer',
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/event/%d', $event->getId()));
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-success', '"Organizer" has been added to the staff team.');
+
+        /** @var EventStaffRepository $repo */
+        $repo = static::getContainer()->get(EventStaffRepository::class);
+        $staffEntries = $repo->findBy(['event' => $event->getId()]);
+
+        // Fixture already has Borrower as staff, so we expect 2
+        self::assertCount(2, $staffEntries);
+    }
+
+    public function testAssignStaffAppearsOnShowPage(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $event = $this->getFixtureEvent();
+
+        // Borrower is already staff via fixtures
+        $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorTextContains('.list-group-item', 'Borrower');
+    }
+
+    public function testAssignStaffInvalidCsrf(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $event = $this->getFixtureEvent();
+
+        $this->client->request('POST', \sprintf('/event/%d/assign-staff', $event->getId()), [
+            '_token' => 'invalid-token',
+            'screen_name' => 'Organizer',
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/event/%d', $event->getId()));
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-danger', 'Invalid security token.');
+
+        /** @var EventStaffRepository $repo */
+        $repo = static::getContainer()->get(EventStaffRepository::class);
+        $staffEntries = $repo->findBy(['event' => $event->getId()]);
+
+        // Only the fixture staff (Borrower)
+        self::assertCount(1, $staffEntries);
+    }
+
+    public function testAssignStaffUserNotFound(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $event = $this->getFixtureEvent();
+
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $csrfToken = $this->getAssignStaffCsrfToken($crawler, $event->getId());
+
+        $this->client->request('POST', \sprintf('/event/%d/assign-staff', $event->getId()), [
+            '_token' => $csrfToken,
+            'screen_name' => 'NonExistentUser',
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/event/%d', $event->getId()));
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-warning', 'User "NonExistentUser" not found.');
+    }
+
+    public function testAssignStaffAlreadyAssigned(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $event = $this->getFixtureEvent();
+
+        // Borrower is already staff via fixtures
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $csrfToken = $this->getAssignStaffCsrfToken($crawler, $event->getId());
+
+        $this->client->request('POST', \sprintf('/event/%d/assign-staff', $event->getId()), [
+            '_token' => $csrfToken,
+            'screen_name' => 'Borrower',
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/event/%d', $event->getId()));
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-warning', '"Borrower" is already a staff member.');
+    }
+
+    public function testAssignStaffIsOrganizer(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $event = $this->getFixtureEvent();
+
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $csrfToken = $this->getAssignStaffCsrfToken($crawler, $event->getId());
+
+        $this->client->request('POST', \sprintf('/event/%d/assign-staff', $event->getId()), [
+            '_token' => $csrfToken,
+            'screen_name' => 'Admin',
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/event/%d', $event->getId()));
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-warning', 'The organizer cannot be assigned as staff.');
+    }
+
+    public function testAssignStaffCancelledEvent(): void
+    {
+        $event = $this->getFixtureEvent();
+
+        // Get a valid CSRF token before cancelling
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $csrfToken = $this->getAssignStaffCsrfToken($crawler, $event->getId());
+
+        // Cancel the event
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $freshEvent = $em->find(Event::class, $event->getId());
+        self::assertNotNull($freshEvent);
+        $freshEvent->setCancelledAt(new \DateTimeImmutable());
+        $em->flush();
+
+        $this->client->request('POST', \sprintf('/event/%d/assign-staff', $event->getId()), [
+            '_token' => $csrfToken,
+            'screen_name' => 'Organizer',
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/event/%d', $event->getId()));
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-warning', 'Cannot assign staff to a cancelled event.');
+    }
+
+    public function testAssignStaffNonOrganizer(): void
+    {
+        $event = $this->getFixtureEvent();
+
+        $this->loginAs('organizer@example.com');
+
+        $this->client->request('POST', \sprintf('/event/%d/assign-staff', $event->getId()), [
+            '_token' => 'any-token',
+            'screen_name' => 'Borrower',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    // ---------------------------------------------------------------
+    // Remove staff
+    // ---------------------------------------------------------------
+
+    public function testRemoveStaff(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $event = $this->getFixtureEvent();
+
+        /** @var EventStaffRepository $repo */
+        $repo = static::getContainer()->get(EventStaffRepository::class);
+        $staffMember = $repo->findOneBy(['event' => $event->getId()]);
+        self::assertNotNull($staffMember);
+
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $removeForm = $crawler->filter(\sprintf('form[action$="/remove-staff/%d"]', $staffMember->getId()));
+        $csrfToken = $removeForm->filter('input[name="_token"]')->attr('value');
+
+        $this->client->request('POST', \sprintf('/event/%d/remove-staff/%d', $event->getId(), $staffMember->getId()), [
+            '_token' => $csrfToken,
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/event/%d', $event->getId()));
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-success', '"Borrower" has been removed from the staff team.');
+
+        $remaining = $repo->findBy(['event' => $event->getId()]);
+        self::assertCount(0, $remaining);
+    }
+
+    public function testRemoveStaffInvalidCsrf(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $event = $this->getFixtureEvent();
+
+        /** @var EventStaffRepository $repo */
+        $repo = static::getContainer()->get(EventStaffRepository::class);
+        $staffMember = $repo->findOneBy(['event' => $event->getId()]);
+        self::assertNotNull($staffMember);
+
+        $this->client->request('POST', \sprintf('/event/%d/remove-staff/%d', $event->getId(), $staffMember->getId()), [
+            '_token' => 'invalid-token',
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/event/%d', $event->getId()));
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-danger', 'Invalid security token.');
+
+        // Staff should still exist
+        $remaining = $repo->findBy(['event' => $event->getId()]);
+        self::assertCount(1, $remaining);
+    }
+
+    public function testRemoveStaffCancelledEvent(): void
+    {
+        $event = $this->getFixtureEvent();
+
+        /** @var EventStaffRepository $repo */
+        $repo = static::getContainer()->get(EventStaffRepository::class);
+        $staffMember = $repo->findOneBy(['event' => $event->getId()]);
+        self::assertNotNull($staffMember);
+        $staffId = $staffMember->getId();
+
+        // Get a valid CSRF token before cancelling
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $removeForm = $crawler->filter(\sprintf('form[action$="/remove-staff/%d"]', $staffId));
+        $csrfToken = $removeForm->filter('input[name="_token"]')->attr('value');
+
+        // Cancel the event
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $freshEvent = $em->find(Event::class, $event->getId());
+        self::assertNotNull($freshEvent);
+        $freshEvent->setCancelledAt(new \DateTimeImmutable());
+        $em->flush();
+
+        $this->client->request('POST', \sprintf('/event/%d/remove-staff/%d', $event->getId(), $staffId), [
+            '_token' => $csrfToken,
+        ]);
+
+        self::assertResponseRedirects(\sprintf('/event/%d', $event->getId()));
+        $this->client->followRedirect();
+
+        self::assertSelectorTextContains('.alert-warning', 'Cannot remove staff from a cancelled event.');
+    }
+
+    public function testRemoveStaffNonOrganizer(): void
+    {
+        $event = $this->getFixtureEvent();
+
+        /** @var EventStaffRepository $repo */
+        $repo = static::getContainer()->get(EventStaffRepository::class);
+        $staffMember = $repo->findOneBy(['event' => $event->getId()]);
+        self::assertNotNull($staffMember);
+
+        $this->loginAs('organizer@example.com');
+
+        $this->client->request('POST', \sprintf('/event/%d/remove-staff/%d', $event->getId(), $staffMember->getId()), [
+            '_token' => 'any-token',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testRemoveStaffWrongEvent(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        /** @var EventRepository $eventRepo */
+        $eventRepo = static::getContainer()->get(EventRepository::class);
+        $events = $eventRepo->findAll();
+        self::assertGreaterThanOrEqual(2, \count($events));
+
+        // Get the second event (Lyon Expanded Cup 2026)
+        $secondEvent = $events[1];
+
+        // Get staff from the first event
+        /** @var EventStaffRepository $repo */
+        $repo = static::getContainer()->get(EventStaffRepository::class);
+        $staffMember = $repo->findOneBy(['event' => $events[0]->getId()]);
+        self::assertNotNull($staffMember);
+        $staffId = $staffMember->getId();
+
+        // Get a valid CSRF token from the first event's show page
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $events[0]->getId()));
+        $removeForm = $crawler->filter(\sprintf('form[action$="/remove-staff/%d"]', $staffId));
+        $csrfToken = $removeForm->filter('input[name="_token"]')->attr('value');
+
+        // Try to use the staff ID on the wrong event
+        $this->client->request('POST', \sprintf('/event/%d/remove-staff/%d', $secondEvent->getId(), $staffId), [
+            '_token' => $csrfToken,
+        ]);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    // ---------------------------------------------------------------
+    // UI visibility
+    // ---------------------------------------------------------------
+
+    public function testCancelledEventHidesStaffSection(): void
+    {
+        $event = $this->getFixtureEvent();
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $event->setCancelledAt(new \DateTimeImmutable());
+        $em->flush();
+
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorNotExists('h6:contains("Staff Team")');
+    }
+
+    public function testStaffSectionOnlyVisibleToOrganizer(): void
+    {
+        $event = $this->getFixtureEvent();
+
+        $this->loginAs('borrower@example.com');
+
+        $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorNotExists('h6:contains("Staff Team")');
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private function getFixtureEvent(): Event
+    {
+        /** @var EventRepository $repo */
+        $repo = static::getContainer()->get(EventRepository::class);
+        $event = $repo->findOneBy([]);
+        self::assertNotNull($event);
+
+        return $event;
+    }
+
+    private function getAssignStaffCsrfToken(\Symfony\Component\DomCrawler\Crawler $crawler, ?int $eventId): string
+    {
+        $form = $crawler->filter(\sprintf('form[action$="/event/%d/assign-staff"]', $eventId));
+        $token = $form->filter('input[name="_token"]')->attr('value');
+        self::assertNotEmpty($token);
+
+        return $token;
+    }
+}


### PR DESCRIPTION
## Summary

- **Assign/remove staff**: organizers can add any registered user as event staff by screen name, and remove them — with full CSRF protection and guard checks (cancelled event, duplicate, self-assignment)
- **Staff Team UI**: new card section on event detail page (organizer-only, hidden when cancelled) showing current staff with remove buttons and an add-staff form
- **Fixtures**: borrower (Alice) assigned as staff on "Expanded Weekly #42"
- **Tests**: 6 unit tests (`EventStaffTest`) + 15 functional tests covering assign/remove happy paths, CSRF, auth, edge cases, and UI visibility

## Test plan

- [x] `make cs-fix` — 0 fixes needed
- [x] `make phpstan` — no errors (level 10)
- [x] `make test` — 141 tests, 557 assertions, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)