### PR TITLE
:sparkles: feat: add Deck.shortTag and Event.finishedAt fields

### DIFF
--- a/migrations/Version20260301202204.php
+++ b/migrations/Version20260301202204.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add Deck.shortTag (F2.1) and Event.finishedAt (F3.20).
+ */
+final class Version20260301202204 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Deck.shortTag (6-char unique code) and Event.finishedAt timestamp';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // 1. Add short_tag as nullable first (to allow backfill)
+        $this->addSql('ALTER TABLE deck ADD short_tag VARCHAR(6) DEFAULT NULL');
+
+        // 2. Backfill existing rows with unique random short tags
+        $this->addSql(<<<'SQL'
+            UPDATE deck SET short_tag = (
+                SELECT CONCAT(
+                    SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ0123456789', FLOOR(1 + RAND() * 34), 1),
+                    SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ0123456789', FLOOR(1 + RAND() * 34), 1),
+                    SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ0123456789', FLOOR(1 + RAND() * 34), 1),
+                    SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ0123456789', FLOOR(1 + RAND() * 34), 1),
+                    SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ0123456789', FLOOR(1 + RAND() * 34), 1),
+                    SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ0123456789', FLOOR(1 + RAND() * 34), 1)
+                )
+            ) WHERE short_tag IS NULL
+            SQL);
+
+        // 3. Make column NOT NULL
+        $this->addSql('ALTER TABLE deck MODIFY short_tag VARCHAR(6) NOT NULL');
+
+        // 4. Add unique index
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_4FAC363774C9F71C ON deck (short_tag)');
+
+        // 5. Event.finishedAt
+        $this->addSql('ALTER TABLE event ADD finished_at DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_4FAC363774C9F71C ON deck');
+        $this->addSql('ALTER TABLE deck DROP short_tag');
+        $this->addSql('ALTER TABLE event DROP finished_at');
+    }
+}

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -32,6 +32,12 @@ class Deck
     #[ORM\Column]
     private ?int $id = null;
 
+    #[ORM\Column(length: 6, unique: true)]
+    #[Assert\NotBlank]
+    #[Assert\Length(exactly: 6)]
+    #[Assert\Regex(pattern: '/^[A-HJ-NP-Z0-9]{6}$/', message: 'Short tag must be 6 characters from A-H, J-N, P-Z, 0-9.')]
+    private string $shortTag = '';
+
     #[ORM\Column(length: 100)]
     #[Assert\NotBlank]
     #[Assert\Length(min: 2, max: 100)]
@@ -80,6 +86,11 @@ class Deck
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getShortTag(): string
+    {
+        return $this->shortTag;
     }
 
     public function getName(): string
@@ -184,11 +195,25 @@ class Deck
     public function onPrePersist(): void
     {
         $this->createdAt = new \DateTimeImmutable();
+        if ('' === $this->shortTag) {
+            $this->shortTag = self::generateShortTag();
+        }
     }
 
     #[ORM\PreUpdate]
     public function onPreUpdate(): void
     {
         $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    private static function generateShortTag(): string
+    {
+        $charset = 'ABCDEFGHJKLMNPQRSTUVWXYZ0123456789';
+        $tag = '';
+        for ($i = 0; $i < 6; ++$i) {
+            $tag .= $charset[random_int(0, 33)];
+        }
+
+        return $tag;
     }
 }

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -26,6 +26,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @see docs/features.md F3.1 — Create a new event
  * @see docs/features.md F3.5 — Assign event staff team
  * @see docs/features.md F3.10 — Cancel an event
+ * @see docs/features.md F3.20 — Mark event as finished
  */
 #[ORM\Entity(repositoryClass: EventRepository::class)]
 #[ORM\HasLifecycleCallbacks]
@@ -114,6 +115,9 @@ class Event
 
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $cancelledAt = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $finishedAt = null;
 
     /** @var Collection<int, EventEngagement> */
     #[ORM\OneToMany(targetEntity: EventEngagement::class, mappedBy: 'event')]
@@ -375,6 +379,18 @@ class Event
     public function setCancelledAt(?\DateTimeImmutable $cancelledAt): static
     {
         $this->cancelledAt = $cancelledAt;
+
+        return $this;
+    }
+
+    public function getFinishedAt(): ?\DateTimeImmutable
+    {
+        return $this->finishedAt;
+    }
+
+    public function setFinishedAt(?\DateTimeImmutable $finishedAt): static
+    {
+        $this->finishedAt = $finishedAt;
 
         return $this;
     }

--- a/src/Repository/EventRepository.php
+++ b/src/Repository/EventRepository.php
@@ -40,6 +40,7 @@ class EventRepository extends ServiceEntityRepository
             ->addSelect('o')
             ->where('e.date >= :today')
             ->andWhere('e.cancelledAt IS NULL')
+            ->andWhere('e.finishedAt IS NULL')
             ->setParameter('today', new \DateTimeImmutable('today'))
             ->orderBy('e.date', 'ASC')
             ->setMaxResults($limit)

--- a/tests/Entity/DeckTest.php
+++ b/tests/Entity/DeckTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Entity;
+
+use App\Entity\Deck;
+use PHPUnit\Framework\TestCase;
+
+class DeckTest extends TestCase
+{
+    public function testShortTagGeneratedOnPrePersist(): void
+    {
+        $deck = new Deck();
+        self::assertSame('', $deck->getShortTag());
+
+        $deck->onPrePersist();
+
+        self::assertNotSame('', $deck->getShortTag());
+        self::assertSame(6, \strlen($deck->getShortTag()));
+    }
+
+    public function testShortTagNotOverwrittenOnPrePersist(): void
+    {
+        $deck = new Deck();
+        $deck->onPrePersist();
+        $firstTag = $deck->getShortTag();
+
+        $deck->onPrePersist();
+
+        self::assertSame($firstTag, $deck->getShortTag());
+    }
+
+    public function testShortTagCharsetValid(): void
+    {
+        $deck = new Deck();
+        $deck->onPrePersist();
+
+        self::assertMatchesRegularExpression('/^[A-HJ-NP-Z0-9]{6}$/', $deck->getShortTag());
+    }
+
+    public function testGenerateShortTagLength(): void
+    {
+        // Generate multiple tags to check length consistency
+        for ($i = 0; $i < 20; ++$i) {
+            $deck = new Deck();
+            $deck->onPrePersist();
+            self::assertSame(6, \strlen($deck->getShortTag()));
+        }
+    }
+}

--- a/tests/Entity/EventTest.php
+++ b/tests/Entity/EventTest.php
@@ -40,6 +40,22 @@ class EventTest extends TestCase
         self::assertSame(0, $event->countByState(EngagementState::RegisteredPlaying));
     }
 
+    public function testFinishedAtDefaultsToNull(): void
+    {
+        $event = new Event();
+        self::assertNull($event->getFinishedAt());
+    }
+
+    public function testSetFinishedAt(): void
+    {
+        $event = new Event();
+        $now = new \DateTimeImmutable();
+
+        $event->setFinishedAt($now);
+
+        self::assertSame($now, $event->getFinishedAt());
+    }
+
     public function testUserGetEventEngagementsReturnsEmptyCollection(): void
     {
         $user = new User();


### PR DESCRIPTION
## Summary

- **`Deck.shortTag`** — 6-char unique code (`[A-HJ-NP-Z0-9]`) auto-generated on persist for physical deck box identification (F2.1). Immutable after creation, uniqueness enforced by DB constraint.
- **`Event.finishedAt`** — nullable `DateTimeImmutable` timestamp to mark an event as finished (F3.20). Finished events are excluded from `findUpcoming()`.
- **Migration** with backfill strategy: adds `short_tag` as nullable, backfills existing rows with random tags, then sets NOT NULL + unique index.

## Test plan

- [x] `DeckTest`: shortTag generation on prePersist, immutability, charset validation, length consistency
- [x] `EventTest`: finishedAt defaults to null, setter/getter roundtrip
- [x] PHPStan level 10 clean
- [x] PHP-CS-Fixer clean
- [x] Full test suite passes (157 tests, 638 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)