### PR TITLE
:sparkles: Feature: In-app notification center (F8.4)

### DIFF
--- a/assets/components/NotificationBell.tsx
+++ b/assets/components/NotificationBell.tsx
@@ -1,0 +1,263 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+    ActionIcon,
+    Badge,
+    Button,
+    Group,
+    Indicator,
+    Popover,
+    ScrollArea,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine/core';
+import { IconBell, IconCheck, IconChecks } from '@tabler/icons-react';
+
+/**
+ * @see docs/features.md F8.4 — In-app notification center
+ */
+
+interface NotificationItem {
+    id: number;
+    type: string;
+    title: string;
+    message: string;
+    isRead: boolean;
+    createdAt: string;
+    context: Record<string, unknown> | null;
+    url: string | null;
+}
+
+interface NotificationBellProps {
+    apiUrl: string;
+    listUrl: string;
+    markReadUrlTemplate: string;
+    markAllReadUrl: string;
+    pollIntervalMs?: number;
+    labels: {
+        markRead: string;
+        markAllRead: string;
+        viewAll: string;
+        empty: string;
+    };
+}
+
+function timeAgo(dateStr: string): string {
+    const now = Date.now();
+    const then = new Date(dateStr).getTime();
+    const diffMs = now - then;
+    const diffMin = Math.floor(diffMs / 60_000);
+
+    if (diffMin < 1) return '< 1m';
+    if (diffMin < 60) return `${diffMin}m`;
+    const diffHours = Math.floor(diffMin / 60);
+    if (diffHours < 24) return `${diffHours}h`;
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays}d`;
+}
+
+function typeIcon(type: string): string {
+    if (type.startsWith('borrow_')) return '↔';
+    if (type.startsWith('event_') || type.startsWith('staff_')) return '📅';
+    return '🔔';
+}
+
+export default function NotificationBell({
+    apiUrl,
+    listUrl,
+    markReadUrlTemplate,
+    markAllReadUrl,
+    pollIntervalMs = 60_000,
+    labels,
+}: NotificationBellProps) {
+    const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+    const [unreadCount, setUnreadCount] = useState(0);
+    const [opened, setOpened] = useState(false);
+
+    const fetchNotifications = useCallback(async () => {
+        try {
+            const res = await fetch(apiUrl);
+            if (!res.ok) return;
+            const data = await res.json();
+            setNotifications(data.notifications);
+            setUnreadCount(data.unreadCount);
+        } catch {
+            // Network error — silently ignore
+        }
+    }, [apiUrl]);
+
+    useEffect(() => {
+        fetchNotifications();
+        const interval = setInterval(fetchNotifications, pollIntervalMs);
+        return () => clearInterval(interval);
+    }, [fetchNotifications, pollIntervalMs]);
+
+    const markRead = async (id: number, e: React.MouseEvent) => {
+        e.stopPropagation();
+        const url = markReadUrlTemplate.replace('__ID__', String(id));
+        try {
+            const res = await fetch(url, { method: 'POST' });
+            if (!res.ok) return;
+            const data = await res.json();
+            setUnreadCount(data.unreadCount);
+            setNotifications((prev) =>
+                prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)),
+            );
+        } catch {
+            // Silently ignore
+        }
+    };
+
+    const markAllRead = async () => {
+        try {
+            const res = await fetch(markAllReadUrl, { method: 'POST' });
+            if (!res.ok) return;
+            setUnreadCount(0);
+            setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
+        } catch {
+            // Silently ignore
+        }
+    };
+
+    return (
+        <Popover
+            opened={opened}
+            onChange={setOpened}
+            width={360}
+            position="bottom-end"
+            shadow="lg"
+            withArrow
+        >
+            <Popover.Target>
+                <Indicator
+                    label={unreadCount > 0 ? (unreadCount > 99 ? '99+' : String(unreadCount)) : undefined}
+                    size={18}
+                    color="red"
+                    disabled={unreadCount === 0}
+                    offset={4}
+                >
+                    <ActionIcon
+                        variant="subtle"
+                        size="lg"
+                        onClick={() => setOpened((o) => !o)}
+                        aria-label="Notifications"
+                        style={{ color: 'rgba(255, 255, 255, 0.85)' }}
+                    >
+                        <IconBell size={22} />
+                    </ActionIcon>
+                </Indicator>
+            </Popover.Target>
+
+            <Popover.Dropdown p={0}>
+                <Group justify="space-between" px="md" py="sm" style={{ borderBottom: '1px solid #eee' }}>
+                    <Text fw={600} size="sm">
+                        Notifications
+                        {unreadCount > 0 && (
+                            <Badge size="sm" color="red" variant="filled" ml={6}>
+                                {unreadCount}
+                            </Badge>
+                        )}
+                    </Text>
+                    {unreadCount > 0 && (
+                        <UnstyledButton onClick={markAllRead}>
+                            <Group gap={4}>
+                                <IconChecks size={14} color="#868e96" />
+                                <Text size="xs" c="dimmed">{labels.markAllRead}</Text>
+                            </Group>
+                        </UnstyledButton>
+                    )}
+                </Group>
+
+                <ScrollArea.Autosize mah={400}>
+                    {notifications.length === 0 ? (
+                        <Text c="dimmed" ta="center" py="xl" size="sm">
+                            {labels.empty}
+                        </Text>
+                    ) : (
+                        <Stack gap={0}>
+                            {notifications.map((n) => (
+                                <Group
+                                    key={n.id}
+                                    wrap="nowrap"
+                                    gap="sm"
+                                    px="md"
+                                    py="xs"
+                                    align="flex-start"
+                                    onClick={async () => {
+                                        if (!n.isRead) {
+                                            const url = markReadUrlTemplate.replace('__ID__', String(n.id));
+                                            try {
+                                                await fetch(url, { method: 'POST' });
+                                            } catch {
+                                                // Best-effort — navigate anyway
+                                            }
+                                        }
+                                        if (n.url) {
+                                            window.location.href = n.url;
+                                        }
+                                    }}
+                                    style={{
+                                        backgroundColor: n.isRead ? 'transparent' : 'rgba(33, 53, 104, 0.04)',
+                                        borderBottom: '1px solid #f1f1f1',
+                                        cursor: n.url ? 'pointer' : 'default',
+                                    }}
+                                >
+                                    <Text size="lg" mt={2}>{typeIcon(n.type)}</Text>
+                                    <div style={{ flex: 1, minWidth: 0 }}>
+                                        <Group justify="space-between" wrap="nowrap">
+                                            <Text
+                                                size="sm"
+                                                fw={n.isRead ? 400 : 600}
+                                                lineClamp={1}
+                                                td={n.url ? 'none' : undefined}
+                                            >
+                                                {n.title}
+                                            </Text>
+                                            <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>
+                                                {timeAgo(n.createdAt)}
+                                            </Text>
+                                        </Group>
+                                        <Text size="xs" c="dimmed" lineClamp={2}>
+                                            {n.message}
+                                        </Text>
+                                        {!n.isRead && (
+                                            <UnstyledButton
+                                                onClick={(e: React.MouseEvent) => markRead(n.id, e)}
+                                                mt={2}
+                                            >
+                                                <Group gap={4}>
+                                                    <IconCheck size={12} color="#868e96" />
+                                                    <Text size="xs" c="dimmed">{labels.markRead}</Text>
+                                                </Group>
+                                            </UnstyledButton>
+                                        )}
+                                    </div>
+                                </Group>
+                            ))}
+                        </Stack>
+                    )}
+                </ScrollArea.Autosize>
+
+                <Group justify="center" py="sm" style={{ borderTop: '1px solid #eee' }}>
+                    <Button
+                        component="a"
+                        href={listUrl}
+                        variant="subtle"
+                        size="xs"
+                    >
+                        {labels.viewAll}
+                    </Button>
+                </Group>
+            </Popover.Dropdown>
+        </Popover>
+    );
+}

--- a/assets/notification-bell.tsx
+++ b/assets/notification-bell.tsx
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { MantineProvider } from '@mantine/core';
+import NotificationBell from './components/NotificationBell';
+
+import '@mantine/core/styles.css';
+
+/**
+ * @see docs/features.md F8.4 — In-app notification center
+ */
+
+const root = document.getElementById('notification-bell-root');
+if (root) {
+    const apiUrl = root.dataset.apiUrl ?? '';
+    const listUrl = root.dataset.listUrl ?? '';
+    const markReadUrlTemplate = root.dataset.markReadUrlTemplate ?? '';
+    const markAllReadUrl = root.dataset.markAllReadUrl ?? '';
+    const labelMarkRead = root.dataset.labelMarkRead ?? 'Mark as read';
+    const labelMarkAllRead = root.dataset.labelMarkAllRead ?? 'Mark all as read';
+    const labelViewAll = root.dataset.labelViewAll ?? 'View all notifications';
+    const labelEmpty = root.dataset.labelEmpty ?? 'No notifications yet';
+
+    createRoot(root).render(
+        <MantineProvider>
+            <NotificationBell
+                apiUrl={apiUrl}
+                listUrl={listUrl}
+                markReadUrlTemplate={markReadUrlTemplate}
+                markAllReadUrl={markAllReadUrl}
+                labels={{
+                    markRead: labelMarkRead,
+                    markAllRead: labelMarkAllRead,
+                    viewAll: labelViewAll,
+                    empty: labelEmpty,
+                }}
+            />
+        </MantineProvider>,
+    );
+}

--- a/docs/models/notification.md
+++ b/docs/models/notification.md
@@ -63,6 +63,18 @@ Users can configure per-type preferences for email and in-app channels via `/pro
 
 All notification services check `User::isNotificationEnabled()` before sending. Default (null): all channels enabled.
 
+### Notification Center (F8.4)
+
+The in-app notification center provides:
+
+- **Notification bell** in the navbar (Mantine React component) showing unread count badge, with a popover dropdown listing recent notifications
+- **Full notification list** page at `/notifications` with pagination and mark-as-read actions (individual + bulk)
+- **API endpoints** for the bell component:
+  - `GET /api/notifications` — recent notifications + unread count
+  - `POST /api/notifications/{id}/read` — mark single as read
+  - `POST /api/notifications/read-all` — mark all as read
+- Bell polls every 60 seconds for new notifications
+
 ### Indexing
 
 - Index on (`recipient`, `isRead`, `createdAt` DESC) for the in-app notification center query (unread first, then recent)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -174,12 +174,12 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F7.1  | Dashboard                        | Medium   | Partial     | F1.4                 |
 | F7.2  | User management                  | Medium   | Not started | F1.4                 |
 | F6.5  | Banned card list management      | Medium   | Not started | F6.3                 |
-| F8.4  | In-app notification center       | Medium   | Not started | F8.1                 |
+| F8.4  | In-app notification center       | Medium   | Done        | F8.1                 |
 | F10.1 | Mobile UX review                 | Medium   | Not started | F6.4, F2.3           |
 | F10.2 | Anonymous homepage               | Medium   | Partial     | F3.2, F2.4           |
 | F1.8  | Account deletion & data export   | Medium   | Partial     | F1.1                 |
 
-**Progress: 0/7 done · 3 partial · 4 not started**
+**Progress: 1/7 done · 3 partial · 3 not started**
 
 **Deliverable:** Admin dashboard and user management, banned card list, notification center, mobile responsiveness pass, public homepage, and GDPR account deletion/export.
 
@@ -325,11 +325,11 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 5     | Core Views & Navigation           | 13   | 0       | 0           | 13    |
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
 | 7     | Engagement, Results & Discovery   | 10   | 0       | 0           | 10    |
-| 8     | Admin, Homepage & Polish          | 0    | 3       | 4           | 7     |
+| 8     | Admin, Homepage & Polish          | 1    | 3       | 3           | 7     |
 | 9     | Content, Archetypes & Low Priority | 1   | 2       | 22          | 25    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **53** | **5**  | **38**      | **96** |
+|       | **Total**                         | **54** | **5**  | **37**      | **96** |
 
 All 96 features from [features.md](features.md) are represented exactly once.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
                 "@mantine/core": "^8.3.15",
                 "@mantine/hooks": "^8.3.15",
                 "@popperjs/core": "^2.11.8",
+                "@tabler/icons-react": "^3.40.0",
                 "bootstrap": "^5.3.8",
                 "bootstrap-icons": "^1.13.1"
             },
@@ -3760,6 +3761,32 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@tabler/icons": {
+            "version": "3.40.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.40.0.tgz",
+            "integrity": "sha512-V/Q4VgNPKubRTiLdmWjV/zscYcj5IIk+euicUtaVVqF6luSC9rDngYWgST5/yh3Mrg/mYUwRv1YVTk71Jp0twQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/codecalm"
+            }
+        },
+        "node_modules/@tabler/icons-react": {
+            "version": "3.40.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.40.0.tgz",
+            "integrity": "sha512-oO5+6QCnna4a//mYubx4euZfECtzQZFDGsDMIdzZUhbdyBCT+3bRVFBPueGIcemWld4Vb/0UQ39C/cmGfGylAg==",
+            "license": "MIT",
+            "dependencies": {
+                "@tabler/icons": "3.40.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/codecalm"
+            },
+            "peerDependencies": {
+                "react": ">= 16"
             }
         },
         "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "@mantine/core": "^8.3.15",
         "@mantine/hooks": "^8.3.15",
         "@popperjs/core": "^2.11.8",
+        "@tabler/icons-react": "^3.40.0",
         "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1"
     }

--- a/src/Controller/NotificationController.php
+++ b/src/Controller/NotificationController.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Entity\Notification;
+use App\Entity\User;
+use App\Enum\NotificationType;
+use App\Repository\NotificationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @see docs/features.md F8.4 — In-app notification center
+ */
+#[IsGranted('ROLE_USER')]
+class NotificationController extends AbstractAppController
+{
+    public function __construct(
+        TranslatorInterface $translator,
+        private readonly NotificationRepository $notificationRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct($translator);
+    }
+
+    #[Route('/api/notifications', name: 'app_notification_api_list', methods: ['GET'])]
+    public function apiList(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $notifications = $this->notificationRepository->findRecentByRecipient($user, 10);
+        $unreadCount = $this->notificationRepository->countUnreadByRecipient($user);
+
+        return $this->json([
+            'unreadCount' => $unreadCount,
+            'notifications' => array_map($this->serializeNotification(...), $notifications),
+        ]);
+    }
+
+    #[Route('/api/notifications/{id}/read', name: 'app_notification_api_mark_read', methods: ['POST'])]
+    public function apiMarkRead(Notification $notification): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($notification->getRecipient()->getId() !== $user->getId()) {
+            return $this->json(['error' => 'Forbidden'], Response::HTTP_FORBIDDEN);
+        }
+
+        $notification->setIsRead(true);
+        $this->entityManager->flush();
+
+        $unreadCount = $this->notificationRepository->countUnreadByRecipient($user);
+
+        return $this->json([
+            'unreadCount' => $unreadCount,
+            'notification' => $this->serializeNotification($notification),
+        ]);
+    }
+
+    #[Route('/api/notifications/read-all', name: 'app_notification_api_mark_all_read', methods: ['POST'])]
+    public function apiMarkAllRead(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $this->notificationRepository->markAllAsReadByRecipient($user);
+
+        return $this->json(['unreadCount' => 0]);
+    }
+
+    #[Route('/notifications', name: 'app_notification_list', methods: ['GET'])]
+    public function list(Request $request): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = 20;
+        $offset = ($page - 1) * $limit;
+
+        $notifications = $this->notificationRepository->findByRecipientPaginated($user, $limit, $offset);
+        $total = $this->notificationRepository->countByRecipient($user);
+
+        $urls = [];
+        foreach ($notifications as $notification) {
+            $id = $notification->getId();
+            if (null !== $id) {
+                $urls[$id] = $this->resolveNotificationUrl($notification);
+            }
+        }
+
+        return $this->render('notification/list.html.twig', [
+            'notifications' => $notifications,
+            'notificationUrls' => $urls,
+            'currentPage' => $page,
+            'totalPages' => (int) ceil($total / $limit),
+            'total' => $total,
+        ]);
+    }
+
+    #[Route('/notifications/{id}/go', name: 'app_notification_go', methods: ['GET'])]
+    public function go(Notification $notification): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($notification->getRecipient()->getId() !== $user->getId()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if (!$notification->isRead()) {
+            $notification->setIsRead(true);
+            $this->entityManager->flush();
+        }
+
+        $url = $this->resolveNotificationUrl($notification);
+
+        return $this->redirect($url ?? $this->generateUrl('app_notification_list'));
+    }
+
+    #[Route('/notifications/{id}/read', name: 'app_notification_mark_read', methods: ['POST'])]
+    public function markRead(Notification $notification, Request $request): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($notification->getRecipient()->getId() !== $user->getId()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if ($this->isCsrfTokenValid('notification_read_'.$notification->getId(), $request->request->getString('_token'))) {
+            $notification->setIsRead(true);
+            $this->entityManager->flush();
+        }
+
+        return $this->redirect($request->headers->get('referer', $this->generateUrl('app_notification_list')));
+    }
+
+    #[Route('/notifications/read-all', name: 'app_notification_mark_all_read', methods: ['POST'])]
+    public function markAllRead(Request $request): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($this->isCsrfTokenValid('notification_read_all', $request->request->getString('_token'))) {
+            $this->notificationRepository->markAllAsReadByRecipient($user);
+        }
+
+        return $this->redirect($request->headers->get('referer', $this->generateUrl('app_notification_list')));
+    }
+
+    #[Route('/notifications/{id}/delete', name: 'app_notification_delete', methods: ['POST'])]
+    public function delete(Notification $notification, Request $request): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($notification->getRecipient()->getId() !== $user->getId()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if ($this->isCsrfTokenValid('notification_delete_'.$notification->getId(), $request->request->getString('_token'))) {
+            $this->entityManager->remove($notification);
+            $this->entityManager->flush();
+        }
+
+        return $this->redirect($request->headers->get('referer', $this->generateUrl('app_notification_list')));
+    }
+
+    #[Route('/notifications/delete-read', name: 'app_notification_delete_read', methods: ['POST'])]
+    public function deleteRead(Request $request): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($this->isCsrfTokenValid('notification_delete_read', $request->request->getString('_token'))) {
+            $this->notificationRepository->deleteReadByRecipient($user);
+        }
+
+        return $this->redirect($request->headers->get('referer', $this->generateUrl('app_notification_list')));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeNotification(Notification $notification): array
+    {
+        return [
+            'id' => $notification->getId(),
+            'type' => $notification->getType()->value,
+            'title' => $notification->getTitle(),
+            'message' => $notification->getMessage(),
+            'isRead' => $notification->isRead(),
+            'createdAt' => $notification->getCreatedAt()->format('c'),
+            'context' => $notification->getContext(),
+            'url' => $this->resolveNotificationUrl($notification),
+        ];
+    }
+
+    /**
+     * Resolve the most actionable URL for a notification.
+     *
+     * Borrow-denied and borrow-cancelled link to the event borrowing section
+     * so the user can browse alternatives. Actionable borrow types link to
+     * the borrow actions panel. Informational borrow types link to the
+     * borrow timeline. Event types link to the relevant event section
+     * (staff, participation, or top of page).
+     */
+    private function resolveNotificationUrl(Notification $notification): ?string
+    {
+        $context = $notification->getContext();
+        if (null === $context) {
+            return null;
+        }
+
+        $type = $notification->getType();
+
+        // Denied/cancelled borrows → event borrowing section to find alternatives
+        if (\in_array($type, [NotificationType::BorrowDenied, NotificationType::BorrowCancelled], true)
+            && isset($context['eventId'])) {
+            return $this->generateUrl('app_event_show', ['id' => $context['eventId']]).'#borrowing';
+        }
+
+        // Actionable borrow types → borrow actions panel
+        if (isset($context['borrowId']) && \in_array($type, [
+            NotificationType::BorrowRequested,
+            NotificationType::BorrowApproved,
+            NotificationType::BorrowHandedOff,
+            NotificationType::BorrowOverdue,
+        ], true)) {
+            return $this->generateUrl('app_borrow_show', ['id' => $context['borrowId']]).'#actions';
+        }
+
+        // Informational borrow types → borrow timeline
+        if (isset($context['borrowId']) && $type->isBorrowType()) {
+            return $this->generateUrl('app_borrow_show', ['id' => $context['borrowId']]).'#timeline';
+        }
+
+        // Staff assigned → staff section
+        if (NotificationType::StaffAssigned === $type && isset($context['eventId'])) {
+            return $this->generateUrl('app_event_show', ['id' => $context['eventId']]).'#staff';
+        }
+
+        // Event invited → participation section
+        if (NotificationType::EventInvited === $type && isset($context['eventId'])) {
+            return $this->generateUrl('app_event_show', ['id' => $context['eventId']]).'#participation';
+        }
+
+        // Other event types → event page top
+        if (isset($context['eventId'])) {
+            return $this->generateUrl('app_event_show', ['id' => $context['eventId']]);
+        }
+
+        return null;
+    }
+}

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -23,11 +23,13 @@ use App\Entity\EventDeckEntry;
 use App\Entity\EventDeckRegistration;
 use App\Entity\EventEngagement;
 use App\Entity\EventStaff;
+use App\Entity\Notification;
 use App\Entity\User;
 use App\Enum\BorrowStatus;
 use App\Enum\DeckStatus;
 use App\Enum\EngagementState;
 use App\Enum\EventVisibility;
+use App\Enum\NotificationType;
 use App\Enum\ParticipationMode;
 use App\Enum\TournamentStructure;
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -85,9 +87,13 @@ class DevFixtures extends Fixture
 
         $manager->flush();
 
-        $this->createBorrowFixtures($manager, $todayEvent, $futureEvent, $borrower, $lender, $admin, $ironThorns, $ancientBox, $lenderDeck, $staff1);
+        $pendingBorrow = $this->createBorrowFixtures($manager, $todayEvent, $futureEvent, $borrower, $lender, $admin, $ironThorns, $ancientBox, $lenderDeck, $staff1);
         $this->createDeckRegistrations($manager, $todayEvent, $ironThorns, $ancientBox, $lenderDeck);
         $this->createFinishedEvent($manager, $admin, $borrower, $staff1, $ironThorns, $ancientBox, $lenderDeck);
+
+        $manager->flush();
+
+        $this->createAdminNotifications($manager, $admin, $borrower, $todayEvent, $pendingBorrow);
 
         $manager->flush();
     }
@@ -991,7 +997,10 @@ class DevFixtures extends Fixture
      * @see docs/features.md F4.9 — Staff deck custody tracking
      * @see docs/features.md F4.10 — Owner borrow inbox
      */
-    private function createBorrowFixtures(ObjectManager $manager, Event $todayEvent, Event $futureEvent, User $borrower, User $lender, User $admin, Deck $ironThorns, Deck $ancientBox, Deck $lenderDeck, User $staff1): void
+    /**
+     * @return Borrow the pending borrow on today's event (for notification fixtures)
+     */
+    private function createBorrowFixtures(ObjectManager $manager, Event $todayEvent, Event $futureEvent, User $borrower, User $lender, User $admin, Deck $ironThorns, Deck $ancientBox, Deck $lenderDeck, User $staff1): Borrow
     {
         $ironThornsVersion = $ironThorns->getCurrentVersion();
         \assert(null !== $ironThornsVersion);
@@ -1045,5 +1054,39 @@ class DevFixtures extends Fixture
         $manager->persist($delegatedBorrow);
 
         // Deck stays Available — approval no longer sets Reserved (per-event concern)
+
+        return $pendingBorrow;
+    }
+
+    private function createAdminNotifications(ObjectManager $manager, User $admin, User $borrower, Event $event, Borrow $pendingBorrow): void
+    {
+        $n1 = new Notification();
+        $n1->setRecipient($admin);
+        $n1->setType(NotificationType::BorrowRequested);
+        $n1->setTitle('New borrow request from '.$borrower->getScreenName());
+        $n1->setMessage($borrower->getScreenName().' wants to borrow Iron Thorns for '.$event->getName().'.');
+        $n1->setContext([
+            'borrowId' => $pendingBorrow->getId(),
+            'deckId' => $pendingBorrow->getDeck()->getId(),
+            'eventId' => $event->getId(),
+        ]);
+        $manager->persist($n1);
+
+        $n2 = new Notification();
+        $n2->setRecipient($admin);
+        $n2->setType(NotificationType::StaffAssigned);
+        $n2->setTitle('You were assigned as staff');
+        $n2->setMessage('You have been assigned as staff for '.$event->getName().'.');
+        $n2->setContext(['eventId' => $event->getId()]);
+        $manager->persist($n2);
+
+        $n3 = new Notification();
+        $n3->setRecipient($admin);
+        $n3->setType(NotificationType::EventInvited);
+        $n3->setTitle('You are invited to an event');
+        $n3->setMessage('You have been invited to '.$event->getName().'. Check it out!');
+        $n3->setContext(['eventId' => $event->getId()]);
+        $n3->setIsRead(true);
+        $manager->persist($n3);
     }
 }

--- a/src/Enum/NotificationType.php
+++ b/src/Enum/NotificationType.php
@@ -30,4 +30,18 @@ enum NotificationType: string
     case EventCancelled = 'event_cancelled';
     case EventInvited = 'event_invited';
     case EventReminder = 'event_reminder';
+
+    public function isBorrowType(): bool
+    {
+        return match ($this) {
+            self::BorrowRequested,
+            self::BorrowApproved,
+            self::BorrowDenied,
+            self::BorrowHandedOff,
+            self::BorrowReturned,
+            self::BorrowOverdue,
+            self::BorrowCancelled => true,
+            default => false,
+        };
+    }
 }

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Notification;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -25,5 +26,92 @@ class NotificationRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Notification::class);
+    }
+
+    public function countUnreadByRecipient(User $user): int
+    {
+        return (int) $this->createQueryBuilder('n')
+            ->select('COUNT(n.id)')
+            ->where('n.recipient = :user')
+            ->andWhere('n.isRead = false')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * @return Notification[]
+     */
+    public function findRecentByRecipient(User $user, int $limit = 10): array
+    {
+        /** @var Notification[] $result */
+        $result = $this->createQueryBuilder('n')
+            ->where('n.recipient = :user')
+            ->setParameter('user', $user)
+            ->orderBy('n.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    /**
+     * @return Notification[]
+     */
+    public function findByRecipientPaginated(User $user, int $limit, int $offset): array
+    {
+        /** @var Notification[] $result */
+        $result = $this->createQueryBuilder('n')
+            ->where('n.recipient = :user')
+            ->setParameter('user', $user)
+            ->orderBy('n.createdAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    public function countByRecipient(User $user): int
+    {
+        return (int) $this->createQueryBuilder('n')
+            ->select('COUNT(n.id)')
+            ->where('n.recipient = :user')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function markAllAsReadByRecipient(User $user): int
+    {
+        /** @var int $affected */
+        $affected = $this->createQueryBuilder('n')
+            ->update()
+            ->set('n.isRead', 'true')
+            ->set('n.readAt', ':now')
+            ->where('n.recipient = :user')
+            ->andWhere('n.isRead = false')
+            ->setParameter('user', $user)
+            ->setParameter('now', new \DateTimeImmutable())
+            ->getQuery()
+            ->execute();
+
+        return $affected;
+    }
+
+    public function deleteReadByRecipient(User $user): int
+    {
+        /** @var int $deleted */
+        $deleted = $this->createQueryBuilder('n')
+            ->delete()
+            ->where('n.recipient = :user')
+            ->andWhere('n.isRead = true')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->execute();
+
+        return $deleted;
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -39,6 +39,18 @@
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('app_event_discover') }}">{{ 'app.nav.discover'|trans }}</a>
                             </li>
+                            <li class="nav-item d-flex align-items-center me-2">
+                                <div id="notification-bell-root"
+                                     data-api-url="{{ path('app_notification_api_list') }}"
+                                     data-list-url="{{ path('app_notification_list') }}"
+                                     data-mark-read-url-template="{{ path('app_notification_api_mark_read', {id: 0})|replace({'0': '__ID__'}) }}"
+                                     data-mark-all-read-url="{{ path('app_notification_api_mark_all_read') }}"
+                                     data-label-mark-read="{{ 'app.notification.center.mark_read'|trans }}"
+                                     data-label-mark-all-read="{{ 'app.notification.center.mark_all_read'|trans }}"
+                                     data-label-view-all="{{ 'app.notification.center.view_all'|trans }}"
+                                     data-label-empty="{{ 'app.notification.center.empty'|trans }}">
+                                </div>
+                            </li>
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle nav-link-user d-flex align-items-center" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                     <img src="{{ gravatar(app.user.email, 64) }}" alt="" width="32" height="32" class="rounded-circle me-1">
@@ -95,6 +107,10 @@
 
         {% block javascripts %}
             {{ encore_entry_script_tags('app') }}
+            {% if app.user %}
+                {{ encore_entry_script_tags('notification_bell') }}
+                {{ encore_entry_link_tags('notification_bell') }}
+            {% endif %}
         {% endblock %}
     </body>
 </html>

--- a/templates/borrow/show.html.twig
+++ b/templates/borrow/show.html.twig
@@ -53,7 +53,7 @@
         </div>
     </div>
 
-    <div class="card shadow-sm mb-3">
+    <div id="timeline" class="card shadow-sm mb-3">
         <div class="card-header card-header-themed">
             <h6 class="mb-0">{{ 'app.borrow.timeline'|trans }}</h6>
         </div>
@@ -103,7 +103,7 @@
     </div>
 
     {% if canApprove or canDeny or canHandOff or canReturn or canCancel or canReturnToOwner %}
-        <div class="card shadow-sm mb-3">
+        <div id="actions" class="card shadow-sm mb-3">
             <div class="card-header card-header-themed">
                 <h6 class="mb-0">{{ 'app.borrow.actions'|trans }}</h6>
             </div>

--- a/templates/event/show.html.twig
+++ b/templates/event/show.html.twig
@@ -121,7 +121,7 @@
     </div>
 
     {% if isOrganizer and not event.cancelledAt %}
-        <div class="card shadow-sm mb-3">
+        <div id="staff" class="card shadow-sm mb-3">
             <div class="card-header card-header-themed">
                 <h6 class="mb-0">{{ 'app.event.staff.title'|trans }}</h6>
             </div>
@@ -161,7 +161,7 @@
         {% set canRegisterAsPlayer = not event.invitationOnly
             or isStaff
             or (userEngagement and userEngagement.invitedBy is not null) %}
-        <div class="card shadow-sm mb-3">
+        <div id="participation" class="card shadow-sm mb-3">
             <div class="card-header card-header-themed">
                 <h6 class="mb-0">{{ 'app.event.participation.title'|trans }}</h6>
             </div>
@@ -597,7 +597,7 @@
             </div>
         {% endif %}
 
-        <div class="card shadow-sm mb-3">
+        <div id="borrowing" class="card shadow-sm mb-3">
             <div class="card-header card-header-themed">
                 <h6 class="mb-0">{{ 'app.event.deck_borrowing'|trans }}</h6>
             </div>

--- a/templates/notification/list.html.twig
+++ b/templates/notification/list.html.twig
@@ -1,0 +1,116 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'app.notification.center.title'|trans }} — Expanded Decks{% endblock %}
+
+{% block body %}
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="mb-0">{{ 'app.notification.center.title'|trans }}</h1>
+        <div class="d-flex gap-2">
+            {% if notifications|length > 0 %}
+                <form method="post" action="{{ path('app_notification_mark_all_read') }}" class="d-inline">
+                    <input type="hidden" name="_token" value="{{ csrf_token('notification_read_all') }}">
+                    <button type="submit" class="btn btn-sm btn-outline-secondary">
+                        <i class="bi bi-check2-all me-1"></i>{{ 'app.notification.center.mark_all_read'|trans }}
+                    </button>
+                </form>
+                <form method="post" action="{{ path('app_notification_delete_read') }}" class="d-inline" onsubmit="return confirm('{{ 'app.notification.center.delete_read_confirm'|trans }}')">
+                    <input type="hidden" name="_token" value="{{ csrf_token('notification_delete_read') }}">
+                    <button type="submit" class="btn btn-sm btn-outline-danger">
+                        <i class="bi bi-trash me-1"></i>{{ 'app.notification.center.delete_read'|trans }}
+                    </button>
+                </form>
+            {% endif %}
+            <a href="{{ path('app_profile_notifications') }}" class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-gear me-1"></i>{{ 'app.notification.center.preferences'|trans }}
+            </a>
+        </div>
+    </div>
+
+    {% if total > 0 %}
+        <p class="text-muted mb-3">
+            {% set firstItem = ((currentPage - 1) * 20) + 1 %}
+            {% set lastItem = currentPage * 20 %}
+            {{ 'app.common.showing'|trans({'%first%': firstItem, '%last%': lastItem < total ? lastItem : total, '%total%': total}) }}
+        </p>
+
+        <div class="list-group shadow-sm">
+            {% for notification in notifications %}
+                <div class="list-group-item list-group-item-action d-flex align-items-start gap-3 {{ not notification.isRead ? 'list-group-item-light' : '' }}">
+                    <div class="flex-shrink-0 mt-1">
+                        {% if notification.type.value starts with 'borrow_' %}
+                            <i class="bi bi-arrow-left-right text-primary fs-5"></i>
+                        {% elseif notification.type.value starts with 'event_' or notification.type.value starts with 'staff_' %}
+                            <i class="bi bi-calendar-event text-info fs-5"></i>
+                        {% else %}
+                            <i class="bi bi-bell text-secondary fs-5"></i>
+                        {% endif %}
+                    </div>
+                    <div class="flex-grow-1">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <h6 class="mb-1 {{ not notification.isRead ? 'fw-bold' : '' }}">
+                                {% if notificationUrls[notification.id] is defined and notificationUrls[notification.id] %}
+                                    <a href="{{ path('app_notification_go', {id: notification.id}) }}" class="text-decoration-none">{{ notification.title }}</a>
+                                {% else %}
+                                    {{ notification.title }}
+                                {% endif %}
+                            </h6>
+                            <small class="text-muted text-nowrap ms-2">
+                                {{ notification.createdAt|user_datetime }}
+                            </small>
+                        </div>
+                        <p class="mb-1 text-muted small">{{ notification.message }}</p>
+                        <div class="d-flex gap-3">
+                            {% if not notification.isRead %}
+                                <form method="post" action="{{ path('app_notification_mark_read', {id: notification.id}) }}" class="d-inline">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('notification_read_' ~ notification.id) }}">
+                                    <button type="submit" class="btn btn-sm btn-link p-0 text-decoration-none">
+                                        <i class="bi bi-check2 me-1"></i>{{ 'app.notification.center.mark_read'|trans }}
+                                    </button>
+                                </form>
+                            {% endif %}
+                            <form method="post" action="{{ path('app_notification_delete', {id: notification.id}) }}" class="d-inline">
+                                <input type="hidden" name="_token" value="{{ csrf_token('notification_delete_' ~ notification.id) }}">
+                                <button type="submit" class="btn btn-sm btn-link p-0 text-decoration-none text-danger">
+                                    <i class="bi bi-trash me-1"></i>{{ 'app.notification.center.delete'|trans }}
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+
+        {% if totalPages > 1 %}
+            <nav class="mt-3">
+                <ul class="pagination justify-content-center">
+                    <li class="page-item {% if currentPage <= 1 %}disabled{% endif %}">
+                        <a class="page-link" href="{{ path('app_notification_list', {page: currentPage - 1}) }}">{{ 'app.common.previous'|trans }}</a>
+                    </li>
+                    {% for p in 1..totalPages %}
+                        <li class="page-item {% if p == currentPage %}active{% endif %}">
+                            <a class="page-link" href="{{ path('app_notification_list', {page: p}) }}">{{ p }}</a>
+                        </li>
+                    {% endfor %}
+                    <li class="page-item {% if currentPage >= totalPages %}disabled{% endif %}">
+                        <a class="page-link" href="{{ path('app_notification_list', {page: currentPage + 1}) }}">{{ 'app.common.next'|trans }}</a>
+                    </li>
+                </ul>
+            </nav>
+        {% endif %}
+    {% else %}
+        <div class="card shadow-sm">
+            <div class="card-body text-center py-5">
+                <i class="bi bi-bell-slash fs-1 text-muted mb-3 d-block"></i>
+                <p class="text-muted mb-0">{{ 'app.notification.center.empty'|trans }}</p>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/tests/Functional/NotificationControllerTest.php
+++ b/tests/Functional/NotificationControllerTest.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\Notification;
+use App\Entity\User;
+use App\Enum\NotificationType;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F8.4 — In-app notification center
+ */
+class NotificationControllerTest extends AbstractFunctionalTest
+{
+    private function createNotification(EntityManagerInterface $em, User $user, string $title, bool $isRead = false): Notification
+    {
+        $notification = new Notification();
+        $notification->setRecipient($user);
+        $notification->setType(NotificationType::BorrowRequested);
+        $notification->setTitle($title);
+        $notification->setMessage('Test notification message for '.$title);
+        if ($isRead) {
+            $notification->setIsRead(true);
+        }
+        $em->persist($notification);
+
+        return $notification;
+    }
+
+    private function getUser(string $email): User
+    {
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+
+        /* @var User */
+        return $repo->findOneBy(['email' => $email]);
+    }
+
+    public function testApiListRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/api/notifications');
+
+        self::assertResponseRedirects('/login');
+    }
+
+    public function testApiListReturnsNotifications(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $this->createNotification($em, $user, 'Unread notification');
+        $this->createNotification($em, $user, 'Read notification', true);
+        $em->flush();
+
+        $this->client->request('GET', '/api/notifications');
+
+        self::assertResponseIsSuccessful();
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        self::assertArrayHasKey('unreadCount', $data);
+        self::assertArrayHasKey('notifications', $data);
+        // 2 fixture unread + 1 test unread = 3
+        self::assertSame(3, $data['unreadCount']);
+        // 3 fixture + 2 test = 5
+        self::assertCount(5, $data['notifications']);
+
+        $titles = array_column($data['notifications'], 'title');
+        self::assertContains('Unread notification', $titles);
+        self::assertContains('Read notification', $titles);
+    }
+
+    public function testApiMarkReadMarksNotification(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $user, 'To be read');
+        $em->flush();
+
+        $this->client->request('POST', '/api/notifications/'.$notification->getId().'/read');
+
+        self::assertResponseIsSuccessful();
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        self::assertTrue($data['notification']['isRead']);
+        // 2 fixture unread remain
+        self::assertSame(2, $data['unreadCount']);
+    }
+
+    public function testApiMarkReadForbidsOtherUsersNotification(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $admin = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $admin, 'Admin notification');
+        $em->flush();
+
+        $this->client->request('POST', '/api/notifications/'.$notification->getId().'/read');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testApiMarkAllReadClearsAll(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $this->createNotification($em, $user, 'Notif 1');
+        $this->createNotification($em, $user, 'Notif 2');
+        $em->flush();
+
+        $this->client->request('POST', '/api/notifications/read-all');
+
+        self::assertResponseIsSuccessful();
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        self::assertSame(0, $data['unreadCount']);
+    }
+
+    public function testListPageRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/notifications');
+
+        self::assertResponseRedirects('/login');
+    }
+
+    public function testListPageRendersForAuthenticatedUser(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $this->createNotification($em, $user, 'Visible notification');
+        $em->flush();
+
+        $this->client->request('GET', '/notifications');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'Notifications');
+        self::assertSelectorTextContains('.list-group', 'Visible notification');
+    }
+
+    public function testListPageShowsEmptyState(): void
+    {
+        // Use borrower who has no fixture notifications
+        $this->loginAs('borrower@example.com');
+
+        $this->client->request('GET', '/notifications');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('.bi-bell-slash');
+    }
+
+    public function testGoMarksAsReadAndRedirectsToTarget(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $user, 'Clickable notification');
+        $notification->setType(NotificationType::EventUpdated);
+        $notification->setContext(['eventId' => 1]);
+        $em->flush();
+
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/notifications/'.$notification->getId().'/go');
+
+        // EventUpdated links to event page top (no anchor)
+        self::assertResponseRedirects('/event/1');
+
+        /** @var Notification $updated */
+        $updated = $em->find(Notification::class, $notification->getId());
+        self::assertTrue($updated->isRead());
+    }
+
+    public function testGoRedirectsToAnchoredSection(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $user, 'Staff assigned');
+        $notification->setType(NotificationType::StaffAssigned);
+        $notification->setContext(['eventId' => 1]);
+        $em->flush();
+
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/notifications/'.$notification->getId().'/go');
+
+        self::assertResponseRedirects('/event/1#staff');
+    }
+
+    public function testGoBorrowRequestRedirectsToActions(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $user, 'Borrow request');
+        $notification->setType(NotificationType::BorrowRequested);
+        $notification->setContext(['borrowId' => 1, 'eventId' => 1]);
+        $em->flush();
+
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/notifications/'.$notification->getId().'/go');
+
+        self::assertResponseRedirects('/borrow/1#actions');
+    }
+
+    public function testGoBorrowDeniedRedirectsToEventBorrowing(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $user, 'Borrow denied');
+        $notification->setType(NotificationType::BorrowDenied);
+        $notification->setContext(['borrowId' => 1, 'eventId' => 1]);
+        $em->flush();
+
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/notifications/'.$notification->getId().'/go');
+
+        self::assertResponseRedirects('/event/1#borrowing');
+    }
+
+    public function testGoWithoutContextRedirectsToList(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $user, 'No context notification');
+        $em->flush();
+
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/notifications/'.$notification->getId().'/go');
+
+        self::assertResponseRedirects('/notifications');
+    }
+
+    public function testGoForbidsOtherUsersNotification(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $admin = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $admin, 'Admin only');
+        $notification->setContext(['eventId' => 1]);
+        $em->flush();
+
+        $this->loginAs('borrower@example.com');
+
+        $this->client->request('GET', '/notifications/'.$notification->getId().'/go');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testMarkReadViaFormRedirects(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $user, 'To mark read');
+        $em->flush();
+
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/notifications');
+        $form = $crawler->filter('form[action*="/notifications/'.$notification->getId().'/read"]')->form();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+    }
+
+    public function testMarkAllReadViaFormRedirects(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $this->createNotification($em, $user, 'Notif for mark all');
+        $em->flush();
+
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/notifications');
+        $form = $crawler->filter('form[action*="/notifications/read-all"]')->form();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+    }
+
+    public function testDeleteNotificationRemovesIt(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $user, 'To delete');
+        $em->flush();
+        $id = $notification->getId();
+
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/notifications');
+        $form = $crawler->filter('form[action*="/notifications/'.$id.'/delete"]')->form();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+
+        self::assertNull($em->find(Notification::class, $id));
+    }
+
+    public function testDeleteNotificationForbidsOtherUser(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $admin = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $admin, 'Admin only delete');
+        $em->flush();
+
+        $this->loginAs('borrower@example.com');
+
+        $this->client->request('POST', '/notifications/'.$notification->getId().'/delete');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testDeleteReadRemovesOnlyReadNotifications(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $borrower = $this->getUser('borrower@example.com');
+
+        $read = $this->createNotification($em, $borrower, 'Read to delete', true);
+        $unread = $this->createNotification($em, $borrower, 'Unread to keep');
+        $em->flush();
+        $readId = $read->getId();
+        $unreadId = $unread->getId();
+
+        $this->loginAs('borrower@example.com');
+
+        $crawler = $this->client->request('GET', '/notifications');
+        $form = $crawler->filter('form[action*="/notifications/delete-read"]')->form();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+
+        self::assertNull($em->find(Notification::class, $readId));
+        self::assertNotNull($em->find(Notification::class, $unreadId));
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2568,6 +2568,53 @@
                 <target>Results can only be viewed for finished events.</target>
                 <note>Flash message when event is not finished</note>
             </trans-unit>
+
+            <!-- Notification Center (F8.4) -->
+            <trans-unit id="app.notification.center.title">
+                <source>app.notification.center.title</source>
+                <target>Notifications</target>
+                <note>Notification center page title</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.mark_read">
+                <source>app.notification.center.mark_read</source>
+                <target>Mark as read</target>
+                <note>Button to mark a single notification as read</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.mark_all_read">
+                <source>app.notification.center.mark_all_read</source>
+                <target>Mark all as read</target>
+                <note>Button to mark all notifications as read</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.view_all">
+                <source>app.notification.center.view_all</source>
+                <target>View all notifications</target>
+                <note>Link to full notification list page</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.empty">
+                <source>app.notification.center.empty</source>
+                <target>No notifications yet</target>
+                <note>Empty state message</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.preferences">
+                <source>app.notification.center.preferences</source>
+                <target>Preferences</target>
+                <note>Link to notification preferences</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.delete">
+                <source>app.notification.center.delete</source>
+                <target>Delete</target>
+                <note>Button to delete a single notification</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.delete_read">
+                <source>app.notification.center.delete_read</source>
+                <target>Delete read</target>
+                <note>Button to delete all read notifications</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.delete_read_confirm">
+                <source>app.notification.center.delete_read_confirm</source>
+                <target>Delete all read notifications? This cannot be undone.</target>
+                <note>Confirmation prompt for bulk delete</note>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -2568,6 +2568,53 @@
                 <target>Les résultats ne sont disponibles que pour les événements terminés.</target>
                 <note>Flash message when event is not finished</note>
             </trans-unit>
+
+            <!-- Notification Center (F8.4) -->
+            <trans-unit id="app.notification.center.title">
+                <source>app.notification.center.title</source>
+                <target>Notifications</target>
+                <note>Notification center page title</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.mark_read">
+                <source>app.notification.center.mark_read</source>
+                <target>Marquer comme lu</target>
+                <note>Button to mark a single notification as read</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.mark_all_read">
+                <source>app.notification.center.mark_all_read</source>
+                <target>Tout marquer comme lu</target>
+                <note>Button to mark all notifications as read</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.view_all">
+                <source>app.notification.center.view_all</source>
+                <target>Voir toutes les notifications</target>
+                <note>Link to full notification list page</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.empty">
+                <source>app.notification.center.empty</source>
+                <target>Aucune notification</target>
+                <note>Empty state message</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.preferences">
+                <source>app.notification.center.preferences</source>
+                <target>Préférences</target>
+                <note>Link to notification preferences</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.delete">
+                <source>app.notification.center.delete</source>
+                <target>Supprimer</target>
+                <note>Button to delete a single notification</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.delete_read">
+                <source>app.notification.center.delete_read</source>
+                <target>Supprimer les lues</target>
+                <note>Button to delete all read notifications</note>
+            </trans-unit>
+            <trans-unit id="app.notification.center.delete_read_confirm">
+                <source>app.notification.center.delete_read_confirm</source>
+                <target>Supprimer toutes les notifications lues ? Cette action est irréversible.</target>
+                <note>Confirmation prompt for bulk delete</note>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ Encore
     .addEntry('walk_up_autocomplete', './assets/walk-up-autocomplete.tsx')
     .addEntry('catalog_filters', './assets/catalog-filters.tsx')
     .addEntry('event_sync', './assets/event-sync.ts')
+    .addEntry('notification_bell', './assets/notification-bell.tsx')
 
     .splitEntryChunks()
     .enableSingleRuntimeChunk()


### PR DESCRIPTION
## Summary
- **Mantine bell popover** in navbar with real-time polling (60s), unread badge, mark-as-read on click, and "Mark all read" action
- **Full notification list page** (`/notifications`) with pagination, per-notification mark-as-read, delete, bulk "Delete read", and notification preferences link
- **Smart URL routing**: clicking a notification marks it as read and redirects to the relevant page section using anchors (`#actions`, `#timeline`, `#staff`, `#participation`, `#borrowing`)
- **API endpoints**: `GET /api/notifications`, `POST /api/notifications/{id}/read`, `POST /api/notifications/read-all`
- **Fixture notifications** for admin on first load (3 sample notifications)
- **19 functional tests** covering auth, API, form actions, ownership guards, anchored redirects, delete actions
- **en/fr translations** for all notification center keys

## Test plan
- [x] `make cs-fix` — no changes
- [x] `make phpstan` — no errors
- [x] `make test` — 479 tests pass (19 notification-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)