### PR TITLE
:sparkles: Feature: user timezone display with IntlDateFormatter (F9.2)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -132,12 +132,12 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | ID   | Feature                    | Priority | State       | Depends on |
 |------|----------------------------|----------|-------------|------------|
 | F9.1 | User language preference   | Medium   | Done        | F1.1       |
-| F9.2 | User timezone              | Medium   | Partial     | F1.1, F9.4 |
+| F9.2 | User timezone              | Medium   | Done        | F1.1, F9.4 |
 | F9.3 | Application translation    | Medium   | Not started | —          |
 | F1.3  | User profile               | Medium   | Not started | F1.1       |
 | F1.11 | Gravatar avatar & navbar user menu | Medium | Not started | F1.1 |
 
-**Progress: 1/5 done · 1 partial · 3 not started**
+**Progress: 2/5 done · 0 partial · 3 not started**
 
 **Deliverable:** All UI strings translatable (en/fr), user-selectable locale and timezone, a profile page showing owned decks, borrow history, and upcoming events, and a Gravatar-powered navbar avatar with user dropdown menu.
 
@@ -315,13 +315,13 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 3     | Events & Staff                    | 4    | 0       | 0           | 4     |
 | 4     | Borrow Workflow & Notifications   | 8    | 0       | 0           | 8     |
 | 5     | Core Views & Navigation           | 12   | 0       | 2           | 14    |
-| 6     | Localization                      | 1    | 1       | 3           | 5     |
+| 6     | Localization                      | 2    | 0       | 3           | 5     |
 | 7     | Engagement, Results & Discovery   | 0    | 4       | 5           | 9     |
 | 8     | Admin, Homepage & Polish          | 0    | 3       | 4           | 7     |
 | 9     | Content, Archetypes & Low Priority | 0   | 2       | 20          | 22    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **37** | **10** | **45**      | **92** |
+|       | **Total**                         | **38** | **9**  | **45**      | **92** |
 
 All 92 features from [features.md](features.md) are represented exactly once.

--- a/src/Twig/Extension/UserTimezoneExtension.php
+++ b/src/Twig/Extension/UserTimezoneExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Twig\Extension;
+
+use App\Twig\Runtime\UserTimezoneRuntime;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * @see docs/features.md F9.2 — User timezone
+ */
+class UserTimezoneExtension extends AbstractExtension
+{
+    /**
+     * @return list<TwigFilter>
+     */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('user_datetime', [UserTimezoneRuntime::class, 'formatDatetime']),
+            new TwigFilter('user_date', [UserTimezoneRuntime::class, 'formatDate']),
+        ];
+    }
+}

--- a/src/Twig/Runtime/UserTimezoneRuntime.php
+++ b/src/Twig/Runtime/UserTimezoneRuntime.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Twig\Runtime;
+
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\RuntimeExtensionInterface;
+
+/**
+ * Formats datetimes in the user's timezone and locale using IntlDateFormatter.
+ *
+ * @see docs/features.md F9.2 — User timezone
+ */
+class UserTimezoneRuntime implements RuntimeExtensionInterface
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * Formats a datetime with both date and time (e.g. "Mar 4, 2026 3:30 PM" / "4 mars 2026 15:30").
+     */
+    public function formatDatetime(\DateTimeInterface $date): string
+    {
+        return $this->format($date, \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT);
+    }
+
+    /**
+     * Formats a date only (e.g. "Mar 4, 2026" / "4 mars 2026").
+     */
+    public function formatDate(\DateTimeInterface $date): string
+    {
+        return $this->format($date, \IntlDateFormatter::MEDIUM, \IntlDateFormatter::NONE);
+    }
+
+    private function format(\DateTimeInterface $date, int $dateType, int $timeType): string
+    {
+        $user = $this->security->getUser();
+
+        $timezone = 'UTC';
+        $locale = 'en';
+
+        if ($user instanceof User) {
+            $timezone = $user->getTimezone();
+            $locale = $user->getPreferredLocale();
+        } else {
+            $request = $this->requestStack->getCurrentRequest();
+            if (null !== $request) {
+                $locale = $request->getLocale();
+            }
+        }
+
+        $formatter = new \IntlDateFormatter(
+            $locale,
+            $dateType,
+            $timeType,
+            $timezone,
+        );
+
+        $result = $formatter->format($date);
+        \assert(false !== $result);
+
+        return $result;
+    }
+}

--- a/templates/borrow/_inbox.html.twig
+++ b/templates/borrow/_inbox.html.twig
@@ -12,7 +12,7 @@
     <div class="card shadow-sm mb-3">
         <div class="card-header card-header-themed d-flex justify-content-between align-items-center">
             <a href="{{ path('app_event_show', {id: group.event.id}) }}" class="text-white text-decoration-none">{{ group.event.name }}</a>
-            <small class="text-white-50">{{ group.event.date|date('M j, Y') }}</small>
+            <small class="text-white-50">{{ group.event.date|user_date }}</small>
         </div>
         <div class="card-body p-0">
             <div class="table-responsive">
@@ -36,7 +36,7 @@
                                 </td>
                                 <td>{{ borrow.borrower.screenName }}</td>
                                 <td>{{ borrowBadge(borrow) }}</td>
-                                <td>{{ borrow.requestedAt|date('M j, Y') }}</td>
+                                <td>{{ borrow.requestedAt|user_date }}</td>
                                 <td class="text-end">
                                     {% if borrow.status.value == 'pending' %}
                                         <form method="post" action="{{ path('app_borrow_approve', {id: borrow.id}) }}" class="d-inline">

--- a/templates/borrow/list.html.twig
+++ b/templates/borrow/list.html.twig
@@ -80,7 +80,7 @@
                                         <td>{{ borrow.deck.owner.screenName }}</td>
                                     {% endif %}
                                     <td>{{ borrowBadge(borrow) }}</td>
-                                    <td>{{ borrow.requestedAt|date('M j, Y') }}</td>
+                                    <td>{{ borrow.requestedAt|user_date }}</td>
                                     <td><a href="{{ path('app_borrow_show', {id: borrow.id}) }}" class="btn btn-sm btn-outline-secondary">View</a></td>
                                 </tr>
                             {% endfor %}

--- a/templates/borrow/show.html.twig
+++ b/templates/borrow/show.html.twig
@@ -61,40 +61,40 @@
             <ul class="list-unstyled mb-0">
                 <li>
                     <strong>Requested:</strong>
-                    {{ borrow.requestedAt|date('M j, Y g:ia') }}
+                    {{ borrow.requestedAt|user_datetime }}
                     by {{ borrow.borrower.screenName }}
                 </li>
                 {% if borrow.approvedAt %}
                     <li class="mt-1">
                         <strong>Approved:</strong>
-                        {{ borrow.approvedAt|date('M j, Y g:ia') }}
+                        {{ borrow.approvedAt|user_datetime }}
                         {% if borrow.approvedBy %}by {{ borrow.approvedBy.screenName }}{% endif %}
                     </li>
                 {% endif %}
                 {% if borrow.handedOffAt %}
                     <li class="mt-1">
                         <strong>Handed off:</strong>
-                        {{ borrow.handedOffAt|date('M j, Y g:ia') }}
+                        {{ borrow.handedOffAt|user_datetime }}
                         {% if borrow.handedOffBy %}by {{ borrow.handedOffBy.screenName }}{% endif %}
                     </li>
                 {% endif %}
                 {% if borrow.returnedAt %}
                     <li class="mt-1">
                         <strong>Returned:</strong>
-                        {{ borrow.returnedAt|date('M j, Y g:ia') }}
+                        {{ borrow.returnedAt|user_datetime }}
                         {% if borrow.returnedTo %}to {{ borrow.returnedTo.screenName }}{% endif %}
                     </li>
                 {% endif %}
                 {% if borrow.returnedToOwnerAt %}
                     <li class="mt-1">
                         <strong>Returned to owner:</strong>
-                        {{ borrow.returnedToOwnerAt|date('M j, Y g:ia') }}
+                        {{ borrow.returnedToOwnerAt|user_datetime }}
                     </li>
                 {% endif %}
                 {% if borrow.cancelledAt %}
                     <li class="mt-1">
                         <strong>Cancelled:</strong>
-                        {{ borrow.cancelledAt|date('M j, Y g:ia') }}
+                        {{ borrow.cancelledAt|user_datetime }}
                         {% if borrow.cancelledBy %}by {{ borrow.cancelledBy.screenName }}{% endif %}
                     </li>
                 {% endif %}

--- a/templates/deck/show.html.twig
+++ b/templates/deck/show.html.twig
@@ -110,7 +110,7 @@
                                         <option value="">Select an event...</option>
                                         {% for event in eligibleEvents %}
                                             <option value="{{ event.id }}" data-token="{{ csrf_token('borrow-request-' ~ event.id) }}">
-                                                {{ event.name }} ({{ event.date|date('M j, Y') }})
+                                                {{ event.name }} ({{ event.date|user_date }})
                                             </option>
                                         {% endfor %}
                                     </select>
@@ -151,7 +151,7 @@
                                             <td><a href="{{ path('app_event_show', {id: borrow.event.id}) }}">{{ borrow.event.name }}</a></td>
                                             <td>{{ borrow.borrower.screenName }}</td>
                                             <td>{{ borrowBadge(borrow) }}</td>
-                                            <td>{{ borrow.requestedAt|date('M j, Y') }}</td>
+                                            <td>{{ borrow.requestedAt|user_date }}</td>
                                             <td><a href="{{ path('app_borrow_show', {id: borrow.id}) }}" class="btn btn-sm btn-outline-secondary">View</a></td>
                                         </tr>
                                     {% endfor %}

--- a/templates/event/available_decks.html.twig
+++ b/templates/event/available_decks.html.twig
@@ -18,7 +18,7 @@
 
     <p class="text-muted mb-4">
         Decks available to borrow for <strong>{{ event.name }}</strong>
-        ({{ event.date|date('M j, Y') }}).
+        ({{ event.date|user_date }}).
     </p>
 
     {% if availableDecks is not empty %}

--- a/templates/event/list.html.twig
+++ b/templates/event/list.html.twig
@@ -28,7 +28,7 @@
                                 <a href="{{ path('app_event_show', {id: event.id}) }}">{{ event.name }}</a>
                             </h5>
                             <p class="text-muted mb-1">
-                                {{ event.date|date('M j, Y g:ia') }}
+                                {{ event.date|user_datetime }}
                                 {% if event.location %} &mdash; {{ event.location }}{% endif %}
                             </p>
                             <p class="mb-0">

--- a/templates/event/show.html.twig
+++ b/templates/event/show.html.twig
@@ -35,9 +35,9 @@
                             <tr>
                                 <th>Date</th>
                                 <td>
-                                    {{ event.date|date('M j, Y g:ia') }}
+                                    {{ event.date|user_datetime }}
                                     {% if event.endDate %}
-                                        — {{ event.endDate|date('M j, Y g:ia') }}
+                                        — {{ event.endDate|user_datetime }}
                                     {% endif %}
                                 </td>
                             </tr>

--- a/templates/home/dashboard.html.twig
+++ b/templates/home/dashboard.html.twig
@@ -65,7 +65,7 @@
                                         <strong><a href="{{ path('app_event_show', {id: event.id}) }}">{{ event.name }}</a></strong>
                                         <br>
                                         <small class="text-muted">
-                                            {{ event.date|date('M j, Y') }}
+                                            {{ event.date|user_date }}
                                             {% if event.location %} &mdash; {{ event.location }}{% endif %}
                                         </small>
                                     </div>
@@ -104,7 +104,7 @@
                             <strong><a href="{{ path('app_event_show', {id: event.id}) }}">{{ event.name }}</a></strong>
                             <br>
                             <small class="text-muted">
-                                {{ event.date|date('M j, Y') }}
+                                {{ event.date|user_date }}
                                 {% if event.location %} &mdash; {{ event.location }}{% endif %}
                             </small>
                         </div>
@@ -143,7 +143,7 @@
                                     <td><a href="{{ path('app_deck_show', {short_tag: borrow.deck.shortTag}) }}"><span class="badge bg-dark me-1">{{ borrow.deck.shortTag }}</span>{{ borrow.deck.name }}</a></td>
                                     <td><a href="{{ path('app_event_show', {id: borrow.event.id}) }}">{{ borrow.event.name }}</a></td>
                                     <td>{{ borrowBadge(borrow) }}</td>
-                                    <td>{{ borrow.requestedAt|date('M j, Y') }}</td>
+                                    <td>{{ borrow.requestedAt|user_date }}</td>
                                     <td><a href="{{ path('app_borrow_show', {id: borrow.id}) }}" class="btn btn-sm btn-outline-secondary">View</a></td>
                                 </tr>
                             {% endfor %}
@@ -182,7 +182,7 @@
                                     <td><a href="{{ path('app_event_show', {id: borrow.event.id}) }}">{{ borrow.event.name }}</a></td>
                                     <td>{{ borrow.borrower.screenName }}</td>
                                     <td>{{ borrowBadge(borrow) }}</td>
-                                    <td>{{ borrow.requestedAt|date('M j, Y') }}</td>
+                                    <td>{{ borrow.requestedAt|user_date }}</td>
                                     <td><a href="{{ path('app_borrow_show', {id: borrow.id}) }}" class="btn btn-sm btn-outline-secondary">View</a></td>
                                 </tr>
                             {% endfor %}
@@ -221,7 +221,7 @@
                                         <td>{{ borrow.borrower.screenName }}</td>
                                         <td><a href="{{ path('app_event_show', {id: borrow.event.id}) }}">{{ borrow.event.name }}</a></td>
                                         <td>{{ borrowBadge(borrow) }}</td>
-                                        <td>{{ borrow.requestedAt|date('M j, Y') }}</td>
+                                        <td>{{ borrow.requestedAt|user_date }}</td>
                                         <td><a href="{{ path('app_borrow_show', {id: borrow.id}) }}" class="btn btn-sm btn-outline-secondary">View</a></td>
                                     </tr>
                                 {% endfor %}

--- a/tests/Twig/UserTimezoneExtensionTest.php
+++ b/tests/Twig/UserTimezoneExtensionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Twig;
+
+use App\Entity\User;
+use App\Twig\Runtime\UserTimezoneRuntime;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class UserTimezoneExtensionTest extends TestCase
+{
+    public function testFormatDatetimeWithUserTimezone(): void
+    {
+        $user = new User();
+        $user->setTimezone('Europe/Paris');
+        $user->setPreferredLocale('fr');
+
+        $runtime = $this->createRuntime($user);
+        $date = new \DateTimeImmutable('2026-03-04 14:30:00', new \DateTimeZone('UTC'));
+
+        $result = $runtime->formatDatetime($date);
+
+        // Europe/Paris is UTC+1 in March, so 14:30 UTC → 15:30 CET
+        self::assertStringContainsString('15:30', $result);
+        self::assertStringContainsString('mars', $result);
+    }
+
+    public function testFormatDateWithUserTimezone(): void
+    {
+        $user = new User();
+        $user->setTimezone('America/New_York');
+        $user->setPreferredLocale('en');
+
+        $runtime = $this->createRuntime($user);
+        $date = new \DateTimeImmutable('2026-03-04 14:30:00', new \DateTimeZone('UTC'));
+
+        $result = $runtime->formatDate($date);
+
+        self::assertStringContainsString('Mar', $result);
+        self::assertStringContainsString('2026', $result);
+        // Should NOT contain time
+        self::assertStringNotContainsString(':', $result);
+    }
+
+    public function testAnonymousUserUsesUtcAndRequestLocale(): void
+    {
+        $runtime = $this->createRuntime(null, 'fr');
+        $date = new \DateTimeImmutable('2026-03-04 14:30:00', new \DateTimeZone('UTC'));
+
+        $result = $runtime->formatDatetime($date);
+
+        self::assertStringContainsString('14:30', $result);
+        self::assertStringContainsString('mars', $result);
+    }
+
+    public function testFormatDatetimeEnglishLocale(): void
+    {
+        $user = new User();
+        $user->setTimezone('UTC');
+        $user->setPreferredLocale('en');
+
+        $runtime = $this->createRuntime($user);
+        $date = new \DateTimeImmutable('2026-03-04 14:30:00', new \DateTimeZone('UTC'));
+
+        $result = $runtime->formatDatetime($date);
+
+        self::assertStringContainsString('Mar', $result);
+        self::assertStringContainsString('2026', $result);
+    }
+
+    private function createRuntime(?User $user, string $requestLocale = 'en'): UserTimezoneRuntime
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $request = Request::create('/');
+        $request->setLocale($requestLocale);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return new UserTimezoneRuntime($security, $requestStack);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `UserTimezoneExtension` with `user_date` and `user_datetime` Twig filters
- Lazy runtime uses `IntlDateFormatter` for locale-aware formatting (e.g. "4 mars 2026" in French)
- All 21 `|date(...)` occurrences across 8 templates replaced with timezone-aware filters
- 4 unit tests covering authenticated/anonymous users, timezone conversion, locale formatting

## Test plan
- [x] `make cs-fix` — no changes
- [x] `make phpstan` — no errors
- [x] `make test.unit` — 83 tests pass (4 new)
- [ ] Log in as user with `timezone: Europe/Paris` → datetimes display in CET
- [ ] French locale → dates show "mars", "avr." etc.
- [ ] Anonymous user → dates in UTC with request locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)