### PR TITLE
:rocket: Release: fixture updates for realistic event scenarios

### DIFF
--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -43,12 +43,12 @@ class DevFixtures extends Fixture
         $admin = $this->createAdmin($manager);
         $this->createOrganizer($manager);
         $borrower = $this->createBorrower($manager);
-        $this->createStaff1($manager);
-        $this->createStaff2($manager);
+        $staff1 = $this->createStaff1($manager);
+        $staff2 = $this->createStaff2($manager);
         $lender = $this->createLender($manager);
         $this->createUnverifiedUser($manager);
         $todayEvent = $this->createEventToday($manager, $admin, $borrower);
-        $this->createEventInTwoMonths($manager, $admin);
+        $this->createEventInTwoMonths($manager, $admin, $lender, $staff1, $staff2);
         $ironThorns = $this->createDeck($manager, $admin, 'Iron Thorns');
         $this->createIronThornsDeckVersion($manager, $ironThorns);
         $ancientBox = $this->createDeck($manager, $admin, 'Ancient Box');
@@ -232,7 +232,7 @@ class DevFixtures extends Fixture
         return $event;
     }
 
-    private function createEventInTwoMonths(ObjectManager $manager, User $organizer): void
+    private function createEventInTwoMonths(ObjectManager $manager, User $organizer, User $lender, User $staff1, User $staff2): Event
     {
         $event = new Event();
         $event->setName('Lyon Expanded Cup 2026');
@@ -249,9 +249,30 @@ class DevFixtures extends Fixture
         $engagement = new EventEngagement();
         $engagement->setEvent($event);
         $engagement->setUser($organizer);
-        $engagement->setState(EngagementState::RegisteredPlaying);
-        $engagement->setParticipationMode(ParticipationMode::Playing);
+        $engagement->setState(EngagementState::RegisteredSpectating);
+        $engagement->setParticipationMode(ParticipationMode::Spectating);
         $manager->persist($engagement);
+
+        $lenderEngagement = new EventEngagement();
+        $lenderEngagement->setEvent($event);
+        $lenderEngagement->setUser($lender);
+        $lenderEngagement->setState(EngagementState::RegisteredPlaying);
+        $lenderEngagement->setParticipationMode(ParticipationMode::Playing);
+        $manager->persist($lenderEngagement);
+
+        $staff1Assignment = new EventStaff();
+        $staff1Assignment->setEvent($event);
+        $staff1Assignment->setUser($staff1);
+        $staff1Assignment->setAssignedBy($organizer);
+        $manager->persist($staff1Assignment);
+
+        $staff2Assignment = new EventStaff();
+        $staff2Assignment->setEvent($event);
+        $staff2Assignment->setUser($staff2);
+        $staff2Assignment->setAssignedBy($organizer);
+        $manager->persist($staff2Assignment);
+
+        return $event;
     }
 
     private function createDeck(ObjectManager $manager, User $owner, string $name, DeckStatus $status = DeckStatus::Available): Deck

--- a/tests/Functional/EventControllerTest.php
+++ b/tests/Functional/EventControllerTest.php
@@ -1216,8 +1216,6 @@ class EventControllerTest extends AbstractFunctionalTest
 
         $event = $this->getFutureEvent();
 
-        // Register as participant to get a select-deck form with CSRF token
-        $this->registerParticipant($event);
         $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
         $csrfToken = $this->extractSelectDeckCsrfToken($crawler);
 


### PR DESCRIPTION
## Summary
- Staff1/Staff2 assigned as staff on event 2 (Lyon Expanded Cup)
- Admin as spectator with registered decks on both events
- Lender as player on both events
- Lugia Archeops deck version languages set to `['en']`

## Test plan
- [x] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)