### PR TITLE
:white_check_mark: test: improve coverage for notification preference guards

### DIFF
--- a/tests/Functional/ProfileNotificationsControllerTest.php
+++ b/tests/Functional/ProfileNotificationsControllerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\User;
+use App\Enum\NotificationType;
+use App\Repository\UserRepository;
+
+/**
+ * @see docs/features.md F8.3 — Notification preferences
+ */
+class ProfileNotificationsControllerTest extends AbstractFunctionalTest
+{
+    public function testNotificationsPageLoadsForAuthenticatedUser(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $this->client->request('GET', '/profile/notifications');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('input[name="preferences[borrow_requested][email]"]');
+        self::assertSelectorExists('input[name="preferences[event_updated][inApp]"]');
+    }
+
+    public function testNotificationsPageRedirectsForAnonymousUser(): void
+    {
+        $this->client->request('GET', '/profile/notifications');
+        self::assertResponseRedirects();
+    }
+
+    public function testSavePreferencesUpdatesUser(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $crawler = $this->client->request('GET', '/profile/notifications');
+        self::assertResponseIsSuccessful();
+
+        $token = $crawler->filter('input[name="_token"]')->attr('value');
+
+        // Submit with borrow_requested email unchecked (omitted) and inApp checked
+        $this->client->request('POST', '/profile/notifications', [
+            '_token' => $token,
+            'preferences' => [
+                'borrow_requested' => ['inApp' => '1'],
+                'borrow_approved' => ['email' => '1', 'inApp' => '1'],
+                'borrow_denied' => ['email' => '1', 'inApp' => '1'],
+                'borrow_handed_off' => ['email' => '1', 'inApp' => '1'],
+                'borrow_returned' => ['email' => '1', 'inApp' => '1'],
+                'borrow_overdue' => ['email' => '1', 'inApp' => '1'],
+                'borrow_cancelled' => ['email' => '1', 'inApp' => '1'],
+                'staff_assigned' => ['email' => '1', 'inApp' => '1'],
+                'event_updated' => ['email' => '1', 'inApp' => '1'],
+                'event_cancelled' => ['email' => '1', 'inApp' => '1'],
+                'event_invited' => ['email' => '1', 'inApp' => '1'],
+                'event_reminder' => ['email' => '1', 'inApp' => '1'],
+            ],
+        ]);
+
+        self::assertResponseRedirects('/profile/notifications');
+        $this->client->followRedirect();
+        self::assertSelectorTextContains('.alert-success', 'notification preferences have been saved');
+
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+        /** @var User $user */
+        $user = $repo->findOneBy(['email' => 'borrower@example.com']);
+
+        self::assertFalse($user->isNotificationEnabled(NotificationType::BorrowRequested, 'email'));
+        self::assertTrue($user->isNotificationEnabled(NotificationType::BorrowRequested, 'inApp'));
+        self::assertTrue($user->isNotificationEnabled(NotificationType::BorrowApproved, 'email'));
+    }
+
+    public function testSaveWithInvalidCsrfTokenRedirects(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $this->client->request('POST', '/profile/notifications', [
+            '_token' => 'invalid_token',
+            'preferences' => [],
+        ]);
+
+        self::assertResponseRedirects('/profile/notifications');
+        $this->client->followRedirect();
+        self::assertSelectorTextContains('.alert-danger', 'security token');
+    }
+
+    public function testAllCheckboxesCheckedByDefault(): void
+    {
+        $this->loginAs('organizer@example.com');
+
+        $crawler = $this->client->request('GET', '/profile/notifications');
+        self::assertResponseIsSuccessful();
+
+        $checkboxes = $crawler->filter('input[type="checkbox"]');
+        $total = $checkboxes->count();
+        $checked = $crawler->filter('input[type="checkbox"][checked]')->count();
+
+        // 12 types × 2 channels = 24 checkboxes, all checked
+        self::assertSame(24, $total);
+        self::assertSame(24, $checked);
+    }
+}

--- a/tests/Service/BorrowEmailPreferenceTest.php
+++ b/tests/Service/BorrowEmailPreferenceTest.php
@@ -115,6 +115,40 @@ class BorrowEmailPreferenceTest extends TestCase
         $this->service->sendBorrowOverdue($borrow);
     }
 
+    public function testSendBorrowOverdueSkipsForBorrowerWhenDisabled(): void
+    {
+        $borrow = $this->createBorrow();
+        $borrow->getBorrower()->setNotificationPreference(
+            NotificationType::BorrowOverdue,
+            'email',
+            false,
+        );
+
+        // Only owner should receive the email (1 send, not 2)
+        $this->mailer->expects(self::once())->method('send');
+
+        $this->service->sendBorrowOverdue($borrow);
+    }
+
+    public function testSendBorrowOverdueSkipsBothWhenDisabled(): void
+    {
+        $borrow = $this->createBorrow();
+        $borrow->getDeck()->getOwner()->setNotificationPreference(
+            NotificationType::BorrowOverdue,
+            'email',
+            false,
+        );
+        $borrow->getBorrower()->setNotificationPreference(
+            NotificationType::BorrowOverdue,
+            'email',
+            false,
+        );
+
+        $this->mailer->expects(self::never())->method('send');
+
+        $this->service->sendBorrowOverdue($borrow);
+    }
+
     public function testSendBorrowCancelledSkipsWhenEmailDisabled(): void
     {
         $borrow = $this->createBorrow();

--- a/tests/Service/BorrowServiceCancelEventTest.php
+++ b/tests/Service/BorrowServiceCancelEventTest.php
@@ -19,6 +19,7 @@ use App\Entity\DeckVersion;
 use App\Entity\Event;
 use App\Entity\User;
 use App\Enum\BorrowStatus;
+use App\Enum\NotificationType;
 use App\Repository\BorrowRepository;
 use App\Repository\EventDeckRegistrationRepository;
 use App\Service\BorrowNotificationEmailService;
@@ -103,6 +104,35 @@ class BorrowServiceCancelEventTest extends TestCase
         $count = $this->service->cancelBorrowsForEvent($event);
 
         self::assertSame(0, $count);
+    }
+
+    public function testCancelBorrowsForEventSkipsInAppNotificationWhenDisabled(): void
+    {
+        $event = $this->createEvent();
+        $pendingBorrow = $this->createBorrow(BorrowStatus::Pending, $event);
+
+        // Disable in-app notifications for the borrower
+        $pendingBorrow->getBorrower()->setNotificationPreference(
+            NotificationType::BorrowCancelled,
+            'inApp',
+            false,
+        );
+
+        $this->borrowRepository->method('findCancellableBorrowsByEvent')
+            ->with($event)
+            ->willReturn([$pendingBorrow]);
+
+        $this->workflow->expects(self::once())
+            ->method('apply')
+            ->with($pendingBorrow, 'cancel_pending');
+
+        // No notification should be persisted
+        $this->em->expects(self::never())->method('persist');
+        $this->em->expects(self::atLeastOnce())->method('flush');
+
+        $count = $this->service->cancelBorrowsForEvent($event);
+
+        self::assertSame(1, $count);
     }
 
     public function testCancelBorrowsForEventDoesNotTouchLentBorrows(): void

--- a/tests/Service/StaffCustodyPreferenceTest.php
+++ b/tests/Service/StaffCustodyPreferenceTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service;
+
+use App\Entity\Borrow;
+use App\Entity\Deck;
+use App\Entity\DeckVersion;
+use App\Entity\Event;
+use App\Entity\EventDeckRegistration;
+use App\Entity\User;
+use App\Enum\BorrowStatus;
+use App\Enum\NotificationType;
+use App\Repository\BorrowRepository;
+use App\Service\StaffCustodyService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+/**
+ * @see docs/features.md F8.3 — Notification preferences
+ */
+class StaffCustodyPreferenceTest extends TestCase
+{
+    private StaffCustodyService $service;
+    private EntityManagerInterface&MockObject $em;
+    private BorrowRepository&MockObject $borrowRepository;
+    private WorkflowInterface&MockObject $workflow;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->borrowRepository = $this->createMock(BorrowRepository::class);
+        $this->workflow = $this->createMock(WorkflowInterface::class);
+
+        $this->service = new StaffCustodyService(
+            $this->em,
+            $this->borrowRepository,
+            $this->workflow,
+        );
+    }
+
+    public function testOwnerReclaimSkipsInAppNotificationWhenDisabled(): void
+    {
+        $owner = $this->createUserWithId(1);
+        $borrower = $this->createUserWithId(2);
+
+        // Disable in-app for BorrowReturned on the borrower
+        $borrower->setNotificationPreference(NotificationType::BorrowReturned, 'inApp', false);
+
+        $deck = new Deck();
+        $deck->setName('Test Deck');
+        $deck->setOwner($owner);
+        $deckRef = new \ReflectionProperty(Deck::class, 'id');
+        $deckRef->setValue($deck, 100);
+
+        $event = new Event();
+        $event->setName('Test Event');
+        $event->setOrganizer($owner);
+        $eventRef = new \ReflectionProperty(Event::class, 'id');
+        $eventRef->setValue($event, 1);
+
+        $registration = new EventDeckRegistration();
+        $registration->setEvent($event);
+        $registration->setDeck($deck);
+        $registration->setDelegateToStaff(true);
+        $registration->setStaffReceivedAt(new \DateTimeImmutable());
+        $registration->setStaffReceivedBy($owner);
+
+        $version = new DeckVersion();
+        $version->setDeck($deck);
+
+        $borrow = new Borrow();
+        $borrow->setDeck($deck);
+        $borrow->setDeckVersion($version);
+        $borrow->setBorrower($borrower);
+        $borrow->setEvent($event);
+        $borrow->setStatus(BorrowStatus::Lent);
+        $borrowRef = new \ReflectionProperty(Borrow::class, 'id');
+        $borrowRef->setValue($borrow, 50);
+
+        $this->borrowRepository->method('findOpenBorrowsForDeckAtEvent')
+            ->willReturn([$borrow]);
+
+        $this->workflow->method('apply')->willReturn(new Marking());
+
+        // No notification should be persisted since in-app is disabled
+        $this->em->expects(self::never())->method('persist');
+        $this->em->expects(self::once())->method('flush');
+
+        $this->service->ownerReclaimDeck($registration, $owner);
+    }
+
+    private function createUserWithId(int $id): User
+    {
+        $user = new User();
+        $user->setEmail("user{$id}@example.com");
+        $user->setScreenName("User{$id}");
+        $user->setFirstName('Test');
+        $user->setLastName('User');
+
+        $ref = new \ReflectionProperty(User::class, 'id');
+        $ref->setValue($user, $id);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- Add functional test for `ProfileController::notifications()` (GET, POST, CSRF validation, default checkboxes)
- Add unit tests covering early-return branches in `BorrowService`, `BorrowNotificationEmailService`, `StaffCustodyService` when notification preferences disable a channel
- Addresses codecov/patch failure from PR #78 (75.73% → target 89.38%)

## Test plan
- [ ] All existing tests still pass
- [ ] New tests cover the 41 previously uncovered lines flagged by codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)