### PR TITLE
:sparkles: Feature: Admin user management (F7.2)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -52,6 +52,7 @@ security:
         - { path: ^/event$, roles: PUBLIC_ACCESS }
         - { path: ^/events/discover$, roles: PUBLIC_ACCESS }
         - { path: '^/event/\d+/results$', roles: PUBLIC_ACCESS }
+        - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/dashboard, roles: ROLE_USER }
         - { path: ^/deck, roles: ROLE_USER }
         - { path: ^/event, roles: ROLE_USER }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -172,14 +172,14 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | ID    | Feature                          | Priority | State       | Depends on           |
 |-------|----------------------------------|----------|-------------|----------------------|
 | F7.1  | Dashboard                        | Medium   | Done        | F1.4                 |
-| F7.2  | User management                  | Medium   | Not started | F1.4                 |
+| F7.2  | User management                  | Medium   | Done        | F1.4                 |
 | F6.5  | Banned card list management      | Medium   | Not started | F6.3                 |
 | F8.4  | In-app notification center       | Medium   | Done        | F8.1                 |
 | F10.1 | Mobile UX review                 | Medium   | Not started | F6.4, F2.3           |
 | F10.2 | Anonymous homepage               | Medium   | Partial     | F3.2, F2.4           |
 | F1.8  | Account deletion & data export   | Medium   | Partial     | F1.1                 |
 
-**Progress: 2/7 done · 2 partial · 3 not started**
+**Progress: 3/7 done · 2 partial · 2 not started**
 
 **Deliverable:** Admin dashboard and user management, banned card list, notification center, mobile responsiveness pass, public homepage, and GDPR account deletion/export.
 
@@ -326,7 +326,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 5     | Core Views & Navigation           | 13   | 0       | 0           | 13    |
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
 | 7     | Engagement, Results & Discovery   | 10   | 0       | 0           | 10    |
-| 8     | Admin, Homepage & Polish          | 2    | 2       | 3           | 7     |
+| 8     | Admin, Homepage & Polish          | 3    | 2       | 2           | 7     |
 | 9     | Content, Archetypes & Low Priority | 1   | 2       | 23          | 26    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |

--- a/src/Controller/AdminUserController.php
+++ b/src/Controller/AdminUserController.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @see docs/features.md F7.2 — User management
+ */
+#[Route('/admin/users')]
+#[IsGranted('ROLE_ADMIN')]
+class AdminUserController extends AbstractAppController
+{
+    private const int PER_PAGE = 20;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        private readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct($translator);
+    }
+
+    #[Route('', name: 'app_admin_user_list', methods: ['GET'])]
+    public function list(Request $request, UserRepository $userRepository): Response
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+        $search = $request->query->getString('q');
+
+        $qb = $userRepository->createAdminListQueryBuilder($search);
+        $qb->setFirstResult(($page - 1) * self::PER_PAGE)
+            ->setMaxResults(self::PER_PAGE);
+
+        $paginator = new Paginator($qb, fetchJoinCollection: false);
+        $totalItems = \count($paginator);
+        $totalPages = max(1, (int) ceil($totalItems / self::PER_PAGE));
+
+        return $this->render('admin/user/list.html.twig', [
+            'users' => $paginator,
+            'totalItems' => $totalItems,
+            'currentPage' => $page,
+            'totalPages' => $totalPages,
+            'search' => $search,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_admin_user_show', methods: ['GET'], requirements: ['id' => '\d+'])]
+    public function show(User $user): Response
+    {
+        return $this->render('admin/user/show.html.twig', [
+            'user' => $user,
+            'availableRoles' => $this->getAssignableRoles(),
+        ]);
+    }
+
+    #[Route('/{id}/roles', name: 'app_admin_user_roles', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function updateRoles(Request $request, User $user): Response
+    {
+        if (!$this->isCsrfTokenValid('user-roles-'.$user->getId(), $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_user_show', ['id' => $user->getId()]);
+        }
+
+        /** @var list<string> $roles */
+        $roles = $request->getPayload()->all('roles');
+        $assignable = $this->getAssignableRoles();
+        $roles = array_values(array_intersect($roles, $assignable));
+
+        $user->setRoles($roles);
+        $this->em->flush();
+
+        $this->addFlash('success', 'app.admin.user.roles_updated');
+
+        return $this->redirectToRoute('app_admin_user_show', ['id' => $user->getId()]);
+    }
+
+    #[Route('/{id}/disable', name: 'app_admin_user_disable', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function disable(Request $request, User $user): Response
+    {
+        if (!$this->isCsrfTokenValid('user-disable-'.$user->getId(), $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_user_show', ['id' => $user->getId()]);
+        }
+
+        if (null !== $user->getDeletedAt()) {
+            $user->setDeletedAt(null);
+            $this->em->flush();
+            $this->addFlash('success', 'app.admin.user.enabled');
+        } else {
+            $user->setDeletedAt(new \DateTimeImmutable());
+            $this->em->flush();
+            $this->addFlash('success', 'app.admin.user.disabled');
+        }
+
+        return $this->redirectToRoute('app_admin_user_show', ['id' => $user->getId()]);
+    }
+
+    #[Route('/{id}/anonymize', name: 'app_admin_user_anonymize', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function anonymize(Request $request, User $user): Response
+    {
+        if (!$this->isCsrfTokenValid('user-anonymize-'.$user->getId(), $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_user_show', ['id' => $user->getId()]);
+        }
+
+        if ($user->isAnonymized()) {
+            $this->addFlash('warning', 'app.admin.user.already_anonymized');
+
+            return $this->redirectToRoute('app_admin_user_show', ['id' => $user->getId()]);
+        }
+
+        $user->setIsAnonymized(true);
+        $user->setDeletedAt($user->getDeletedAt() ?? new \DateTimeImmutable());
+        $user->setEmail('anonymized-'.$user->getId().'@example.com');
+        $user->setScreenName('anonymous-'.$user->getId());
+        $user->setFirstName('Anonymous');
+        $user->setLastName('User');
+        $user->setPlayerId(null);
+        $user->setPassword('');
+        $user->setRoles([]);
+        $user->setVerificationToken(null);
+        $user->setResetToken(null);
+        $user->setNotificationPreferences(null);
+
+        $this->em->flush();
+
+        $this->addFlash('success', 'app.admin.user.anonymized');
+
+        return $this->redirectToRoute('app_admin_user_show', ['id' => $user->getId()]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getAssignableRoles(): array
+    {
+        return ['ROLE_ADMIN', 'ROLE_ORGANIZER', 'ROLE_CMS_EDITOR', 'ROLE_ARCHETYPE_EDITOR'];
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -16,6 +16,7 @@ namespace App\Repository;
 use App\Entity\Event;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -141,6 +142,24 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
             ->getResult();
 
         return $results;
+    }
+
+    /**
+     * Query builder for the admin user list (paginated, searchable).
+     *
+     * @see docs/features.md F7.2 — User management
+     */
+    public function createAdminListQueryBuilder(string $search = ''): QueryBuilder
+    {
+        $qb = $this->createQueryBuilder('u')
+            ->orderBy('u.createdAt', 'DESC');
+
+        if ('' !== $search) {
+            $qb->andWhere('u.screenName LIKE :search OR u.email LIKE :search OR u.playerId LIKE :search OR u.firstName LIKE :search OR u.lastName LIKE :search')
+                ->setParameter('search', '%'.$search.'%');
+        }
+
+        return $qb;
     }
 
     /**

--- a/templates/admin/user/list.html.twig
+++ b/templates/admin/user/list.html.twig
@@ -1,0 +1,118 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'app.admin.user.list_title'|trans }} — Expanded Decks{% endblock %}
+
+{% block body %}
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="mb-0">{{ 'app.admin.user.list_title'|trans }}</h1>
+    </div>
+
+    <form method="get" action="{{ path('app_admin_user_list') }}" class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="row g-2 align-items-end">
+                <div class="col-md-9">
+                    <label for="q" class="form-label">{{ 'app.admin.user.search'|trans }}</label>
+                    <input type="text" id="q" name="q" class="form-control" value="{{ search }}" placeholder="{{ 'app.admin.user.search_placeholder'|trans }}">
+                </div>
+                <div class="col-md-3 d-flex gap-2">
+                    <button type="submit" class="btn btn-gold flex-fill">{{ 'app.common.filter'|trans }}</button>
+                    {% if search is not empty %}
+                        <a href="{{ path('app_admin_user_list') }}" class="btn btn-outline-secondary">{{ 'app.common.clear'|trans }}</a>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </form>
+
+    <p class="text-muted mb-3">
+        {% set first = (currentPage - 1) * 20 + 1 %}
+        {% set lastCandidate = currentPage * 20 %}
+        {% set last = lastCandidate < totalItems ? lastCandidate : totalItems %}
+        {{ 'app.common.showing'|trans({'%first%': first, '%last%': last, '%total%': totalItems}) }}
+    </p>
+
+    {% if totalItems > 0 %}
+        <div class="card shadow-sm">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-striped table-themed mb-0">
+                        <thead>
+                            <tr>
+                                <th>{{ 'app.admin.user.table.screen_name'|trans }}</th>
+                                <th>{{ 'app.admin.user.table.email'|trans }}</th>
+                                <th>{{ 'app.admin.user.table.roles'|trans }}</th>
+                                <th>{{ 'app.admin.user.table.status'|trans }}</th>
+                                <th>{{ 'app.admin.user.table.created'|trans }}</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for user in users %}
+                                <tr>
+                                    <td>{{ user.screenName }}</td>
+                                    <td>{{ user.email }}</td>
+                                    <td>
+                                        {% for role in user.roles %}
+                                            {% if role != 'ROLE_USER' %}
+                                                <span class="badge bg-secondary">{{ role }}</span>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </td>
+                                    <td>
+                                        {% if user.anonymized %}
+                                            <span class="badge bg-dark">{{ 'app.admin.user.status.anonymized'|trans }}</span>
+                                        {% elseif user.deletedAt is not null %}
+                                            <span class="badge bg-danger">{{ 'app.admin.user.status.disabled'|trans }}</span>
+                                        {% elseif not user.verified %}
+                                            <span class="badge bg-warning text-dark">{{ 'app.admin.user.status.unverified'|trans }}</span>
+                                        {% else %}
+                                            <span class="badge bg-success">{{ 'app.admin.user.status.active'|trans }}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ user.createdAt|date('Y-m-d') }}</td>
+                                    <td>
+                                        <a href="{{ path('app_admin_user_show', {id: user.id}) }}" class="btn btn-sm btn-outline-secondary">
+                                            {{ 'app.common.view'|trans }}
+                                        </a>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        {% if totalPages > 1 %}
+            <nav class="mt-3">
+                <ul class="pagination justify-content-center">
+                    <li class="page-item {% if currentPage <= 1 %}disabled{% endif %}">
+                        <a class="page-link" href="{{ path('app_admin_user_list', {q: search, page: currentPage - 1}) }}">
+                            {{ 'app.common.previous'|trans }}
+                        </a>
+                    </li>
+                    {% for p in 1..totalPages %}
+                        <li class="page-item {% if p == currentPage %}active{% endif %}">
+                            <a class="page-link" href="{{ path('app_admin_user_list', {q: search, page: p}) }}">{{ p }}</a>
+                        </li>
+                    {% endfor %}
+                    <li class="page-item {% if currentPage >= totalPages %}disabled{% endif %}">
+                        <a class="page-link" href="{{ path('app_admin_user_list', {q: search, page: currentPage + 1}) }}">
+                            {{ 'app.common.next'|trans }}
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+        {% endif %}
+    {% else %}
+        <div class="alert alert-info">{{ 'app.admin.user.no_results'|trans }}</div>
+    {% endif %}
+{% endblock %}

--- a/templates/admin/user/show.html.twig
+++ b/templates/admin/user/show.html.twig
@@ -1,0 +1,142 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ user.screenName }} — {{ 'app.admin.user.list_title'|trans }} — Expanded Decks{% endblock %}
+
+{% block body %}
+    <div class="mb-4">
+        <a href="{{ path('app_admin_user_list') }}" class="text-decoration-none">&larr; {{ 'app.admin.user.back_to_list'|trans }}</a>
+    </div>
+
+    {# User info card #}
+    <div class="card shadow-sm mb-3">
+        <div class="card-header card-header-themed d-flex justify-content-between align-items-center">
+            <h5 class="mb-0">{{ user.screenName }}</h5>
+            <div class="d-flex align-items-center gap-2">
+                {% if user.anonymized %}
+                    <span class="badge bg-dark">{{ 'app.admin.user.status.anonymized'|trans }}</span>
+                {% elseif user.deletedAt is not null %}
+                    <span class="badge bg-danger">{{ 'app.admin.user.status.disabled'|trans }}</span>
+                {% elseif not user.verified %}
+                    <span class="badge bg-warning text-dark">{{ 'app.admin.user.status.unverified'|trans }}</span>
+                {% else %}
+                    <span class="badge bg-success">{{ 'app.admin.user.status.active'|trans }}</span>
+                {% endif %}
+            </div>
+        </div>
+        <div class="card-body">
+            <div class="row">
+                <div class="col-md-6">
+                    <dl>
+                        <dt>{{ 'app.admin.user.detail.email'|trans }}</dt>
+                        <dd>{{ user.email }}</dd>
+                        <dt>{{ 'app.admin.user.detail.name'|trans }}</dt>
+                        <dd>{{ user.firstName }} {{ user.lastName }}</dd>
+                        <dt>{{ 'app.admin.user.detail.player_id'|trans }}</dt>
+                        <dd>{{ user.playerId ?? '—' }}</dd>
+                    </dl>
+                </div>
+                <div class="col-md-6">
+                    <dl>
+                        <dt>{{ 'app.admin.user.detail.created'|trans }}</dt>
+                        <dd>{{ user.createdAt|date('Y-m-d H:i') }}</dd>
+                        <dt>{{ 'app.admin.user.detail.last_login'|trans }}</dt>
+                        <dd>{{ user.lastLoginAt ? user.lastLoginAt|date('Y-m-d H:i') : '—' }}</dd>
+                        <dt>{{ 'app.admin.user.detail.locale'|trans }}</dt>
+                        <dd>{{ user.preferredLocale }} / {{ user.timezone }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {# Roles card #}
+    {% if not user.anonymized %}
+        <div class="card shadow-sm mb-3">
+            <div class="card-header card-header-themed">
+                <h5 class="mb-0">{{ 'app.admin.user.roles_title'|trans }}</h5>
+            </div>
+            <div class="card-body">
+                <form method="post" action="{{ path('app_admin_user_roles', {id: user.id}) }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('user-roles-' ~ user.id) }}">
+                    {% for role in availableRoles %}
+                        <div class="form-check mb-2">
+                            <input class="form-check-input" type="checkbox" name="roles[]"
+                                   value="{{ role }}" id="role_{{ role }}"
+                                   {% if role in user.roles %}checked{% endif %}>
+                            <label class="form-check-label" for="role_{{ role }}">
+                                {{ role }}
+                            </label>
+                        </div>
+                    {% endfor %}
+                    <button type="submit" class="btn btn-gold mt-2">{{ 'app.admin.user.save_roles'|trans }}</button>
+                </form>
+            </div>
+        </div>
+    {% endif %}
+
+    {# Actions card #}
+    {% if not user.anonymized %}
+        <div class="card shadow-sm mb-3">
+            <div class="card-header card-header-themed">
+                <h5 class="mb-0">{{ 'app.admin.user.actions_title'|trans }}</h5>
+            </div>
+            <div class="card-body d-flex gap-2 flex-wrap">
+                <form method="post" action="{{ path('app_admin_user_disable', {id: user.id}) }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('user-disable-' ~ user.id) }}">
+                    {% if user.deletedAt is not null %}
+                        <button type="submit" class="btn btn-success">
+                            {{ 'app.admin.user.action.enable'|trans }}
+                        </button>
+                    {% else %}
+                        <button type="submit" class="btn btn-warning"
+                                onclick="return confirm('{{ 'app.admin.user.confirm_disable'|trans|e('js') }}')">
+                            {{ 'app.admin.user.action.disable'|trans }}
+                        </button>
+                    {% endif %}
+                </form>
+                <form method="post" action="{{ path('app_admin_user_anonymize', {id: user.id}) }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('user-anonymize-' ~ user.id) }}">
+                    <button type="submit" class="btn btn-danger"
+                            onclick="return confirm('{{ 'app.admin.user.confirm_anonymize'|trans|e('js') }}')">
+                        {{ 'app.admin.user.action.anonymize'|trans }}
+                    </button>
+                </form>
+            </div>
+        </div>
+    {% endif %}
+
+    {# Related data summary #}
+    <div class="card shadow-sm mb-3">
+        <div class="card-header card-header-themed">
+            <h5 class="mb-0">{{ 'app.admin.user.activity_title'|trans }}</h5>
+        </div>
+        <div class="card-body">
+            <div class="row text-center">
+                <div class="col-md-3">
+                    <div class="fs-4 fw-bold text-primary">{{ user.ownedDecks|length }}</div>
+                    <div class="text-muted">{{ 'app.admin.user.activity.decks'|trans }}</div>
+                </div>
+                <div class="col-md-3">
+                    <div class="fs-4 fw-bold text-success">{{ user.borrowRequests|length }}</div>
+                    <div class="text-muted">{{ 'app.admin.user.activity.borrows'|trans }}</div>
+                </div>
+                <div class="col-md-3">
+                    <div class="fs-4 fw-bold text-info">{{ user.eventEngagements|length }}</div>
+                    <div class="text-muted">{{ 'app.admin.user.activity.engagements'|trans }}</div>
+                </div>
+                <div class="col-md-3">
+                    <div class="fs-4 fw-bold text-warning">{{ user.staffAssignments|length }}</div>
+                    <div class="text-muted">{{ 'app.admin.user.activity.staff'|trans }}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -60,6 +60,10 @@
                                     <li><a class="dropdown-item" href="{{ path('app_dashboard') }}">{{ 'app.nav.dashboard'|trans }}</a></li>
                                     <li><a class="dropdown-item" href="{{ path('app_profile_edit') }}">{{ 'app.nav.profile'|trans }}</a></li>
                                     <li><a class="dropdown-item" href="{{ path('app_profile_notifications') }}">{{ 'app.nav.notifications'|trans }}</a></li>
+                                    {% if is_granted('ROLE_ADMIN') %}
+                                        <li><hr class="dropdown-divider"></li>
+                                        <li><a class="dropdown-item" href="{{ path('app_admin_user_list') }}">{{ 'app.nav.admin_users'|trans }}</a></li>
+                                    {% endif %}
                                     <li><hr class="dropdown-divider"></li>
                                     <li><a class="dropdown-item" href="{{ path('app_logout') }}">{{ 'app.nav.logout'|trans }}</a></li>
                                 </ul>

--- a/tests/Functional/AdminUserTest.php
+++ b/tests/Functional/AdminUserTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F7.2 — User management
+ */
+class AdminUserTest extends AbstractFunctionalTest
+{
+    public function testListRequiresAdmin(): void
+    {
+        $this->loginAs('organizer@example.com');
+
+        $this->client->request('GET', '/admin/users');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testListRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/admin/users');
+
+        self::assertResponseRedirects('/login');
+    }
+
+    public function testAdminCanAccessList(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/admin/users');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('table.table-themed');
+        self::assertStringContainsString('User management', $crawler->html());
+    }
+
+    public function testListShowsUsers(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/admin/users');
+
+        $rows = $crawler->filter('table.table-themed tbody tr');
+        self::assertGreaterThanOrEqual(1, $rows->count());
+    }
+
+    public function testListSearchFilters(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $crawler = $this->client->request('GET', '/admin/users?q=lender');
+
+        self::assertResponseIsSuccessful();
+        $html = $crawler->html();
+        self::assertStringContainsString('lender@example.com', $html);
+    }
+
+    public function testShowDisplaysUserDetails(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $userId = $this->getUserId('lender@example.com');
+        $crawler = $this->client->request('GET', '/admin/users/'.$userId);
+
+        self::assertResponseIsSuccessful();
+        $html = $crawler->html();
+        self::assertStringContainsString('lender@example.com', $html);
+        self::assertStringContainsString('Roles', $html);
+    }
+
+    public function testRoleAssignment(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $userId = $this->getUserId('lender@example.com');
+        $crawler = $this->client->request('GET', '/admin/users/'.$userId);
+
+        self::assertResponseIsSuccessful();
+
+        $token = $crawler->filter('form[action*="/roles"] input[name="_token"]')->attr('value');
+        \assert(\is_string($token));
+
+        $this->client->request('POST', '/admin/users/'.$userId.'/roles', [
+            '_token' => $token,
+            'roles' => ['ROLE_ORGANIZER'],
+        ]);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+        self::assertSelectorTextContains('.alert-success', 'Roles updated');
+    }
+
+    public function testDisableAndEnable(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $userId = $this->getUserId('lender@example.com');
+        $crawler = $this->client->request('GET', '/admin/users/'.$userId);
+
+        // Disable
+        $token = $crawler->filter('form[action*="/disable"] input[name="_token"]')->attr('value');
+        \assert(\is_string($token));
+
+        $this->client->request('POST', '/admin/users/'.$userId.'/disable', ['_token' => $token]);
+
+        self::assertResponseRedirects();
+        $crawler = $this->client->followRedirect();
+        self::assertSelectorTextContains('.alert-success', 'disabled');
+        self::assertSelectorTextContains('.badge.bg-danger', 'Disabled');
+
+        // Re-enable
+        $token = $crawler->filter('form[action*="/disable"] input[name="_token"]')->attr('value');
+        \assert(\is_string($token));
+
+        $this->client->request('POST', '/admin/users/'.$userId.'/disable', ['_token' => $token]);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+        self::assertSelectorTextContains('.alert-success', 'enabled');
+    }
+
+    public function testAnonymize(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $userId = $this->getUserId('unverified@example.com');
+        $crawler = $this->client->request('GET', '/admin/users/'.$userId);
+
+        $token = $crawler->filter('form[action*="/anonymize"] input[name="_token"]')->attr('value');
+        \assert(\is_string($token));
+
+        $this->client->request('POST', '/admin/users/'.$userId.'/anonymize', ['_token' => $token]);
+
+        self::assertResponseRedirects();
+        $crawler = $this->client->followRedirect();
+        self::assertSelectorTextContains('.alert-success', 'anonymized');
+        self::assertSelectorTextContains('.badge.bg-dark', 'Anonymized');
+    }
+
+    public function testInvalidCsrfTokenRejected(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $userId = $this->getUserId('lender@example.com');
+
+        $this->client->request('POST', '/admin/users/'.$userId.'/disable', ['_token' => 'invalid']);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-danger');
+    }
+
+    private function getUserId(string $email): int
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        /** @var User $user */
+        $user = $em->getRepository(User::class)->findOneBy(['email' => $email]);
+        $id = $user->getId();
+        \assert(null !== $id);
+
+        return $id;
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -80,6 +80,11 @@
                 <target>Search</target>
                 <note>Shared UI button or label, used across multiple pages</note>
             </trans-unit>
+            <trans-unit id="app.common.invalid_csrf">
+                <source>app.common.invalid_csrf</source>
+                <target>Invalid security token. Please try again.</target>
+                <note>Shown when a CSRF token is invalid</note>
+            </trans-unit>
             <trans-unit id="app.common.approve">
                 <source>app.common.approve</source>
                 <target>Approve</target>
@@ -2654,6 +2659,204 @@
                 <source>app.notification.center.delete_read_confirm</source>
                 <target>Delete all read notifications? This cannot be undone.</target>
                 <note>Confirmation prompt for bulk delete</note>
+            </trans-unit>
+            <!-- Admin: Navigation -->
+            <trans-unit id="app.nav.admin_users">
+                <source>app.nav.admin_users</source>
+                <target>Manage users</target>
+                <note>Admin dropdown link to user management</note>
+            </trans-unit>
+
+            <!-- Admin: User management -->
+            <trans-unit id="app.admin.user.list_title">
+                <source>app.admin.user.list_title</source>
+                <target>User management</target>
+                <note>Admin user list page title</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.search">
+                <source>app.admin.user.search</source>
+                <target>Search</target>
+                <note>Admin user search label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.search_placeholder">
+                <source>app.admin.user.search_placeholder</source>
+                <target>Name, email, or player ID…</target>
+                <note>Admin user search placeholder</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.no_results">
+                <source>app.admin.user.no_results</source>
+                <target>No users found.</target>
+                <note>Admin user list empty state</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.screen_name">
+                <source>app.admin.user.table.screen_name</source>
+                <target>Screen name</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.email">
+                <source>app.admin.user.table.email</source>
+                <target>Email</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.roles">
+                <source>app.admin.user.table.roles</source>
+                <target>Roles</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.status">
+                <source>app.admin.user.table.status</source>
+                <target>Status</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.created">
+                <source>app.admin.user.table.created</source>
+                <target>Created</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.status.active">
+                <source>app.admin.user.status.active</source>
+                <target>Active</target>
+                <note>User status badge</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.status.disabled">
+                <source>app.admin.user.status.disabled</source>
+                <target>Disabled</target>
+                <note>User status badge</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.status.unverified">
+                <source>app.admin.user.status.unverified</source>
+                <target>Unverified</target>
+                <note>User status badge</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.status.anonymized">
+                <source>app.admin.user.status.anonymized</source>
+                <target>Anonymized</target>
+                <note>User status badge</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.back_to_list">
+                <source>app.admin.user.back_to_list</source>
+                <target>Back to user list</target>
+                <note>Back link on user detail page</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.email">
+                <source>app.admin.user.detail.email</source>
+                <target>Email</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.name">
+                <source>app.admin.user.detail.name</source>
+                <target>Full name</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.player_id">
+                <source>app.admin.user.detail.player_id</source>
+                <target>Player ID</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.created">
+                <source>app.admin.user.detail.created</source>
+                <target>Created at</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.last_login">
+                <source>app.admin.user.detail.last_login</source>
+                <target>Last login</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.locale">
+                <source>app.admin.user.detail.locale</source>
+                <target>Locale / Timezone</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.roles_title">
+                <source>app.admin.user.roles_title</source>
+                <target>Roles</target>
+                <note>Roles section title on user detail page</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.save_roles">
+                <source>app.admin.user.save_roles</source>
+                <target>Save roles</target>
+                <note>Button to save role assignment</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.roles_updated">
+                <source>app.admin.user.roles_updated</source>
+                <target>Roles updated successfully.</target>
+                <note>Flash message after roles update</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.actions_title">
+                <source>app.admin.user.actions_title</source>
+                <target>Actions</target>
+                <note>Actions section title on user detail page</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.action.disable">
+                <source>app.admin.user.action.disable</source>
+                <target>Disable account</target>
+                <note>Button to disable a user account</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.action.enable">
+                <source>app.admin.user.action.enable</source>
+                <target>Enable account</target>
+                <note>Button to re-enable a disabled user account</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.action.anonymize">
+                <source>app.admin.user.action.anonymize</source>
+                <target>Anonymize account</target>
+                <note>Button to anonymize a user account (GDPR)</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.confirm_disable">
+                <source>app.admin.user.confirm_disable</source>
+                <target>Disable this user account? They will no longer be able to log in.</target>
+                <note>Confirmation prompt for disabling a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.confirm_anonymize">
+                <source>app.admin.user.confirm_anonymize</source>
+                <target>Anonymize this user? All personal data will be permanently erased. This cannot be undone.</target>
+                <note>Confirmation prompt for anonymizing a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.disabled">
+                <source>app.admin.user.disabled</source>
+                <target>Account disabled.</target>
+                <note>Flash message after disabling a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.enabled">
+                <source>app.admin.user.enabled</source>
+                <target>Account enabled.</target>
+                <note>Flash message after enabling a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.anonymized">
+                <source>app.admin.user.anonymized</source>
+                <target>Account anonymized.</target>
+                <note>Flash message after anonymizing a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.already_anonymized">
+                <source>app.admin.user.already_anonymized</source>
+                <target>This account is already anonymized.</target>
+                <note>Warning when trying to anonymize an already anonymized user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity_title">
+                <source>app.admin.user.activity_title</source>
+                <target>Activity</target>
+                <note>Activity section title on user detail page</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity.decks">
+                <source>app.admin.user.activity.decks</source>
+                <target>Owned decks</target>
+                <note>Activity stat label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity.borrows">
+                <source>app.admin.user.activity.borrows</source>
+                <target>Borrow requests</target>
+                <note>Activity stat label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity.engagements">
+                <source>app.admin.user.activity.engagements</source>
+                <target>Event engagements</target>
+                <note>Activity stat label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity.staff">
+                <source>app.admin.user.activity.staff</source>
+                <target>Staff assignments</target>
+                <note>Activity stat label</note>
             </trans-unit>
         </body>
     </file>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -80,6 +80,11 @@
                 <target>Rechercher</target>
                 <note>Shared UI button or label, used across multiple pages</note>
             </trans-unit>
+            <trans-unit id="app.common.invalid_csrf">
+                <source>app.common.invalid_csrf</source>
+                <target>Jeton de sécurité invalide. Veuillez réessayer.</target>
+                <note>Shown when a CSRF token is invalid</note>
+            </trans-unit>
             <trans-unit id="app.common.approve">
                 <source>app.common.approve</source>
                 <target>Approuver</target>
@@ -2654,6 +2659,204 @@
                 <source>app.notification.center.delete_read_confirm</source>
                 <target>Supprimer toutes les notifications lues ? Cette action est irréversible.</target>
                 <note>Confirmation prompt for bulk delete</note>
+            </trans-unit>
+            <!-- Admin: Navigation -->
+            <trans-unit id="app.nav.admin_users">
+                <source>app.nav.admin_users</source>
+                <target>Gérer les utilisateurs</target>
+                <note>Admin dropdown link to user management</note>
+            </trans-unit>
+
+            <!-- Admin: User management -->
+            <trans-unit id="app.admin.user.list_title">
+                <source>app.admin.user.list_title</source>
+                <target>Gestion des utilisateurs</target>
+                <note>Admin user list page title</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.search">
+                <source>app.admin.user.search</source>
+                <target>Rechercher</target>
+                <note>Admin user search label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.search_placeholder">
+                <source>app.admin.user.search_placeholder</source>
+                <target>Nom, e-mail ou ID joueur…</target>
+                <note>Admin user search placeholder</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.no_results">
+                <source>app.admin.user.no_results</source>
+                <target>Aucun utilisateur trouvé.</target>
+                <note>Admin user list empty state</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.screen_name">
+                <source>app.admin.user.table.screen_name</source>
+                <target>Pseudo</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.email">
+                <source>app.admin.user.table.email</source>
+                <target>E-mail</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.roles">
+                <source>app.admin.user.table.roles</source>
+                <target>Rôles</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.status">
+                <source>app.admin.user.table.status</source>
+                <target>Statut</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.table.created">
+                <source>app.admin.user.table.created</source>
+                <target>Créé le</target>
+                <note>Admin user table column header</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.status.active">
+                <source>app.admin.user.status.active</source>
+                <target>Actif</target>
+                <note>User status badge</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.status.disabled">
+                <source>app.admin.user.status.disabled</source>
+                <target>Désactivé</target>
+                <note>User status badge</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.status.unverified">
+                <source>app.admin.user.status.unverified</source>
+                <target>Non vérifié</target>
+                <note>User status badge</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.status.anonymized">
+                <source>app.admin.user.status.anonymized</source>
+                <target>Anonymisé</target>
+                <note>User status badge</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.back_to_list">
+                <source>app.admin.user.back_to_list</source>
+                <target>Retour à la liste</target>
+                <note>Back link on user detail page</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.email">
+                <source>app.admin.user.detail.email</source>
+                <target>E-mail</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.name">
+                <source>app.admin.user.detail.name</source>
+                <target>Nom complet</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.player_id">
+                <source>app.admin.user.detail.player_id</source>
+                <target>ID joueur</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.created">
+                <source>app.admin.user.detail.created</source>
+                <target>Créé le</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.last_login">
+                <source>app.admin.user.detail.last_login</source>
+                <target>Dernière connexion</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.detail.locale">
+                <source>app.admin.user.detail.locale</source>
+                <target>Langue / Fuseau horaire</target>
+                <note>User detail label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.roles_title">
+                <source>app.admin.user.roles_title</source>
+                <target>Rôles</target>
+                <note>Roles section title on user detail page</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.save_roles">
+                <source>app.admin.user.save_roles</source>
+                <target>Enregistrer les rôles</target>
+                <note>Button to save role assignment</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.roles_updated">
+                <source>app.admin.user.roles_updated</source>
+                <target>Rôles mis à jour avec succès.</target>
+                <note>Flash message after roles update</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.actions_title">
+                <source>app.admin.user.actions_title</source>
+                <target>Actions</target>
+                <note>Actions section title on user detail page</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.action.disable">
+                <source>app.admin.user.action.disable</source>
+                <target>Désactiver le compte</target>
+                <note>Button to disable a user account</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.action.enable">
+                <source>app.admin.user.action.enable</source>
+                <target>Activer le compte</target>
+                <note>Button to re-enable a disabled user account</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.action.anonymize">
+                <source>app.admin.user.action.anonymize</source>
+                <target>Anonymiser le compte</target>
+                <note>Button to anonymize a user account (GDPR)</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.confirm_disable">
+                <source>app.admin.user.confirm_disable</source>
+                <target>Désactiver ce compte ? L'utilisateur ne pourra plus se connecter.</target>
+                <note>Confirmation prompt for disabling a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.confirm_anonymize">
+                <source>app.admin.user.confirm_anonymize</source>
+                <target>Anonymiser cet utilisateur ? Toutes les données personnelles seront définitivement supprimées. Cette action est irréversible.</target>
+                <note>Confirmation prompt for anonymizing a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.disabled">
+                <source>app.admin.user.disabled</source>
+                <target>Compte désactivé.</target>
+                <note>Flash message after disabling a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.enabled">
+                <source>app.admin.user.enabled</source>
+                <target>Compte activé.</target>
+                <note>Flash message after enabling a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.anonymized">
+                <source>app.admin.user.anonymized</source>
+                <target>Compte anonymisé.</target>
+                <note>Flash message after anonymizing a user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.already_anonymized">
+                <source>app.admin.user.already_anonymized</source>
+                <target>Ce compte est déjà anonymisé.</target>
+                <note>Warning when trying to anonymize an already anonymized user</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity_title">
+                <source>app.admin.user.activity_title</source>
+                <target>Activité</target>
+                <note>Activity section title on user detail page</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity.decks">
+                <source>app.admin.user.activity.decks</source>
+                <target>Decks possédés</target>
+                <note>Activity stat label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity.borrows">
+                <source>app.admin.user.activity.borrows</source>
+                <target>Demandes d'emprunt</target>
+                <note>Activity stat label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity.engagements">
+                <source>app.admin.user.activity.engagements</source>
+                <target>Participations</target>
+                <note>Activity stat label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.user.activity.staff">
+                <source>app.admin.user.activity.staff</source>
+                <target>Affectations staff</target>
+                <note>Activity stat label</note>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
## Summary
- **List** (`/admin/users`) — Paginated, searchable user table (name, email, player ID)
- **Show** (`/admin/users/{id}`) — Detail view with user info, activity stats
- **Role assignment** — Checkbox form for assignable roles (Admin, Organizer, CMS Editor, Archetype Editor)
- **Disable/Enable** — Toggle soft-delete via `deletedAt` (prevents login)
- **Anonymize** — Irreversible GDPR wipe: clears PII, sets anonymized flag
- Access restricted to `ROLE_ADMIN` via both `#[IsGranted]` and `access_control`
- EN/FR translations (40+ keys)

## Test plan
- [x] Non-admin users get 403 on `/admin/users`
- [x] Unauthenticated users redirected to login
- [x] Admin sees paginated user list with search
- [x] Admin can view user detail page
- [x] Role assignment updates roles and shows flash
- [x] Disable/enable toggles `deletedAt` and badge
- [x] Anonymize clears PII irreversibly
- [x] Invalid CSRF tokens are rejected
- [x] PHPStan Level 10 passes
- [x] All 497 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)