### PR TITLE
:memo: Docs: add F7.5 registered decks aggregate view to roadmap

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -123,6 +123,7 @@ The frontend is built with **React.js** (via Symfony UX / Webpack Encore) for al
 | F7.2   | User management                      | Medium   | Admin CRUD for user accounts and role assignment. |
 | F7.3   | Audit log                            | Low      | Log significant actions (deck registered, borrow approved, return confirmed) for traceability. |
 | F7.4   | Dashboard action reminders           | Medium   | Dashboard widget showing upcoming actions due soon (borrows to return, pending requests to review, upcoming events requiring deck selection). Helps users stay on top of time-sensitive tasks. |
+| F7.5   | Registered decks aggregate view      | Low      | A page listing all decks registered across the user's upcoming events (organizer or staff), so the "Registered decks" dashboard stat card has a link target. Could be a deck catalog filter (`scope=managed`) or a dedicated view. |
 
 ## F8 — Notifications
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -243,8 +243,9 @@ Each feature carries a **State** that must be kept up to date as work progresses
 |-------|-----------------------------------------|----------|-------------|------------------|
 | F5.12 | Deck show activity pagination           | Medium   | Not started | F2.3             |
 | F7.4  | Dashboard action reminders              | Medium   | Not started | F7.1             |
+| F7.5  | Registered decks aggregate view         | Low      | Not started | F7.1             |
 
-**Progress: 1/25 done · 2 partial · 22 not started**
+**Progress: 1/26 done · 2 partial · 23 not started**
 
 **Deliverable:** Auth hardening (flexible login, password strength scoring, MFA, Pokemon SSO). Managed archetype catalogue with detail pages, sprite pictograms, and backlinking across the UI. CMS content pages with Markdown, translations, and menu categories. Event series, iCal feeds, deck version history, card mosaic view, overdue tracking, friend delegation for borrow completion, notification preferences, and audit log.
 
@@ -326,10 +327,10 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
 | 7     | Engagement, Results & Discovery   | 10   | 0       | 0           | 10    |
 | 8     | Admin, Homepage & Polish          | 2    | 2       | 3           | 7     |
-| 9     | Content, Archetypes & Low Priority | 1   | 2       | 22          | 25    |
+| 9     | Content, Archetypes & Low Priority | 1   | 2       | 23          | 26    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **55** | **4**  | **37**      | **96** |
+|       | **Total**                         | **55** | **4**  | **38**      | **97** |
 
 All 96 features from [features.md](features.md) are represented exactly once.


### PR DESCRIPTION
## Summary
- Add **F7.5 — Registered decks aggregate view** to `features.md` and `roadmap.md` (Phase 9, Low priority)
- Provides a future link target for the dashboard "Registered decks" stat card which currently has no link

🤖 Generated with [Claude Code](https://claude.com/claude-code)