### PR TITLE
:sparkles: feat: add tournament result fields to EventDeckEntry

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -151,7 +151,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F3.11 | Event visibility                 | Medium   | Not started | F3.1             |
 | F3.13 | Player engagement states         | Medium   | Not started | F3.4             |
 | F2.14 | Deck event status overview       | Medium   | Not started | F2.3, F3.13      |
-| F3.7  | Register played deck for event   | Medium   | Partial     | F3.4, F2.2       |
+| F3.7  | Register played deck for event   | Medium   | Done        | F3.4, F2.2       |
 | F3.17 | Tournament results               | Medium   | Not started | F3.7             |
 | F3.10 | Cancel an event                  | Medium   | Partial     | F3.1, F4.1       |
 | F3.20 | Mark event as finished           | Medium   | Partial     | F3.1, F4.6       |
@@ -159,7 +159,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F8.2  | Event notifications              | Medium   | Partial     | F3.1, F3.13      |
 | F3.18 | Sync from Pokemon event page     | Medium   | Not started | F3.1, F3.9       |
 
-**Progress: 0/10 done · 4 partial · 6 not started**
+**Progress: 1/10 done · 3 partial · 6 not started**
 
 **Deliverable:** Public/private/invitation-only events, player engagement states (interested → registered), deck event status overview, tournament results with privacy, event cancellation with cascading borrows, event finishment with overdue triggers, event discovery page, event notifications, and Pokemon event page sync.
 
@@ -324,12 +324,12 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 4     | Borrow Workflow & Notifications   | 8    | 0       | 0           | 8     |
 | 5     | Core Views & Navigation           | 13   | 0       | 0           | 13    |
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
-| 7     | Engagement, Results & Discovery   | 0    | 4       | 6           | 10    |
+| 7     | Engagement, Results & Discovery   | 1    | 3       | 6           | 10    |
 | 8     | Admin, Homepage & Polish          | 0    | 3       | 4           | 7     |
 | 9     | Content, Archetypes & Low Priority | 0   | 2       | 23          | 25    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **42** | **9**  | **45**      | **96** |
+|       | **Total**                         | **43** | **8**  | **45**      | **96** |
 
 All 96 features from [features.md](features.md) are represented exactly once.

--- a/migrations/Version20260304223212.php
+++ b/migrations/Version20260304223212.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * F3.7 — Add tournament result fields to EventDeckEntry.
+ */
+final class Version20260304223212 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add final_placement and match_record columns to event_deck_entry';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event_deck_entry ADD final_placement SMALLINT DEFAULT NULL, ADD match_record VARCHAR(20) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event_deck_entry DROP final_placement, DROP match_record');
+    }
+}

--- a/src/Entity/EventDeckEntry.php
+++ b/src/Entity/EventDeckEntry.php
@@ -15,6 +15,7 @@ namespace App\Entity;
 
 use App\Repository\EventDeckEntryRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @see docs/features.md F3.7 — Register deck for tournament
@@ -40,6 +41,15 @@ class EventDeckEntry
     #[ORM\ManyToOne(targetEntity: DeckVersion::class)]
     #[ORM\JoinColumn(nullable: false)]
     private DeckVersion $deckVersion;
+
+    #[ORM\Column(type: 'smallint', nullable: true)]
+    #[Assert\Positive]
+    private ?int $finalPlacement = null;
+
+    #[ORM\Column(length: 20, nullable: true)]
+    #[Assert\Length(max: 20)]
+    #[Assert\Regex(pattern: '/^\d{1,2}-\d{1,2}-\d{1,2}$/', message: 'Match record must be in W-L-T format (e.g. 3-1-0).')]
+    private ?string $matchRecord = null;
 
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
@@ -86,6 +96,30 @@ class EventDeckEntry
     public function setDeckVersion(DeckVersion $deckVersion): static
     {
         $this->deckVersion = $deckVersion;
+
+        return $this;
+    }
+
+    public function getFinalPlacement(): ?int
+    {
+        return $this->finalPlacement;
+    }
+
+    public function setFinalPlacement(?int $finalPlacement): static
+    {
+        $this->finalPlacement = $finalPlacement;
+
+        return $this;
+    }
+
+    public function getMatchRecord(): ?string
+    {
+        return $this->matchRecord;
+    }
+
+    public function setMatchRecord(?string $matchRecord): static
+    {
+        $this->matchRecord = $matchRecord;
 
         return $this;
     }


### PR DESCRIPTION
## Summary
- Add nullable `finalPlacement` (smallint) and `matchRecord` (string, W-L-T format) columns to `event_deck_entry`
- Include Doctrine migration for schema change
- Update roadmap: F3.7 → Done

## Test plan
- [x] `make cs-fix && make phpstan && make test` — all pass
- [x] Run migration on dev database
- [x] Verify columns exist with correct types

🤖 Generated with [Claude Code](https://claude.com/claude-code)