### PR TITLE
:sparkles: Feature: Dashboard admin overview stats (F7.1)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -171,7 +171,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 
 | ID    | Feature                          | Priority | State       | Depends on           |
 |-------|----------------------------------|----------|-------------|----------------------|
-| F7.1  | Dashboard                        | Medium   | Partial     | F1.4                 |
+| F7.1  | Dashboard                        | Medium   | Done        | F1.4                 |
 | F7.2  | User management                  | Medium   | Not started | F1.4                 |
 | F6.5  | Banned card list management      | Medium   | Not started | F6.3                 |
 | F8.4  | In-app notification center       | Medium   | Done        | F8.1                 |
@@ -179,7 +179,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F10.2 | Anonymous homepage               | Medium   | Partial     | F3.2, F2.4           |
 | F1.8  | Account deletion & data export   | Medium   | Partial     | F1.1                 |
 
-**Progress: 1/7 done · 3 partial · 3 not started**
+**Progress: 2/7 done · 2 partial · 3 not started**
 
 **Deliverable:** Admin dashboard and user management, banned card list, notification center, mobile responsiveness pass, public homepage, and GDPR account deletion/export.
 
@@ -325,11 +325,11 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 5     | Core Views & Navigation           | 13   | 0       | 0           | 13    |
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
 | 7     | Engagement, Results & Discovery   | 10   | 0       | 0           | 10    |
-| 8     | Admin, Homepage & Polish          | 1    | 3       | 3           | 7     |
+| 8     | Admin, Homepage & Polish          | 2    | 2       | 3           | 7     |
 | 9     | Content, Archetypes & Low Priority | 1   | 2       | 22          | 25    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **54** | **5**  | **37**      | **96** |
+|       | **Total**                         | **55** | **4**  | **37**      | **96** |
 
 All 96 features from [features.md](features.md) are represented exactly once.

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -41,7 +41,7 @@ class HomeController extends AbstractController
     }
 
     /**
-     * @see docs/features.md F1.2 — Log in / Log out
+     * @see docs/features.md F7.1 — Dashboard
      */
     #[Route('/dashboard', name: 'app_dashboard')]
     #[IsGranted('ROLE_USER')]
@@ -53,7 +53,7 @@ class HomeController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
 
-        return $this->render('home/dashboard.html.twig', [
+        $params = [
             'user' => $user,
             'ownedDecks' => $user->getOwnedDecks(),
             'myEvents' => $eventRepository->findUpcomingByEngagement($user),
@@ -61,6 +61,17 @@ class HomeController extends AbstractController
             'recentBorrows' => $borrowRepository->findRecentByBorrower($user),
             'recentLends' => $borrowRepository->findRecentByDeckOwner($user),
             'recentManagedBorrows' => $borrowRepository->findRecentByEventOrganizerOrStaff($user),
-        ]);
+        ];
+
+        if ($this->isGranted('ROLE_ORGANIZER')) {
+            $params['stats'] = [
+                'totalDecks' => $deckRepository->countAll(),
+                'activeBorrows' => $borrowRepository->countActive(),
+                'upcomingEvents' => $eventRepository->countUpcoming(),
+                'overdueReturns' => $borrowRepository->countOverdue(),
+            ];
+        }
+
+        return $this->render('home/dashboard.html.twig', $params);
     }
 }

--- a/src/Repository/BorrowRepository.php
+++ b/src/Repository/BorrowRepository.php
@@ -33,6 +33,38 @@ class BorrowRepository extends ServiceEntityRepository
     }
 
     /**
+     * @see docs/features.md F7.1 — Dashboard
+     */
+    public function countActive(): int
+    {
+        /** @var int $count */
+        $count = $this->createQueryBuilder('b')
+            ->select('COUNT(b.id)')
+            ->where('b.status IN (:statuses)')
+            ->setParameter('statuses', self::activeStatusValues())
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return $count;
+    }
+
+    /**
+     * @see docs/features.md F7.1 — Dashboard
+     */
+    public function countOverdue(): int
+    {
+        /** @var int $count */
+        $count = $this->createQueryBuilder('b')
+            ->select('COUNT(b.id)')
+            ->where('b.status = :status')
+            ->setParameter('status', BorrowStatus::Overdue->value)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return $count;
+    }
+
+    /**
      * @see docs/features.md F4.1 — Request to borrow a deck
      *
      * @return list<Borrow>

--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -32,6 +32,22 @@ class DeckRepository extends ServiceEntityRepository
     }
 
     /**
+     * @see docs/features.md F7.1 — Dashboard
+     */
+    public function countAll(): int
+    {
+        /** @var int $count */
+        $count = $this->createQueryBuilder('d')
+            ->select('COUNT(d.id)')
+            ->where('d.status != :retired')
+            ->setParameter('retired', DeckStatus::Retired)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return $count;
+    }
+
+    /**
      * @see docs/features.md F10.2 — Anonymous homepage
      */
     public function countPublicDecks(): int

--- a/templates/home/dashboard.html.twig
+++ b/templates/home/dashboard.html.twig
@@ -14,6 +14,43 @@
 {% block body %}
     <h1 class="mb-4">{{ 'app.dashboard.welcome'|trans({'%name%': user.screenName}) }}</h1>
 
+    {% if stats is defined %}
+        <div class="row mb-4">
+            <div class="col-6 col-md-3 mb-3 mb-md-0">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body py-3">
+                        <div class="fs-2 fw-bold text-primary">{{ stats.totalDecks }}</div>
+                        <small class="text-muted">{{ 'app.dashboard.stats.total_decks'|trans }}</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3 mb-3 mb-md-0">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body py-3">
+                        <div class="fs-2 fw-bold text-success">{{ stats.activeBorrows }}</div>
+                        <small class="text-muted">{{ 'app.dashboard.stats.active_borrows'|trans }}</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body py-3">
+                        <div class="fs-2 fw-bold text-info">{{ stats.upcomingEvents }}</div>
+                        <small class="text-muted">{{ 'app.dashboard.stats.upcoming_events'|trans }}</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body py-3">
+                        <div class="fs-2 fw-bold {{ stats.overdueReturns > 0 ? 'text-danger' : 'text-secondary' }}">{{ stats.overdueReturns }}</div>
+                        <small class="text-muted">{{ 'app.dashboard.stats.overdue_returns'|trans }}</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
     <div class="row">
         <div class="col-md-6 mb-4">
             <div class="card h-100">

--- a/tests/Functional/DashboardStatsTest.php
+++ b/tests/Functional/DashboardStatsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+/**
+ * @see docs/features.md F7.1 — Dashboard
+ */
+class DashboardStatsTest extends AbstractFunctionalTest
+{
+    public function testDashboardRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/dashboard');
+
+        self::assertResponseRedirects('/login');
+    }
+
+    public function testOrganizerSeesStatsOverview(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/dashboard');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('.card .fs-2.fw-bold.text-primary');
+        self::assertSelectorExists('.card .fs-2.fw-bold.text-success');
+        self::assertSelectorExists('.card .fs-2.fw-bold.text-info');
+    }
+
+    public function testRegularUserDoesNotSeeStats(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $this->client->request('GET', '/dashboard');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('.card .fs-2.fw-bold.text-primary');
+    }
+
+    public function testStatsShowNumericValues(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/dashboard');
+
+        $statCards = $crawler->filter('.card .fs-2.fw-bold');
+        self::assertGreaterThanOrEqual(4, $statCards->count());
+
+        // Each stat should contain a numeric value
+        for ($i = 0; $i < 4; ++$i) {
+            self::assertMatchesRegularExpression('/^\d+$/', trim($statCards->eq($i)->text()));
+        }
+    }
+
+    public function testStatsLabelsAreTranslated(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/dashboard');
+
+        $html = $crawler->html();
+        self::assertStringContainsString('Total decks', $html);
+        self::assertStringContainsString('Active borrows', $html);
+        self::assertStringContainsString('Upcoming events', $html);
+        self::assertStringContainsString('Overdue returns', $html);
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -279,6 +279,26 @@
                 <target>Staff</target>
                 <note>Small status badge shown next to items in dashboard lists</note>
             </trans-unit>
+            <trans-unit id="app.dashboard.stats.total_decks">
+                <source>app.dashboard.stats.total_decks</source>
+                <target>Total decks</target>
+                <note>Admin overview stat label</note>
+            </trans-unit>
+            <trans-unit id="app.dashboard.stats.active_borrows">
+                <source>app.dashboard.stats.active_borrows</source>
+                <target>Active borrows</target>
+                <note>Admin overview stat label</note>
+            </trans-unit>
+            <trans-unit id="app.dashboard.stats.upcoming_events">
+                <source>app.dashboard.stats.upcoming_events</source>
+                <target>Upcoming events</target>
+                <note>Admin overview stat label</note>
+            </trans-unit>
+            <trans-unit id="app.dashboard.stats.overdue_returns">
+                <source>app.dashboard.stats.overdue_returns</source>
+                <target>Overdue returns</target>
+                <note>Admin overview stat label</note>
+            </trans-unit>
 
             <!-- Deck catalog, detail, and forms -->
             <trans-unit id="app.deck.catalog_title">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -279,6 +279,26 @@
                 <target>Staff</target>
                 <note>Small status badge shown next to items in dashboard lists</note>
             </trans-unit>
+            <trans-unit id="app.dashboard.stats.total_decks">
+                <source>app.dashboard.stats.total_decks</source>
+                <target>Decks au total</target>
+                <note>Admin overview stat label</note>
+            </trans-unit>
+            <trans-unit id="app.dashboard.stats.active_borrows">
+                <source>app.dashboard.stats.active_borrows</source>
+                <target>Emprunts actifs</target>
+                <note>Admin overview stat label</note>
+            </trans-unit>
+            <trans-unit id="app.dashboard.stats.upcoming_events">
+                <source>app.dashboard.stats.upcoming_events</source>
+                <target>Événements à venir</target>
+                <note>Admin overview stat label</note>
+            </trans-unit>
+            <trans-unit id="app.dashboard.stats.overdue_returns">
+                <source>app.dashboard.stats.overdue_returns</source>
+                <target>Retours en retard</target>
+                <note>Admin overview stat label</note>
+            </trans-unit>
 
             <!-- Deck catalog, detail, and forms -->
             <trans-unit id="app.deck.catalog_title">


### PR DESCRIPTION
## Summary
- **Stats banner** at the top of the dashboard for organizers/admins showing 4 KPI cards: total decks, active borrows, upcoming events, overdue returns
- **Repository count methods**: `DeckRepository::countAll()`, `BorrowRepository::countActive()`, `BorrowRepository::countOverdue()`
- Overdue returns card highlights in red when count > 0
- Hidden for regular users (gated behind `ROLE_ORGANIZER`)
- **en/fr translations** for all stat labels

## Test plan
- [x] `make cs-fix` — no changes
- [x] `make phpstan` — no errors
- [x] `make test` — 484 tests pass (5 dashboard-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)