### PR TITLE
:sparkles: Feature: locale listener for user language preference (F9.1)

### DIFF
--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -1,5 +1,8 @@
 framework:
     default_locale: en
+    enabled_locales: ['en', 'fr']
     translator:
         default_path: '%kernel.project_dir%/translations'
+        fallbacks:
+            - en
         providers:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -131,13 +131,13 @@ Each feature carries a **State** that must be kept up to date as work progresses
 
 | ID   | Feature                    | Priority | State       | Depends on |
 |------|----------------------------|----------|-------------|------------|
-| F9.1 | User language preference   | Medium   | Partial     | F1.1       |
+| F9.1 | User language preference   | Medium   | Done        | F1.1       |
 | F9.2 | User timezone              | Medium   | Partial     | F1.1, F9.4 |
 | F9.3 | Application translation    | Medium   | Not started | —          |
 | F1.3  | User profile               | Medium   | Not started | F1.1       |
 | F1.11 | Gravatar avatar & navbar user menu | Medium | Not started | F1.1 |
 
-**Progress: 0/5 done · 2 partial · 3 not started**
+**Progress: 1/5 done · 1 partial · 3 not started**
 
 **Deliverable:** All UI strings translatable (en/fr), user-selectable locale and timezone, a profile page showing owned decks, borrow history, and upcoming events, and a Gravatar-powered navbar avatar with user dropdown menu.
 
@@ -315,13 +315,13 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 3     | Events & Staff                    | 4    | 0       | 0           | 4     |
 | 4     | Borrow Workflow & Notifications   | 8    | 0       | 0           | 8     |
 | 5     | Core Views & Navigation           | 12   | 0       | 2           | 14    |
-| 6     | Localization                      | 0    | 2       | 3           | 5     |
+| 6     | Localization                      | 1    | 1       | 3           | 5     |
 | 7     | Engagement, Results & Discovery   | 0    | 4       | 5           | 9     |
 | 8     | Admin, Homepage & Polish          | 0    | 3       | 4           | 7     |
 | 9     | Content, Archetypes & Low Priority | 0   | 2       | 20          | 22    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **36** | **11** | **45**      | **92** |
+|       | **Total**                         | **37** | **10** | **45**      | **92** |
 
 All 92 features from [features.md](features.md) are represented exactly once.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,8 @@
         <testsuite name="unit">
             <directory>tests/Service</directory>
             <directory>tests/Entity</directory>
+            <directory>tests/EventListener</directory>
+            <directory>tests/Twig</directory>
         </testsuite>
         <testsuite name="functional">
             <directory>tests/Functional</directory>

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\EventListener;
+
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Sets the request locale based on (in order of priority):
+ * 1. Authenticated user's preferredLocale
+ * 2. Existing session locale
+ * 3. Accept-Language header detection
+ * 4. Default locale (en)
+ *
+ * @see docs/features.md F9.1 — User language preference
+ */
+#[AsEventListener(event: KernelEvents::REQUEST, priority: 20)]
+class LocaleListener
+{
+    private const array SUPPORTED_LOCALES = ['en', 'fr'];
+    private const string DEFAULT_LOCALE = 'en';
+
+    public function __construct(
+        private readonly Security $security,
+    ) {
+    }
+
+    public function __invoke(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        if (!$request->hasSession()) {
+            return;
+        }
+
+        $user = $this->security->getUser();
+
+        if ($user instanceof User) {
+            $locale = $user->getPreferredLocale();
+            $request->setLocale($locale);
+            $request->getSession()->set('_locale', $locale);
+
+            return;
+        }
+
+        $sessionLocale = $request->getSession()->get('_locale');
+        if (\is_string($sessionLocale) && \in_array($sessionLocale, self::SUPPORTED_LOCALES, true)) {
+            $request->setLocale($sessionLocale);
+
+            return;
+        }
+
+        $locale = $this->detectFromAcceptLanguage($request->headers->get('Accept-Language', ''));
+        $request->setLocale($locale);
+        $request->getSession()->set('_locale', $locale);
+    }
+
+    private function detectFromAcceptLanguage(string $header): string
+    {
+        if ('' === $header) {
+            return self::DEFAULT_LOCALE;
+        }
+
+        $best = self::DEFAULT_LOCALE;
+        $bestQ = 0.0;
+
+        foreach (explode(',', $header) as $part) {
+            $segments = explode(';', trim($part));
+            $lang = strtolower(trim($segments[0]));
+            $q = 1.0;
+
+            foreach ($segments as $segment) {
+                $segment = trim($segment);
+                if (str_starts_with($segment, 'q=')) {
+                    $q = (float) substr($segment, 2);
+                }
+            }
+
+            // Match primary language subtag (e.g., "fr-FR" → "fr")
+            $primary = explode('-', $lang)[0];
+
+            if (\in_array($primary, self::SUPPORTED_LOCALES, true) && $q > $bestQ) {
+                $bestQ = $q;
+                $best = $primary;
+            }
+        }
+
+        return $best;
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -7,7 +7,7 @@
  # file that was distributed with this source code.
  #}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ app.request.locale }}">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/tests/EventListener/LocaleListenerTest.php
+++ b/tests/EventListener/LocaleListenerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\EventListener;
+
+use App\Entity\User;
+use App\EventListener\LocaleListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class LocaleListenerTest extends TestCase
+{
+    public function testAuthenticatedUserLocaleIsApplied(): void
+    {
+        $user = new User();
+        $user->setPreferredLocale('fr');
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $request = $this->createRequestWithSession();
+        $event = $this->createRequestEvent($request);
+
+        $listener = new LocaleListener($security);
+        $listener($event);
+
+        self::assertSame('fr', $request->getLocale());
+        self::assertSame('fr', $request->getSession()->get('_locale'));
+    }
+
+    public function testSessionLocaleUsedForAnonymousUser(): void
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $request = $this->createRequestWithSession();
+        $request->getSession()->set('_locale', 'fr');
+        $event = $this->createRequestEvent($request);
+
+        $listener = new LocaleListener($security);
+        $listener($event);
+
+        self::assertSame('fr', $request->getLocale());
+    }
+
+    public function testAcceptLanguageDetectionForAnonymousUser(): void
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $request = $this->createRequestWithSession();
+        $request->headers->set('Accept-Language', 'fr-FR,fr;q=0.9,en;q=0.8');
+        $event = $this->createRequestEvent($request);
+
+        $listener = new LocaleListener($security);
+        $listener($event);
+
+        self::assertSame('fr', $request->getLocale());
+        self::assertSame('fr', $request->getSession()->get('_locale'));
+    }
+
+    public function testDefaultLocaleWhenNoSignal(): void
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $request = $this->createRequestWithSession();
+        $event = $this->createRequestEvent($request);
+
+        $listener = new LocaleListener($security);
+        $listener($event);
+
+        self::assertSame('en', $request->getLocale());
+    }
+
+    public function testUnsupportedSessionLocaleIsIgnored(): void
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $request = $this->createRequestWithSession();
+        $request->getSession()->set('_locale', 'de');
+        $event = $this->createRequestEvent($request);
+
+        $listener = new LocaleListener($security);
+        $listener($event);
+
+        self::assertSame('en', $request->getLocale());
+    }
+
+    public function testAcceptLanguageWithUnsupportedLocalesFallsToDefault(): void
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $request = $this->createRequestWithSession();
+        $request->headers->set('Accept-Language', 'de-DE,de;q=0.9,ja;q=0.8');
+        $event = $this->createRequestEvent($request);
+
+        $listener = new LocaleListener($security);
+        $listener($event);
+
+        self::assertSame('en', $request->getLocale());
+    }
+
+    private function createRequestWithSession(): Request
+    {
+        $request = Request::create('/');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        return $request;
+    }
+
+    private function createRequestEvent(Request $request): RequestEvent
+    {
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        return new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LocaleListener` (priority 20) that sets request locale from authenticated user's `preferredLocale`, session `_locale`, or `Accept-Language` header detection
- Configure `enabled_locales: ['en', 'fr']` and `fallbacks: ['en']` in translation config
- Dynamic `<html lang>` attribute in base template
- 6 unit tests covering all locale resolution paths

## Test plan
- [x] `make cs-fix` — no changes
- [x] `make phpstan` — no errors
- [x] `make test.unit` — 85 tests pass (6 new)
- [ ] Log in as user with `preferredLocale: fr` → request locale is `fr`
- [ ] Visit as anonymous with French browser → locale detected from `Accept-Language`
- [ ] Session locale persists across anonymous page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)