### PR TITLE
:sparkles: Feature: deck event status overview (F2.14)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -150,7 +150,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 |-------|----------------------------------|----------|-------------|------------------|
 | F3.11 | Event visibility                 | Medium   | Done        | F3.1             |
 | F3.13 | Player engagement states         | Medium   | Done        | F3.4             |
-| F2.14 | Deck event status overview       | Medium   | Not started | F2.3, F3.13      |
+| F2.14 | Deck event status overview       | Medium   | Done        | F2.3, F3.13      |
 | F3.7  | Register played deck for event   | Medium   | Done        | F3.4, F2.2       |
 | F3.17 | Tournament results               | Medium   | Not started | F3.7             |
 | F3.10 | Cancel an event                  | Medium   | Done        | F3.1, F4.1       |
@@ -159,7 +159,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F8.2  | Event notifications              | Medium   | Done        | F3.1, F3.13      |
 | F3.18 | Sync from Pokemon event page     | Medium   | Not started | F3.1, F3.9       |
 
-**Progress: 7/10 done · 0 partial · 3 not started**
+**Progress: 8/10 done · 0 partial · 2 not started**
 
 **Deliverable:** Public/private/invitation-only events, player engagement states (interested → registered), deck event status overview, tournament results with privacy, event cancellation with cascading borrows, event finishment with overdue triggers, event discovery page, event notifications, and Pokemon event page sync.
 
@@ -324,12 +324,12 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 4     | Borrow Workflow & Notifications   | 8    | 0       | 0           | 8     |
 | 5     | Core Views & Navigation           | 13   | 0       | 0           | 13    |
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
-| 7     | Engagement, Results & Discovery   | 7    | 1       | 2           | 10    |
+| 7     | Engagement, Results & Discovery   | 8    | 0       | 2           | 10    |
 | 8     | Admin, Homepage & Polish          | 0    | 3       | 4           | 7     |
 | 9     | Content, Archetypes & Low Priority | 1   | 2       | 22          | 25    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **50** | **6**  | **40**      | **96** |
+|       | **Total**                         | **51** | **5**  | **40**      | **96** |
 
 All 96 features from [features.md](features.md) are represented exactly once.

--- a/src/Controller/DeckShowController.php
+++ b/src/Controller/DeckShowController.php
@@ -16,8 +16,11 @@ namespace App\Controller;
 use App\Entity\Deck;
 use App\Entity\DeckCard;
 use App\Entity\User;
+use App\Enum\DeckEventStatus;
 use App\Enum\DeckStatus;
 use App\Repository\BorrowRepository;
+use App\Repository\EventDeckEntryRepository;
+use App\Repository\EventDeckRegistrationRepository;
 use App\Repository\EventRepository;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -26,6 +29,7 @@ use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @see docs/features.md F2.3 — Detail view
+ * @see docs/features.md F2.14 — Deck event status overview
  * @see docs/features.md F4.5 — Borrow history
  */
 class DeckShowController extends AbstractController
@@ -35,6 +39,8 @@ class DeckShowController extends AbstractController
         #[MapEntity(mapping: ['short_tag' => 'shortTag'])] Deck $deck,
         BorrowRepository $borrowRepository,
         EventRepository $eventRepository,
+        EventDeckEntryRepository $eventDeckEntryRepository,
+        EventDeckRegistrationRepository $eventDeckRegistrationRepository,
     ): Response {
         /** @var User|null $user */
         $user = $this->getUser();
@@ -98,6 +104,7 @@ class DeckShowController extends AbstractController
         // Anonymous users get empty borrow data
         $deckBorrows = [];
         $eligibleEvents = [];
+        $eventStatusOverview = [];
 
         if (null !== $user) {
             $deckBorrows = $borrowRepository->findByDeckForUser($deck, $user);
@@ -114,6 +121,28 @@ class DeckShowController extends AbstractController
                     }
                 }
             }
+
+            if ($isOwner) {
+                $upcomingEvents = $eventRepository->findUpcomingByEngagement($user);
+                foreach ($upcomingEvents as $event) {
+                    if (null !== $eventDeckEntryRepository->findOneByEventAndDeck($event, $deck)) {
+                        $status = DeckEventStatus::Played;
+                    } elseif (null !== $borrowRepository->findActiveBorrowForDeckAtEvent($deck, $event)) {
+                        $status = DeckEventStatus::ActivelyBorrowed;
+                    } elseif (null !== ($registration = $eventDeckRegistrationRepository->findOneByEventAndDeck($event, $deck))) {
+                        $status = $registration->isDelegateToStaff()
+                            ? DeckEventStatus::DelegatedToStaff
+                            : DeckEventStatus::Registered;
+                    } else {
+                        $status = DeckEventStatus::NotRegistered;
+                    }
+
+                    $eventStatusOverview[] = [
+                        'event' => $event,
+                        'status' => $status,
+                    ];
+                }
+            }
         }
 
         return $this->render('deck/show.html.twig', [
@@ -122,6 +151,7 @@ class DeckShowController extends AbstractController
             'isOwner' => $isOwner,
             'deckBorrows' => $deckBorrows,
             'eligibleEvents' => $eligibleEvents,
+            'eventStatusOverview' => $eventStatusOverview,
         ]);
     }
 }

--- a/src/Enum/DeckEventStatus.php
+++ b/src/Enum/DeckEventStatus.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Enum;
+
+/**
+ * @see docs/features.md F2.14 — Deck event status overview
+ */
+enum DeckEventStatus: string
+{
+    case Played = 'played';
+    case ActivelyBorrowed = 'actively_borrowed';
+    case DelegatedToStaff = 'delegated_to_staff';
+    case Registered = 'registered';
+    case NotRegistered = 'not_registered';
+}

--- a/src/Repository/EventDeckEntryRepository.php
+++ b/src/Repository/EventDeckEntryRepository.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Deck;
 use App\Entity\Event;
 use App\Entity\EventDeckEntry;
 use App\Entity\User;
@@ -43,6 +44,26 @@ class EventDeckEntryRepository extends ServiceEntityRepository
             ->andWhere('e.player = :player')
             ->setParameter('event', $event)
             ->setParameter('player', $player)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entry;
+    }
+
+    /**
+     * @see docs/features.md F2.14 — Deck event status overview
+     */
+    public function findOneByEventAndDeck(Event $event, Deck $deck): ?EventDeckEntry
+    {
+        /** @var EventDeckEntry|null $entry */
+        $entry = $this->createQueryBuilder('e')
+            ->join('e.deckVersion', 'dv')
+            ->join('dv.deck', 'd')
+            ->where('e.event = :event')
+            ->andWhere('d = :deck')
+            ->setParameter('event', $event)
+            ->setParameter('deck', $deck)
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();

--- a/templates/deck/show.html.twig
+++ b/templates/deck/show.html.twig
@@ -172,6 +172,49 @@
         </div>
     {% endif %}
 
+    {# Event status overview — owner only #}
+    {% if isOwner and eventStatusOverview is not empty %}
+        <div class="card shadow-sm mb-3">
+            <div class="card-header card-header-themed">
+                <h5 class="mb-0">{{ 'app.deck.event_status_overview'|trans }}</h5>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-striped table-themed table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>{{ 'app.deck.event_status.event'|trans }}</th>
+                                <th>{{ 'app.deck.event_status.date'|trans }}</th>
+                                <th>{{ 'app.deck.event_status.status'|trans }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for entry in eventStatusOverview %}
+                                <tr>
+                                    <td><a href="{{ path('app_event_show', {id: entry.event.id}) }}">{{ entry.event.name }}</a></td>
+                                    <td>{{ entry.event.date|user_date(entry.event.timezone) }}</td>
+                                    <td>
+                                        {% if entry.status.value == 'played' %}
+                                            <span class="badge bg-success">{{ 'app.deck.event_status.played'|trans }}</span>
+                                        {% elseif entry.status.value == 'actively_borrowed' %}
+                                            <span class="badge bg-primary">{{ 'app.deck.event_status.actively_borrowed'|trans }}</span>
+                                        {% elseif entry.status.value == 'delegated_to_staff' %}
+                                            <span class="badge bg-info">{{ 'app.deck.event_status.delegated_to_staff'|trans }}</span>
+                                        {% elseif entry.status.value == 'registered' %}
+                                            <span class="badge bg-warning">{{ 'app.deck.event_status.registered'|trans }}</span>
+                                        {% else %}
+                                            <span class="badge bg-secondary">{{ 'app.deck.event_status.not_registered'|trans }}</span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
     {# Card list — 2 columns on md+, energy under the shortest column #}
     {% if deck.currentVersion and groupedCards|length > 0 %}
         {% set pokemonCards = groupedCards.pokemon|default([]) %}

--- a/tests/Functional/DeckControllerTest.php
+++ b/tests/Functional/DeckControllerTest.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\EntityManagerInterface;
 /**
  * @see docs/features.md F2.3 — Detail view
  * @see docs/features.md F2.6 — Archetype management
+ * @see docs/features.md F2.14 — Deck event status overview
  * @see docs/features.md F4.5 — Borrow history
  */
 class DeckControllerTest extends AbstractFunctionalTest
@@ -193,6 +194,53 @@ class DeckControllerTest extends AbstractFunctionalTest
         self::assertSelectorNotExists('#borrow_event');
         $loginLink = $crawler->filter('a[href^="/login"]');
         self::assertGreaterThan(0, $loginLink->count(), 'Login CTA should be present for anonymous users.');
+    }
+
+    // ---------------------------------------------------------------
+    // Deck event status overview (F2.14)
+    // ---------------------------------------------------------------
+
+    /**
+     * @see docs/features.md F2.14 — Deck event status overview
+     */
+    public function testOwnerSeesEventStatusOverview(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $shortTag = $this->getDeckShortTag('Iron Thorns');
+        $crawler = $this->client->request('GET', '/deck/'.$shortTag);
+
+        self::assertResponseIsSuccessful();
+        $overviewHeaders = $crawler->filter('.card-header:contains("Event Status Overview")');
+        self::assertGreaterThan(0, $overviewHeaders->count(), 'Event status overview card should be present for owner.');
+    }
+
+    /**
+     * @see docs/features.md F2.14 — Deck event status overview
+     */
+    public function testNonOwnerDoesNotSeeEventStatusOverview(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $shortTag = $this->getDeckShortTag('Iron Thorns');
+        $crawler = $this->client->request('GET', '/deck/'.$shortTag);
+
+        self::assertResponseIsSuccessful();
+        $overviewHeaders = $crawler->filter('.card-header:contains("Event Status Overview")');
+        self::assertSame(0, $overviewHeaders->count(), 'Event status overview card should not be present for non-owner.');
+    }
+
+    /**
+     * @see docs/features.md F2.14 — Deck event status overview
+     */
+    public function testAnonymousDoesNotSeeEventStatusOverview(): void
+    {
+        $shortTag = $this->getDeckShortTag('Iron Thorns');
+        $crawler = $this->client->request('GET', '/deck/'.$shortTag);
+
+        self::assertResponseIsSuccessful();
+        $overviewHeaders = $crawler->filter('.card-header:contains("Event Status Overview")');
+        self::assertSame(0, $overviewHeaders->count(), 'Event status overview card should not be present for anonymous user.');
     }
 
     // ---------------------------------------------------------------

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -486,6 +486,51 @@
                 <target>Set</target>
                 <note>Column header in card list table</note>
             </trans-unit>
+            <trans-unit id="app.deck.event_status_overview">
+                <source>app.deck.event_status_overview</source>
+                <target>Event Status Overview</target>
+                <note>Section heading for deck event status overview card</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.event">
+                <source>app.deck.event_status.event</source>
+                <target>Event</target>
+                <note>Column header in event status overview table</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.date">
+                <source>app.deck.event_status.date</source>
+                <target>Date</target>
+                <note>Column header in event status overview table</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.status">
+                <source>app.deck.event_status.status</source>
+                <target>Status</target>
+                <note>Column header in event status overview table</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.played">
+                <source>app.deck.event_status.played</source>
+                <target>Played</target>
+                <note>Badge label for deck played at event</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.actively_borrowed">
+                <source>app.deck.event_status.actively_borrowed</source>
+                <target>Actively Borrowed</target>
+                <note>Badge label for deck with active borrow at event</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.delegated_to_staff">
+                <source>app.deck.event_status.delegated_to_staff</source>
+                <target>Delegated to Staff</target>
+                <note>Badge label for deck delegated to event staff</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.registered">
+                <source>app.deck.event_status.registered</source>
+                <target>Registered</target>
+                <note>Badge label for deck registered at event</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.not_registered">
+                <source>app.deck.event_status.not_registered</source>
+                <target>Not Registered</target>
+                <note>Badge label for deck not registered at event</note>
+            </trans-unit>
 
             <!-- Event list, detail, and forms -->
             <trans-unit id="app.event.list_title">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -486,6 +486,51 @@
                 <target>Set</target>
                 <note>Column header in card list table</note>
             </trans-unit>
+            <trans-unit id="app.deck.event_status_overview">
+                <source>app.deck.event_status_overview</source>
+                <target>Aperçu des événements</target>
+                <note>Section heading for deck event status overview card</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.event">
+                <source>app.deck.event_status.event</source>
+                <target>Événement</target>
+                <note>Column header in event status overview table</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.date">
+                <source>app.deck.event_status.date</source>
+                <target>Date</target>
+                <note>Column header in event status overview table</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.status">
+                <source>app.deck.event_status.status</source>
+                <target>Statut</target>
+                <note>Column header in event status overview table</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.played">
+                <source>app.deck.event_status.played</source>
+                <target>Joué</target>
+                <note>Badge label for deck played at event</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.actively_borrowed">
+                <source>app.deck.event_status.actively_borrowed</source>
+                <target>Emprunté (actif)</target>
+                <note>Badge label for deck with active borrow at event</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.delegated_to_staff">
+                <source>app.deck.event_status.delegated_to_staff</source>
+                <target>Délégué au staff</target>
+                <note>Badge label for deck delegated to event staff</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.registered">
+                <source>app.deck.event_status.registered</source>
+                <target>Inscrit</target>
+                <note>Badge label for deck registered at event</note>
+            </trans-unit>
+            <trans-unit id="app.deck.event_status.not_registered">
+                <source>app.deck.event_status.not_registered</source>
+                <target>Non inscrit</target>
+                <note>Badge label for deck not registered at event</note>
+            </trans-unit>
 
             <!-- Event list, detail, and forms -->
             <trans-unit id="app.event.list_title">


### PR DESCRIPTION
## Summary
- Add owner-only event status overview card on the deck detail page showing the deck's status across all upcoming events the owner is engaged in
- New `DeckEventStatus` enum with 5 priority-ordered cases: Played, Actively Borrowed, Delegated to Staff, Registered, Not Registered
- Color-coded badges and responsive table with linked event names and dates

## Test plan
- [x] Owner sees event status overview card on their deck's detail page
- [x] Non-owner does not see the event status overview card
- [x] Anonymous user does not see the event status overview card
- [x] PHPStan level 10 passes
- [x] PHP-CS-Fixer passes
- [x] All 428 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)