### PR TITLE
:memo: docs: Phase 6 localization release docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,30 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [0.3.0] — 2026-03-04
+
+Phase 6 — Localization: multi-language support (en/fr), timezone-aware display, user profile page, and Gravatar navbar avatar.
+
+### Localization
+
+- **F9.1** — User language preference: Symfony locale listener detects user locale from session, user preference, or `Accept-Language` header. All UI strings render in the active locale.
+- **F9.2** — User timezone display: `user_datetime` / `user_date` Twig filters convert UTC timestamps to the user's timezone with locale-aware formatting via `IntlDateFormatter`. Event dates display in the event's timezone with a tooltip showing the user's local time when different.
+- **F9.3** — Application translation: all ~300 user-facing strings extracted to XLIFF catalogues (`messages.en.xlf`, `messages.fr.xlf`). Covers templates, controller flash messages, form labels, and email templates/subjects. Emails render in the recipient's preferred locale.
+- **F9.4** — UTC datetime storage: event form uses `model_timezone` / `view_timezone` for automatic UTC conversion. PHP timezone set to UTC via `.symfony.local.yaml`.
+
+### User Management
+
+- **F1.3** — User profile page: edit screen name, player ID, preferred locale, and timezone. Locale changes apply immediately via `LocaleSwitcher`.
+- **F1.11** — Gravatar avatar & navbar dropdown: 32px Gravatar avatar (64px Retina source) in the navbar with a Bootstrap dropdown menu (Dashboard, Profile, Logout).
+
+### Cross-Cutting
+
+- Abstract base controller (`AbstractAppController`) with auto-translating `addFlash()` for all controllers
+- Bootstrap Icons and tooltip initialization for timezone display
+- 363 tests, PHPStan level 10
+
+---
+
 ## [0.2.0] — 2026-03-04
 
 Borrow workflow maturity: staff custody chain, conflict management, owner inbox, and UI refinements.
@@ -120,8 +144,8 @@ First tagged release. Covers the core domain: authentication, deck library, even
 
 - **F1.8** — Account deletion & data export *(partial)* — soft-delete with anonymization scaffolded; confirmation email and JSON export not yet implemented
 - **F2.7** — Retire / reactivate a deck *(partial)* — status transitions exist; UI controls pending
-- **F9.1** — User language preference *(partial)* — locale field on User entity; preference UI and full i18n not yet applied
-- **F9.2** — User timezone *(partial)* — timezone field on User entity; display conversion not yet applied
+- **F9.1** — User language preference *(partial)* — locale field on User entity; preference UI and full i18n not yet applied *(completed in 0.3.0)*
+- **F9.2** — User timezone *(partial)* — timezone field on User entity; display conversion not yet applied *(completed in 0.3.0)*
 
 ### Cross-Cutting
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -100,6 +100,7 @@ The frontend is built with **React.js** (via Symfony UX / Webpack Encore) for al
 | F5.5   | PrintNode printer management         | Medium   | Configure PrintNode API key and select target printer from available PrintNode printers. |
 | F5.6   | Camera QR scan (mobile fallback)     | Medium   | Tap scan button to open device camera and scan deck label QR code. Uses `html5-qrcode`. Same lookup/action as HID scanner (F5.3). See [Camera Scanner Technicality](technicalities/camera_scanner.md). |
 | F5.7   | PDF label card (home printing)       | Medium   | Generate a downloadable PDF with a TCG card-sized label (63.5 × 88.9 mm) containing deck ID, name, owner, and QR code. Printed on any home printer, cut out, and slipped into a card sleeve. Uses Dompdf + `endroid/qr-code`. Same QR encoding as ZPL label — scannable by F5.3 and F5.6. See [PDF Label Technicality](technicalities/pdf_label.md). |
+| F5.12  | Deck show activity pagination        | Medium   | Deck detail page shows only the 5 most recent activity entries (borrows, returns, etc.) with a "See more" link to the full history page. Keeps the deck page focused while preserving access to the complete timeline. |
 
 > **Future:** A dedicated technicality document for PrintNode integration (ZPL generation, API client, printer selection) is planned — `docs/technicalities/printnode.md`.
 
@@ -121,6 +122,7 @@ The frontend is built with **React.js** (via Symfony UX / Webpack Encore) for al
 | F7.1   | Dashboard                            | Medium   | Admin overview: total decks, active borrows, upcoming events, overdue returns. Includes a **"Staffing"** card showing events where the user is organizer or staff (start date within the last 7 days or in the future, hidden when empty), and a **"My Events"** card showing upcoming events where the user has an engagement (interested, playing, spectating) with state badges. |
 | F7.2   | User management                      | Medium   | Admin CRUD for user accounts and role assignment. |
 | F7.3   | Audit log                            | Low      | Log significant actions (deck registered, borrow approved, return confirmed) for traceability. |
+| F7.4   | Dashboard action reminders           | Medium   | Dashboard widget showing upcoming actions due soon (borrows to return, pending requests to review, upcoming events requiring deck selection). Helps users stay on top of time-sensitive tasks. |
 
 ## F8 — Notifications
 
@@ -164,6 +166,7 @@ Both email (via Symfony Mailer + Messenger async transport) and in-app (stored i
 | F9.2   | User timezone                        | Medium   | Each user has a `timezone` (IANA string, default `UTC`). All UI datetimes are converted to the user's timezone for display. See [User model](models/user.md). |
 | F9.3   | Application translation              | Medium   | Symfony Translation component (YAML catalogues) for backend strings and `react-i18next` (JSON catalogues) for frontend strings. Initial languages: `en`, `fr`. Dot-notation keys (e.g. `app.deck.status.available`). All user-facing strings wrapped in translation calls (`trans()` / `t()`). |
 | F9.4   | UTC datetime storage                 | High     | All database datetimes stored in **UTC**. Event dates are displayed in the event's `timezone` field (see [Event model](models/event.md)). When the user's timezone differs from the event's timezone, a user-relative hint is shown — e.g. "10:00 CET (16:00 your time)". Borrow and notification timestamps displayed in the user's timezone (F9.2). |
+| F9.5   | Weblate integration                  | Low      | Cloud-hosted Weblate instance for collaborative editing of translation files (XLIFF catalogues). Translators edit via Weblate web UI; changes sync back to the repository via automated PRs. |
 
 ## F11 — CMS Content Pages
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -235,8 +235,16 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F4.6  | Overdue tracking                        | Low      | Not started | F4.4             |
 | F7.3  | Audit log                               | Low      | Not started | —                |
 | F8.3  | Notification preferences                | Low      | Not started | F8.1             |
+| F9.5  | Weblate integration                     | Low      | Not started | F9.3             |
 
-**Progress: 0/22 done · 2 partial · 20 not started**
+### UX Improvements
+
+| ID    | Feature                                 | Priority | State       | Depends on       |
+|-------|-----------------------------------------|----------|-------------|------------------|
+| F5.12 | Deck show activity pagination           | Medium   | Not started | F2.3             |
+| F7.4  | Dashboard action reminders              | Medium   | Not started | F7.1             |
+
+**Progress: 0/25 done · 2 partial · 23 not started**
 
 **Deliverable:** Auth hardening (flexible login, password strength scoring, MFA, Pokemon SSO). Managed archetype catalogue with detail pages, sprite pictograms, and backlinking across the UI. CMS content pages with Markdown, translations, and menu categories. Event series, iCal feeds, deck version history, card mosaic view, overdue tracking, friend delegation for borrow completion, notification preferences, and audit log.
 
@@ -318,10 +326,10 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
 | 7     | Engagement, Results & Discovery   | 0    | 4       | 6           | 10    |
 | 8     | Admin, Homepage & Polish          | 0    | 3       | 4           | 7     |
-| 9     | Content, Archetypes & Low Priority | 0   | 2       | 20          | 22    |
+| 9     | Content, Archetypes & Low Priority | 0   | 2       | 23          | 25    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **42** | **9**  | **42**      | **93** |
+|       | **Total**                         | **42** | **9**  | **45**      | **96** |
 
-All 92 features from [features.md](features.md) are represented exactly once.
+All 96 features from [features.md](features.md) are represented exactly once.

--- a/docs/technicalities/localization.md
+++ b/docs/technicalities/localization.md
@@ -1,0 +1,107 @@
+# Localization
+
+> **Audience:** Developer · **Scope:** Technical Reference
+
+<- Back to [Main Documentation](../docs.md) | [Features](../features.md)
+
+---
+
+## Supported Locales
+
+- `en` (English) — default
+- `fr` (French)
+
+Enabled in `config/packages/translation.yaml`:
+
+```yaml
+framework:
+    default_locale: en
+    enabled_locales: ['en', 'fr']
+```
+
+## Locale Detection
+
+`LocaleListener` (priority 20, after firewall) resolves the locale in this order:
+
+1. **Authenticated user** -> `user.preferredLocale`, stored in session
+2. **Anonymous with session `_locale`** -> use it
+3. **Anonymous without** -> detect from `Accept-Language` header against enabled locales, fallback `en`, store in session
+
+The `<html lang>` attribute reflects the request locale.
+
+## Translation Catalogues
+
+XLIFF format: `translations/messages.en.xlf`, `translations/messages.fr.xlf`.
+
+### Key Naming Convention
+
+Dot-notation, organized by domain:
+
+| Prefix                   | Usage                                    |
+|--------------------------|------------------------------------------|
+| `app.nav.*`              | Navigation links                         |
+| `app.common.*`           | Shared buttons/labels (view, edit, etc.) |
+| `app.dashboard.*`        | Dashboard sections                       |
+| `app.deck.*`             | Deck catalog, show, new, edit            |
+| `app.event.*`            | Event list, show, new, edit              |
+| `app.borrow.*`           | Borrow show, list, inbox, badges         |
+| `app.auth.*`             | Login, register, password reset          |
+| `app.profile.*`          | Profile page                             |
+| `app.email.*`            | Email templates and subjects             |
+| `app.flash.*`            | Flash messages (controller layer)        |
+| `app.form.label.*`       | Form field labels                        |
+| `app.form.placeholder.*` | Form field placeholders                  |
+| `app.footer.*`           | Footer                                   |
+
+### Templates
+
+Use `{{ 'key'|trans }}` or `{{ 'key'|trans({'%param%': value}) }}`.
+
+### Controllers
+
+All controllers extend `AbstractAppController`, which overrides `addFlash()` to auto-translate messages:
+
+```php
+$this->addFlash('success', 'app.flash.borrow.approved');
+```
+
+### Emails
+
+Email templates receive a `locale` context variable (the recipient's `preferredLocale`) and use explicit locale on every `|trans` call:
+
+```twig
+{{ 'app.email.greeting'|trans({'%name%': recipient.screenName}, 'messages', locale) }}
+```
+
+Email subjects are translated server-side via `TranslatorInterface::trans()` with the recipient's locale.
+
+## Timezone Display
+
+### Twig Filters
+
+| Filter           | Description                                          |
+|------------------|------------------------------------------------------|
+| `user_datetime`  | Full datetime in user's timezone and locale           |
+| `user_date`      | Date only in user's timezone and locale               |
+| `tz_abbr`        | Short timezone abbreviation (e.g. "CET", "EST")      |
+
+All filters accept an optional `?string $timezone` parameter to override the user's timezone (used for event-local display).
+
+### Event Date Display
+
+The `event/_datetime.html.twig` partial shows event dates in the event's timezone with an abbreviation. When the user's timezone differs, a clock icon tooltip displays the user's local time:
+
+```twig
+{% include 'event/_datetime.html.twig' with {dt: event.date, tz: event.timezone} %}
+```
+
+### UTC Storage
+
+All database datetimes are stored in UTC. The event form uses `model_timezone: 'UTC'` and `view_timezone: event.timezone` for automatic conversion. PHP timezone is set to UTC via `.symfony.local.yaml`.
+
+## Adding a New Locale
+
+1. Add the locale code to `enabled_locales` in `config/packages/translation.yaml`
+2. Create `translations/messages.{locale}.xlf` by copying `messages.en.xlf` and translating all `<target>` values
+3. Add the locale as a choice in `ProfileFormType::preferredLocale`
+4. Test: log in as a user with the new locale, verify all pages render correctly


### PR DESCRIPTION
## Summary
- Add **0.3.0 changelog** entry covering Phase 6: F9.1-F9.4 (locale, timezone, translation, UTC storage), F1.3 (profile page), F1.11 (Gravatar navbar)
- Add **F9.5** (Weblate integration) to features.md and roadmap Phase 9
- Add **F5.12** (deck show activity pagination) and **F7.4** (dashboard action reminders) to features.md and roadmap Phase 9
- Create **docs/technicalities/localization.md** — technical reference for key naming conventions, locale detection, timezone display, email locale handling, and adding a new locale
- Update roadmap summary: 42 done, 9 partial, 45 not started (96 total features)
- Phase 6 is now **5/5 done**

## Test plan
- [ ] Verify all doc links resolve correctly
- [ ] Verify feature counts match between features.md and roadmap.md
- [ ] `make cs-fix && make phpstan && make test` — all pass (363 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)