### PR TITLE
:sparkles: feat: event visibility and discovery page (F3.11, F3.15)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -50,6 +50,7 @@ security:
         - { path: ^/api/archetype/search$, roles: PUBLIC_ACCESS }
         - { path: ^/api/deck-owner/search$, roles: PUBLIC_ACCESS }
         - { path: ^/event$, roles: PUBLIC_ACCESS }
+        - { path: ^/events/discover$, roles: PUBLIC_ACCESS }
         - { path: ^/dashboard, roles: ROLE_USER }
         - { path: ^/deck, roles: ROLE_USER }
         - { path: ^/event, roles: ROLE_USER }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,18 +148,18 @@ Each feature carries a **State** that must be kept up to date as work progresses
 
 | ID    | Feature                          | Priority | State       | Depends on       |
 |-------|----------------------------------|----------|-------------|------------------|
-| F3.11 | Event visibility                 | Medium   | Not started | F3.1             |
+| F3.11 | Event visibility                 | Medium   | Done        | F3.1             |
 | F3.13 | Player engagement states         | Medium   | Done        | F3.4             |
 | F2.14 | Deck event status overview       | Medium   | Not started | F2.3, F3.13      |
 | F3.7  | Register played deck for event   | Medium   | Done        | F3.4, F2.2       |
 | F3.17 | Tournament results               | Medium   | Not started | F3.7             |
 | F3.10 | Cancel an event                  | Medium   | Done        | F3.1, F4.1       |
 | F3.20 | Mark event as finished           | Medium   | Done        | F3.1, F4.6       |
-| F3.15 | Event discovery                  | Medium   | Not started | F3.11, F3.13     |
+| F3.15 | Event discovery                  | Medium   | Done        | F3.11, F3.13     |
 | F8.2  | Event notifications              | Medium   | Partial     | F3.1, F3.13      |
 | F3.18 | Sync from Pokemon event page     | Medium   | Not started | F3.1, F3.9       |
 
-**Progress: 4/10 done · 2 partial · 4 not started**
+**Progress: 6/10 done · 2 partial · 2 not started**
 
 **Deliverable:** Public/private/invitation-only events, player engagement states (interested → registered), deck event status overview, tournament results with privacy, event cancellation with cascading borrows, event finishment with overdue triggers, event discovery page, event notifications, and Pokemon event page sync.
 
@@ -324,12 +324,12 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 4     | Borrow Workflow & Notifications   | 8    | 0       | 0           | 8     |
 | 5     | Core Views & Navigation           | 13   | 0       | 0           | 13    |
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
-| 7     | Engagement, Results & Discovery   | 4    | 2       | 4           | 10    |
+| 7     | Engagement, Results & Discovery   | 6    | 2       | 2           | 10    |
 | 8     | Admin, Homepage & Polish          | 0    | 3       | 4           | 7     |
 | 9     | Content, Archetypes & Low Priority | 0   | 2       | 23          | 25    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **46** | **7**  | **43**      | **96** |
+|       | **Total**                         | **48** | **7**  | **41**      | **96** |
 
 All 96 features from [features.md](features.md) are represented exactly once.

--- a/migrations/Version20260305105246.php
+++ b/migrations/Version20260305105246.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260305105246 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add visibility column to event table (F3.11)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE event ADD visibility VARCHAR(20) NOT NULL DEFAULT 'public'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE event DROP visibility');
+    }
+}

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -24,6 +24,7 @@ use App\Entity\User;
 use App\Enum\BorrowStatus;
 use App\Enum\DeckStatus;
 use App\Enum\EngagementState;
+use App\Enum\EventVisibility;
 use App\Enum\ParticipationMode;
 use App\Form\EventFormType;
 use App\Message\CancelEventBorrowsMessage;
@@ -99,6 +100,7 @@ class EventController extends AbstractAppController
     /**
      * @see docs/features.md F3.3 — Event detail view
      * @see docs/features.md F3.7 — Register played deck for event
+     * @see docs/features.md F3.11 — Event visibility
      */
     #[Route('/{id}', name: 'app_event_show', methods: ['GET'], requirements: ['id' => '\d+'])]
     public function show(
@@ -110,6 +112,16 @@ class EventController extends AbstractAppController
     ): Response {
         /** @var User $user */
         $user = $this->getUser();
+
+        // Draft/Private events: only visible to organizer, staff, invited users, and admins
+        if (EventVisibility::Public !== $event->getVisibility()
+            && !$event->isOrganizerOrStaff($user)
+            && !$this->isGranted('ROLE_ADMIN')) {
+            $engagement = $event->getEngagementFor($user);
+            if (null === $engagement || null === $engagement->getInvitedBy()) {
+                throw $this->createAccessDeniedException();
+            }
+        }
 
         $userEngagement = $event->getEngagementFor($user);
         $isParticipant = null !== $userEngagement;

--- a/src/Controller/EventListController.php
+++ b/src/Controller/EventListController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\User;
 use App\Repository\EventRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,14 +23,32 @@ use Symfony\Component\Routing\Attribute\Route;
  * Public event listing, accessible without authentication.
  *
  * @see docs/features.md F3.2 — Event listing
+ * @see docs/features.md F3.15 — Event discovery
  */
 class EventListController extends AbstractController
 {
+    /**
+     * @see docs/features.md F3.11 — Event visibility
+     */
     #[Route('/event', name: 'app_event_list', methods: ['GET'], priority: 10)]
     public function list(EventRepository $eventRepository): Response
     {
+        /** @var User|null $user */
+        $user = $this->getUser();
+
         return $this->render('event/list.html.twig', [
-            'events' => $eventRepository->findUpcoming(20),
+            'events' => $eventRepository->findVisibleUpcoming($user),
+        ]);
+    }
+
+    /**
+     * @see docs/features.md F3.15 — Event discovery
+     */
+    #[Route('/events/discover', name: 'app_event_discover', methods: ['GET'])]
+    public function discover(EventRepository $eventRepository): Response
+    {
+        return $this->render('event/discover.html.twig', [
+            'events' => $eventRepository->findPublicUpcoming(),
         ]);
     }
 }

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -26,6 +26,7 @@ use App\Entity\User;
 use App\Enum\BorrowStatus;
 use App\Enum\DeckStatus;
 use App\Enum\EngagementState;
+use App\Enum\EventVisibility;
 use App\Enum\ParticipationMode;
 use App\Enum\TournamentStructure;
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -51,6 +52,7 @@ class DevFixtures extends Fixture
         $todayEvent = $this->createEventToday($manager, $admin, $borrower, $staff1);
         $futureEvent = $this->createEventInTwoMonths($manager, $admin, $lender, $staff1, $staff2);
         $this->createInvitationalEvent($manager, $organizer, $admin, $staff2);
+        $this->createDraftEvent($manager, $organizer, $admin);
 
         // Create archetypes
         $archetypeIronThorns = $this->createArchetype($manager, 'Iron Thorns ex');
@@ -350,6 +352,34 @@ class DevFixtures extends Fixture
         $staffAssignment->setUser($staff2);
         $staffAssignment->setAssignedBy($organizer);
         $manager->persist($staffAssignment);
+
+        return $event;
+    }
+
+    /**
+     * @see docs/features.md F3.11 — Event visibility
+     */
+    private function createDraftEvent(ObjectManager $manager, User $organizer, User $admin): Event
+    {
+        $event = new Event();
+        $event->setName('Draft Event — Not Yet Published');
+        $event->setDate(new \DateTimeImmutable('+5 weeks', new \DateTimeZone('Europe/Paris')));
+        $event->setTimezone('Europe/Paris');
+        $event->setLocation('TBD');
+        $event->setOrganizer($organizer);
+        $event->setRegistrationLink('https://pokemon-paris.example.com/draft');
+        $event->setFormat('Expanded');
+        $event->setVisibility(EventVisibility::Draft);
+
+        $manager->persist($event);
+
+        // Admin is invited so they can see it
+        $adminEngagement = new EventEngagement();
+        $adminEngagement->setEvent($event);
+        $adminEngagement->setUser($admin);
+        $adminEngagement->setState(EngagementState::Invited);
+        $adminEngagement->setInvitedBy($organizer);
+        $manager->persist($adminEngagement);
 
         return $event;
     }

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Enum\EngagementState;
+use App\Enum\EventVisibility;
 use App\Enum\TournamentStructure;
 use App\Repository\EventRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -26,6 +27,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @see docs/features.md F3.1 — Create a new event
  * @see docs/features.md F3.5 — Assign event staff team
  * @see docs/features.md F3.10 — Cancel an event
+ * @see docs/features.md F3.11 — Event visibility
  * @see docs/features.md F3.20 — Mark event as finished
  */
 #[ORM\Entity(repositoryClass: EventRepository::class)]
@@ -106,6 +108,9 @@ class Event
     #[ORM\Column(length: 3, nullable: true)]
     #[Assert\Length(exactly: 3)]
     private ?string $entryFeeCurrency = null;
+
+    #[ORM\Column(length: 20, enumType: EventVisibility::class)]
+    private EventVisibility $visibility = EventVisibility::Public;
 
     #[ORM\Column]
     private bool $isDecklistMandatory = false;
@@ -358,6 +363,21 @@ class Event
     public function setEntryFeeCurrency(?string $entryFeeCurrency): static
     {
         $this->entryFeeCurrency = $entryFeeCurrency;
+
+        return $this;
+    }
+
+    /**
+     * @see docs/features.md F3.11 — Event visibility
+     */
+    public function getVisibility(): EventVisibility
+    {
+        return $this->visibility;
+    }
+
+    public function setVisibility(EventVisibility $visibility): static
+    {
+        $this->visibility = $visibility;
 
         return $this;
     }

--- a/src/Enum/EventVisibility.php
+++ b/src/Enum/EventVisibility.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Enum;
+
+/**
+ * @see docs/features.md F3.11 — Event visibility
+ */
+enum EventVisibility: string
+{
+    case Public = 'public';
+    case Draft = 'draft';
+    case Private = 'private';
+}

--- a/src/Form/EventFormType.php
+++ b/src/Form/EventFormType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Entity\Event;
+use App\Enum\EventVisibility;
 use App\Enum\TournamentStructure;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -127,6 +128,15 @@ class EventFormType extends AbstractType
                 'label' => 'app.form.label.currency',
                 'required' => false,
                 'placeholder' => 'app.form.placeholder.select',
+            ])
+            ->add('visibility', EnumType::class, [
+                'class' => EventVisibility::class,
+                'label' => 'app.form.label.visibility',
+                'choice_label' => static fn (EventVisibility $v): string => match ($v) {
+                    EventVisibility::Public => 'app.event.visibility.public',
+                    EventVisibility::Draft => 'app.event.visibility.draft',
+                    EventVisibility::Private => 'app.event.visibility.private',
+                },
             ])
             ->add('isDecklistMandatory', CheckboxType::class, [
                 'label' => 'app.form.label.decklist_mandatory',

--- a/src/Repository/EventRepository.php
+++ b/src/Repository/EventRepository.php
@@ -16,6 +16,7 @@ namespace App\Repository;
 use App\Entity\Deck;
 use App\Entity\Event;
 use App\Entity\User;
+use App\Enum\EventVisibility;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -62,6 +63,71 @@ class EventRepository extends ServiceEntityRepository
             ->andWhere('e.cancelledAt IS NULL')
             ->andWhere('e.finishedAt IS NULL')
             ->setParameter('today', new \DateTimeImmutable('today'))
+            ->orderBy('e.date', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $events;
+    }
+
+    /**
+     * Upcoming events visible to the given user (public + their own engagements/organized).
+     * For anonymous users, pass null to get public events only.
+     *
+     * @see docs/features.md F3.11 — Event visibility
+     *
+     * @return list<Event>
+     */
+    public function findVisibleUpcoming(?User $user, int $limit = 20): array
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->join('e.organizer', 'o')
+            ->addSelect('o')
+            ->where('e.date >= :today')
+            ->andWhere('e.cancelledAt IS NULL')
+            ->andWhere('e.finishedAt IS NULL')
+            ->setParameter('today', new \DateTimeImmutable('today'))
+            ->orderBy('e.date', 'ASC')
+            ->setMaxResults($limit);
+
+        if (null !== $user) {
+            $qb->leftJoin('e.engagements', 'eg', 'WITH', 'eg.user = :user')
+                ->leftJoin('e.staff', 's', 'WITH', 's.user = :user')
+                ->andWhere('e.visibility = :public OR e.organizer = :user OR eg.id IS NOT NULL OR s.id IS NOT NULL')
+                ->setParameter('user', $user)
+                ->setParameter('public', EventVisibility::Public);
+        } else {
+            $qb->andWhere('e.visibility = :public')
+                ->setParameter('public', EventVisibility::Public);
+        }
+
+        /** @var list<Event> $events */
+        $events = $qb->getQuery()->getResult();
+
+        return $events;
+    }
+
+    /**
+     * Public upcoming events for the discovery page.
+     *
+     * @see docs/features.md F3.11 — Event visibility
+     * @see docs/features.md F3.15 — Event discovery
+     *
+     * @return list<Event>
+     */
+    public function findPublicUpcoming(int $limit = 50): array
+    {
+        /** @var list<Event> $events */
+        $events = $this->createQueryBuilder('e')
+            ->join('e.organizer', 'o')
+            ->addSelect('o')
+            ->where('e.date >= :today')
+            ->andWhere('e.cancelledAt IS NULL')
+            ->andWhere('e.finishedAt IS NULL')
+            ->andWhere('e.visibility = :visibility')
+            ->setParameter('today', new \DateTimeImmutable('today'))
+            ->setParameter('visibility', EventVisibility::Public)
             ->orderBy('e.date', 'ASC')
             ->setMaxResults($limit)
             ->getQuery()

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -36,6 +36,9 @@
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_event_discover') }}">{{ 'app.nav.discover'|trans }}</a>
+                            </li>
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle nav-link-user d-flex align-items-center" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                     <img src="{{ gravatar(app.user.email, 64) }}" alt="" width="32" height="32" class="rounded-circle me-1">
@@ -54,6 +57,9 @@
                             </li>
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_event_discover') }}">{{ 'app.nav.discover'|trans }}</a>
                             </li>
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('app_login', {'_target_path': app.request.requestUri}) }}">{{ 'app.nav.login'|trans }}</a>

--- a/templates/event/discover.html.twig
+++ b/templates/event/discover.html.twig
@@ -1,0 +1,64 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'app.event.discover_title'|trans }} — Expanded Decks{% endblock %}
+
+{% block body %}
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="mb-0">{{ 'app.event.discover_title'|trans }}</h1>
+    </div>
+
+    {% if events|length > 0 %}
+        <div class="row">
+            {% for event in events %}
+                <div class="col-md-6 col-lg-4 mb-3">
+                    <div class="card shadow-sm h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                <a href="{{ path('app_event_show', {id: event.id}) }}">{{ event.name }}</a>
+                            </h5>
+                            <p class="text-muted mb-1">
+                                {% include 'event/_datetime.html.twig' with {dt: event.date, tz: event.timezone} %}
+                            </p>
+                            {% if event.location %}
+                                <p class="text-muted mb-1">{{ event.location }}</p>
+                            {% endif %}
+                            <p class="mb-2">
+                                <small>
+                                    <strong>{{ 'app.event.format'|trans }}:</strong> {{ event.format }}
+                                    {% if event.tournamentStructure %}
+                                        &middot; {{ event.tournamentStructure.value|replace({'_': ' '})|title }}
+                                    {% endif %}
+                                </small>
+                            </p>
+                            <div class="d-flex justify-content-between align-items-center">
+                                <small class="text-muted">
+                                    {{ 'app.event.organized_by'|trans({'%name%': event.organizer.screenName}) }}
+                                </small>
+                                {% if app.user %}
+                                    <form method="post" action="{{ path('app_event_interested', {id: event.id}) }}" class="d-inline">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('interested-event-' ~ event.id) }}">
+                                        <button type="submit" class="btn btn-sm btn-outline-primary">{{ 'app.event.interested_button'|trans }}</button>
+                                    </form>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="card shadow-sm">
+            <div class="card-body text-center py-5">
+                <p class="text-muted mb-0">{{ 'app.event.discover_no_events'|trans }}</p>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/tests/Functional/EventControllerTest.php
+++ b/tests/Functional/EventControllerTest.php
@@ -2233,6 +2233,86 @@ class EventControllerTest extends AbstractFunctionalTest
         self::assertSelectorTextContains('.alert-success', 'registered as a player');
     }
 
+    // ---------------------------------------------------------------
+    // F3.15 — Event discovery
+    // ---------------------------------------------------------------
+
+    public function testDiscoverPageShowsPublicEvents(): void
+    {
+        $this->loginAs('lender@example.com');
+
+        $crawler = $this->client->request('GET', '/events/discover');
+        self::assertResponseIsSuccessful();
+
+        // The main fixture event is public — it should appear
+        self::assertSelectorExists('.card-title');
+    }
+
+    public function testDiscoverPageExcludesDraftEvents(): void
+    {
+        $this->loginAs('lender@example.com');
+
+        $crawler = $this->client->request('GET', '/events/discover');
+        self::assertResponseIsSuccessful();
+
+        // Draft events should NOT appear in discovery
+        $html = $crawler->html();
+        self::assertStringNotContainsString('Draft Event', $html);
+    }
+
+    public function testDiscoverPageAccessibleAnonymously(): void
+    {
+        $this->client->request('GET', '/events/discover');
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testEventListHidesDraftEventsFromNonEngagedUser(): void
+    {
+        // Lender has no engagement on draft event
+        $this->loginAs('lender@example.com');
+
+        $crawler = $this->client->request('GET', '/event');
+        self::assertResponseIsSuccessful();
+
+        // Draft event should NOT appear in the list
+        $html = $crawler->html();
+        self::assertStringNotContainsString('Draft Event', $html);
+    }
+
+    public function testEventListShowsDraftEventForInvitedUser(): void
+    {
+        // Admin is invited to the draft event
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/event');
+        self::assertResponseIsSuccessful();
+
+        // Should see the draft event because they have an engagement
+        $html = $crawler->html();
+        self::assertStringContainsString('Draft Event', $html);
+    }
+
+    public function testDraftEventAccessDeniedForNonEngagedUser(): void
+    {
+        $this->loginAs('lender@example.com');
+
+        $event = $this->getDraftEvent();
+
+        $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testDraftEventAccessibleForInvitedUser(): void
+    {
+        // Admin is invited to the draft event
+        $this->loginAs('admin@example.com');
+
+        $event = $this->getDraftEvent();
+
+        $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        self::assertResponseIsSuccessful();
+    }
+
     /**
      * @see docs/features.md F3.21 — Clear deck selection on withdrawal
      */
@@ -2297,6 +2377,16 @@ class EventControllerTest extends AbstractFunctionalTest
         /** @var EventRepository $repo */
         $repo = static::getContainer()->get(EventRepository::class);
         $event = $repo->findOneBy(['name' => 'Invitation-Only Expanded Meetup']);
+        self::assertNotNull($event);
+
+        return $event;
+    }
+
+    private function getDraftEvent(): Event
+    {
+        /** @var EventRepository $repo */
+        $repo = static::getContainer()->get(EventRepository::class);
+        $event = $repo->findOneBy(['name' => 'Draft Event — Not Yet Published']);
         self::assertNotNull($event);
 
         return $event;

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -18,6 +18,11 @@
                 <target>Events</target>
                 <note>Main navigation bar link</note>
             </trans-unit>
+            <trans-unit id="app.nav.discover">
+                <source>app.nav.discover</source>
+                <target>Discover</target>
+                <note>Main navigation bar link for event discovery</note>
+            </trans-unit>
             <trans-unit id="app.nav.login">
                 <source>app.nav.login</source>
                 <target>Login</target>
@@ -488,6 +493,16 @@
                 <target>Upcoming Events</target>
                 <note>Page heading for event list</note>
             </trans-unit>
+            <trans-unit id="app.event.discover_title">
+                <source>app.event.discover_title</source>
+                <target>Discover Events</target>
+                <note>Page heading for event discovery</note>
+            </trans-unit>
+            <trans-unit id="app.event.discover_no_events">
+                <source>app.event.discover_no_events</source>
+                <target>No public events to discover right now.</target>
+                <note>Empty state on discovery page</note>
+            </trans-unit>
             <trans-unit id="app.event.new_title">
                 <source>app.event.new_title</source>
                 <target>New Event</target>
@@ -642,6 +657,21 @@
                 <source>app.event.no_events</source>
                 <target>No upcoming events.</target>
                 <note>Empty state when no upcoming events</note>
+            </trans-unit>
+            <trans-unit id="app.event.visibility.public">
+                <source>app.event.visibility.public</source>
+                <target>Public</target>
+                <note>Visibility option: event visible to everyone</note>
+            </trans-unit>
+            <trans-unit id="app.event.visibility.draft">
+                <source>app.event.visibility.draft</source>
+                <target>Draft</target>
+                <note>Visibility option: event not yet ready, only visible to staff and invited users</note>
+            </trans-unit>
+            <trans-unit id="app.event.visibility.private">
+                <source>app.event.visibility.private</source>
+                <target>Private</target>
+                <note>Visibility option: event only visible to staff and invited users</note>
             </trans-unit>
             <trans-unit id="app.event.organized_by">
                 <source>app.event.organized_by</source>
@@ -1845,6 +1875,11 @@
                 <source>app.form.label.invitation_only</source>
                 <target>Invitation only</target>
                 <note>Form label for invitation-only checkbox</note>
+            </trans-unit>
+            <trans-unit id="app.form.label.visibility">
+                <source>app.form.label.visibility</source>
+                <target>Visibility</target>
+                <note>Form label for event visibility selector</note>
             </trans-unit>
             <trans-unit id="app.form.label.email">
                 <source>app.form.label.email</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -18,6 +18,11 @@
                 <target>Événements</target>
                 <note>Main navigation bar link</note>
             </trans-unit>
+            <trans-unit id="app.nav.discover">
+                <source>app.nav.discover</source>
+                <target>Découvrir</target>
+                <note>Main navigation bar link for event discovery</note>
+            </trans-unit>
             <trans-unit id="app.nav.login">
                 <source>app.nav.login</source>
                 <target>Connexion</target>
@@ -488,6 +493,16 @@
                 <target>Événements à venir</target>
                 <note>Page heading for event list</note>
             </trans-unit>
+            <trans-unit id="app.event.discover_title">
+                <source>app.event.discover_title</source>
+                <target>Découvrir des événements</target>
+                <note>Page heading for event discovery</note>
+            </trans-unit>
+            <trans-unit id="app.event.discover_no_events">
+                <source>app.event.discover_no_events</source>
+                <target>Aucun événement public à découvrir pour le moment.</target>
+                <note>Empty state on discovery page</note>
+            </trans-unit>
             <trans-unit id="app.event.new_title">
                 <source>app.event.new_title</source>
                 <target>Nouvel Événement</target>
@@ -642,6 +657,21 @@
                 <source>app.event.no_events</source>
                 <target>Aucun événement à venir.</target>
                 <note>Empty state when no upcoming events</note>
+            </trans-unit>
+            <trans-unit id="app.event.visibility.public">
+                <source>app.event.visibility.public</source>
+                <target>Public</target>
+                <note>Visibility option: event visible to everyone</note>
+            </trans-unit>
+            <trans-unit id="app.event.visibility.draft">
+                <source>app.event.visibility.draft</source>
+                <target>Brouillon</target>
+                <note>Visibility option: event not yet ready, only visible to staff and invited users</note>
+            </trans-unit>
+            <trans-unit id="app.event.visibility.private">
+                <source>app.event.visibility.private</source>
+                <target>Privé</target>
+                <note>Visibility option: event only visible to staff and invited users</note>
             </trans-unit>
             <trans-unit id="app.event.organized_by">
                 <source>app.event.organized_by</source>
@@ -1845,6 +1875,11 @@
                 <source>app.form.label.invitation_only</source>
                 <target>Sur invitation uniquement</target>
                 <note>Form label for invitation-only checkbox</note>
+            </trans-unit>
+            <trans-unit id="app.form.label.visibility">
+                <source>app.form.label.visibility</source>
+                <target>Visibilité</target>
+                <note>Form label for event visibility selector</note>
             </trans-unit>
             <trans-unit id="app.form.label.email">
                 <source>app.form.label.email</source>


### PR DESCRIPTION
## Summary
- Add `EventVisibility` enum (`Public`, `Draft`, `Private`) to control event listing
  - **Public**: visible to everyone in list and discovery
  - **Draft**: event not yet ready — only organizer, staff, and invited users can see it
  - **Private**: intentionally restricted — same access rules as Draft, different intent
- Visibility and invitation-only are **independent concepts**: visibility controls who can see the event, invitation-only controls who can register as a player
- New `/events/discover` page shows public upcoming events with "I'm interested" quick action
- Event list (`/event`) now respects visibility: non-public events only shown to engaged/organizer/staff users
- Draft/Private events return 403 on the show page for unauthorized users
- "Discover" nav link added for both authenticated and anonymous users

## Changes
- **Enum**: `EventVisibility` (Public, Draft, Private)
- **Entity**: `Event.visibility` field + migration
- **Repository**: `findPublicUpcoming()` and `findVisibleUpcoming()` query methods
- **Controller**: `discover()` action, visibility guard on `show()`
- **Form**: Visibility EnumType selector
- **Templates**: `discover.html.twig`, "Discover" nav link
- **Security**: `/events/discover` public access
- **Fixtures**: Draft event with invited user
- **Tests**: 7 new tests (discovery page, visibility filtering, draft access guard)
- **Translations**: EN + FR for all new keys
- **Roadmap**: F3.11 + F3.15 → Done (48/96)

## Test plan
- [ ] Visit `/events/discover` anonymously — shows public events only
- [ ] Create a Draft event — should not appear in discovery or event list
- [ ] Invited user can see draft event, non-invited user gets 403
- [ ] Invitation-only public event visible to all, player registration restricted
- [ ] `make test` — all 390 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)