### PR TITLE
:bug: Fix: spacing between deck selection and borrow table

### DIFF
--- a/templates/event/show.html.twig
+++ b/templates/event/show.html.twig
@@ -260,7 +260,7 @@
                                 {% endfor %}
                             </tbody>
                         </table>
-                        <div class="d-flex align-items-center gap-2 mt-3">
+                        <div class="d-flex align-items-center gap-2 mt-3 mb-3">
                             {% if canChangeDeck %}
                                 <button type="submit" class="btn btn-sm btn-primary">Save selection</button>
                             {% endif %}


### PR DESCRIPTION
## Summary

- Add `mb-3` margin between the deck selection form buttons and the other borrows table on the event page for readability

## Test plan

- [x] All 221 tests pass
- [x] Visual: verify spacing between "Browse available decks" and the borrow activity table

🤖 Generated with [Claude Code](https://claude.com/claude-code)