### PR TITLE
:wrench: perf(test): transaction rollback for functional test isolation

### DIFF
--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,0 +1,4 @@
+services:
+    App\Tests\DBAL\StaticConnectionMiddleware:
+        tags:
+            - { name: doctrine.middleware }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
     <php>
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
+        <ini name="memory_limit" value="256M" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
     </php>

--- a/tests/DBAL/StaticConnectionMiddleware.php
+++ b/tests/DBAL/StaticConnectionMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\DBAL;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware;
+
+/**
+ * DBAL middleware that caches the underlying driver connection statically.
+ *
+ * When Symfony reboots the kernel (e.g. on each createClient()), the new DBAL
+ * Connection reconnects through this middleware and gets the same underlying PDO,
+ * preserving any open test transaction.
+ *
+ * Registered only in the test environment via config/services_test.yaml.
+ */
+class StaticConnectionMiddleware implements Middleware
+{
+    public function wrap(Driver $driver): Driver
+    {
+        return new StaticDriver($driver);
+    }
+}

--- a/tests/DBAL/StaticDriver.php
+++ b/tests/DBAL/StaticDriver.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\DBAL;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+
+/**
+ * Driver wrapper that caches the connection statically across kernel reboots.
+ *
+ * Ensures all kernel instances share the same underlying PDO connection,
+ * so the outer test transaction is preserved between setUp/tearDown cycles.
+ */
+class StaticDriver extends AbstractDriverMiddleware
+{
+    private static ?TestConnection $connection = null;
+
+    public function connect(array $params): Connection
+    {
+        if (null === self::$connection) {
+            self::$connection = new TestConnection(parent::connect($params));
+        }
+
+        return self::$connection;
+    }
+
+    public static function getConnection(): ?TestConnection
+    {
+        return self::$connection;
+    }
+
+    public static function reset(): void
+    {
+        self::$connection = null;
+    }
+}

--- a/tests/DBAL/TestConnection.php
+++ b/tests/DBAL/TestConnection.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\DBAL;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+
+/**
+ * Connection wrapper that intercepts transaction calls during test execution.
+ *
+ * In normal mode (during schema creation + fixture loading), all calls pass through.
+ * In test mode (after beginTestTransaction()), application-level beginTransaction()
+ * creates savepoints, commit() releases them, and rollBack() rolls back to them.
+ * The outer test transaction stays open until rollbackTestTransaction() is called.
+ */
+class TestConnection extends AbstractConnectionMiddleware
+{
+    private bool $testTransactionActive = false;
+    private int $savepointCounter = 0;
+
+    public function __construct(Connection $connection)
+    {
+        parent::__construct($connection);
+    }
+
+    /**
+     * Begin the outer test transaction. Called in setUp().
+     */
+    public function beginTestTransaction(): void
+    {
+        parent::beginTransaction();
+        $this->testTransactionActive = true;
+        $this->savepointCounter = 0;
+    }
+
+    /**
+     * Roll back the outer test transaction. Called in tearDown().
+     */
+    public function rollbackTestTransaction(): void
+    {
+        parent::rollBack();
+        $this->testTransactionActive = false;
+        $this->savepointCounter = 0;
+    }
+
+    public function beginTransaction(): void
+    {
+        if ($this->testTransactionActive) {
+            ++$this->savepointCounter;
+            parent::exec('SAVEPOINT test_sp_'.$this->savepointCounter);
+
+            return;
+        }
+
+        parent::beginTransaction();
+    }
+
+    public function commit(): void
+    {
+        if ($this->testTransactionActive) {
+            if ($this->savepointCounter > 0) {
+                parent::exec('RELEASE SAVEPOINT test_sp_'.$this->savepointCounter);
+                --$this->savepointCounter;
+            }
+
+            // At level 0: no-op (outer test transaction stays open)
+            return;
+        }
+
+        parent::commit();
+    }
+
+    public function rollBack(): void
+    {
+        if ($this->testTransactionActive) {
+            if ($this->savepointCounter > 0) {
+                parent::exec('ROLLBACK TO SAVEPOINT test_sp_'.$this->savepointCounter);
+                --$this->savepointCounter;
+            }
+
+            // At level 0: no-op
+            return;
+        }
+
+        parent::rollBack();
+    }
+}

--- a/tests/Functional/AbstractFunctionalTest.php
+++ b/tests/Functional/AbstractFunctionalTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\DataFixtures\DevFixtures;
+use App\Tests\DBAL\StaticDriver;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
@@ -24,13 +25,32 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 abstract class AbstractFunctionalTest extends WebTestCase
 {
+    private static bool $fixturesLoaded = false;
+
     protected KernelBrowser $client;
 
     protected function setUp(): void
     {
         $this->client = static::createClient();
 
-        $this->resetDatabase();
+        if (!self::$fixturesLoaded) {
+            $this->initializeDatabase();
+            self::$fixturesLoaded = true;
+        }
+
+        $conn = StaticDriver::getConnection();
+        \assert(null !== $conn);
+        $conn->beginTestTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $conn = StaticDriver::getConnection();
+        if (null !== $conn) {
+            $conn->rollbackTestTransaction();
+        }
+
+        parent::tearDown();
     }
 
     protected function loginAs(string $email): void
@@ -42,7 +62,7 @@ abstract class AbstractFunctionalTest extends WebTestCase
         ]);
     }
 
-    private function resetDatabase(): void
+    private function initializeDatabase(): void
     {
         /** @var EntityManagerInterface $em */
         $em = static::getContainer()->get('doctrine.orm.entity_manager');


### PR DESCRIPTION
## Summary

- Replace per-test `dropSchema + createSchema + loadFixtures` with a DBAL middleware that caches the driver connection statically and wraps each test in a transaction that rolls back
- Schema and fixtures load once per process; application commits become savepoint releases within the outer test transaction
- Full suite drops from **~3.5 min to ~14s** (~15x speedup)

### How it works

1. `StaticConnectionMiddleware` → `StaticDriver` caches the underlying PDO connection statically, so kernel reboots (from `createClient()`) reuse the same connection and preserve the open transaction
2. `TestConnection` intercepts `beginTransaction()`/`commit()`/`rollBack()` during test mode, converting them to savepoint operations
3. `AbstractFunctionalTest::setUp()` loads fixtures once, then begins an outer test transaction; `tearDown()` rolls it back

### New files

| File | Purpose |
|------|---------|
| `tests/DBAL/StaticConnectionMiddleware.php` | DBAL middleware entry point |
| `tests/DBAL/StaticDriver.php` | Driver wrapper with static connection cache |
| `tests/DBAL/TestConnection.php` | Connection wrapper intercepting transaction calls |
| `config/services_test.yaml` | Registers middleware for test env only |

## Test plan

- [x] `make cs-fix` — 0 fixes needed
- [x] `make phpstan` — no errors (level 10)
- [x] `make test` — 312 tests pass, 1329 assertions (14s)
- [x] `--order-by=random` — 233 functional tests pass in random order (isolation verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)