### PR TITLE
:bug: Fix: Localize parser and validator error messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ PHP-CS-Fixer enforces this header automatically via the `header_comment` rule.
 - Constructor injection, autowiring, thin controllers
 - Doctrine entities use PHP 8 attributes (not annotations)
 - Symfony best practices: service autowiring, param binding, env vars for config
+- **No hardcoded user-facing strings**: all text displayed to end users (flash messages, validation errors, form labels, email subjects/bodies, UI labels) **MUST** use translation keys and be defined in the XLIFF translation files (`translations/messages.en.xlf` and `translations/messages.fr.xlf`). Services that produce user-facing messages must inject `TranslatorInterface` and call `$this->translator->trans()`. CLI command output (developer-facing) is exempt.
 - **Feature traceability**: methods implementing a documented feature rule **MUST** reference the feature ID in their PHPDoc (`@see`) or JSDoc. This links code back to the feature specification.
 
 PHP example:

--- a/src/Service/DeckListParser.php
+++ b/src/Service/DeckListParser.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use Symfony\Contracts\Translation\TranslatorInterface;
+
 /**
  * Parses a PTCG-format deck list (copy-pasted from PTCGO/PTCGL).
  *
@@ -40,6 +42,11 @@ class DeckListParser
         'trainer' => 'trainer',
         'energy' => 'energy',
     ];
+
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
 
     public function parse(string $rawText): DeckListParseResult
     {
@@ -73,7 +80,10 @@ class DeckListParser
 
             if (preg_match(self::CARD_LINE_PATTERN, $line, $matches)) {
                 if (null === $currentSection) {
-                    $errors[] = \sprintf('Line %d: card line found before any section header: "%s"', $lineNumber + 1, $line);
+                    $errors[] = $this->translator->trans('app.deck.parse.no_section_header', [
+                        '%line%' => $lineNumber + 1,
+                        '%content%' => $line,
+                    ]);
 
                     continue;
                 }
@@ -89,7 +99,10 @@ class DeckListParser
                 continue;
             }
 
-            $errors[] = \sprintf('Line %d: unrecognized format: "%s"', $lineNumber + 1, $line);
+            $errors[] = $this->translator->trans('app.deck.parse.unrecognized_format', [
+                '%line%' => $lineNumber + 1,
+                '%content%' => $line,
+            ]);
         }
 
         return new DeckListParseResult($cards, $errors, $sectionTotals);

--- a/src/Service/DeckListValidator.php
+++ b/src/Service/DeckListValidator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Repository\BannedCardRepository;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Validates a parsed deck list against Expanded format rules.
@@ -41,6 +42,7 @@ class DeckListValidator
 
     public function __construct(
         private readonly BannedCardRepository $bannedCardRepo,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -51,11 +53,10 @@ class DeckListValidator
 
         $totalCards = $parseResult->totalCards();
         if (self::REQUIRED_CARD_COUNT !== $totalCards) {
-            $errors[] = \sprintf(
-                'A deck must contain exactly %d cards, but this list has %d.',
-                self::REQUIRED_CARD_COUNT,
-                $totalCards,
-            );
+            $errors[] = $this->translator->trans('app.deck.validation.card_count', [
+                '%required%' => self::REQUIRED_CARD_COUNT,
+                '%actual%' => $totalCards,
+            ]);
         }
 
         // Group quantities by card identity (setCode|cardNumber)
@@ -78,12 +79,11 @@ class DeckListValidator
 
         foreach ($cardCounts as $data) {
             if ($data['quantity'] > self::MAX_COPIES) {
-                $errors[] = \sprintf(
-                    'Card "%s" appears %d times, but the maximum is %d copies.',
-                    $data['name'],
-                    $data['quantity'],
-                    self::MAX_COPIES,
-                );
+                $errors[] = $this->translator->trans('app.deck.validation.max_copies', [
+                    '%name%' => $data['name'],
+                    '%count%' => $data['quantity'],
+                    '%max%' => self::MAX_COPIES,
+                ]);
             }
         }
 
@@ -101,12 +101,11 @@ class DeckListValidator
             $checkedKeys[$key] = true;
 
             if (isset($bannedKeys[$key])) {
-                $errors[] = \sprintf(
-                    'Card "%s" (%s %s) is banned in the Expanded format.',
-                    $card->cardName,
-                    $card->setCode,
-                    $card->cardNumber,
-                );
+                $errors[] = $this->translator->trans('app.deck.validation.banned_card', [
+                    '%name%' => $card->cardName,
+                    '%set%' => $card->setCode,
+                    '%number%' => $card->cardNumber,
+                ]);
             }
         }
 

--- a/tests/Service/DeckListParserTest.php
+++ b/tests/Service/DeckListParserTest.php
@@ -15,6 +15,7 @@ namespace App\Tests\Service;
 
 use App\Service\DeckListParser;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @see docs/features.md F6.1 — Parse PTCG text format
@@ -25,7 +26,12 @@ class DeckListParserTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->parser = new DeckListParser();
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $params = []): string => $id.' '.implode(' ', array_map('strval', array_values($params))),
+        );
+
+        $this->parser = new DeckListParser($translator);
     }
 
     public function testParseFullDeckList(): void
@@ -152,7 +158,7 @@ class DeckListParserTest extends TestCase
         self::assertFalse($result->isValid());
         self::assertCount(1, $result->cards);
         self::assertCount(2, $result->errors);
-        self::assertStringContainsString('unrecognized format', $result->errors[0]);
+        self::assertStringContainsString('app.deck.parse.unrecognized_format', $result->errors[0]);
         self::assertStringContainsString('this is not a valid card line', $result->errors[0]);
     }
 
@@ -213,6 +219,6 @@ class DeckListParserTest extends TestCase
         self::assertFalse($result->isValid());
         self::assertCount(1, $result->cards);
         self::assertCount(1, $result->errors);
-        self::assertStringContainsString('before any section header', $result->errors[0]);
+        self::assertStringContainsString('app.deck.parse.no_section_header', $result->errors[0]);
     }
 }

--- a/tests/Service/DeckListValidatorTest.php
+++ b/tests/Service/DeckListValidatorTest.php
@@ -18,6 +18,7 @@ use App\Service\DeckListParseResult;
 use App\Service\DeckListValidator;
 use App\Service\ParsedCard;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @see docs/features.md F6.3 — Validate deck list (card count, duplicates)
@@ -36,7 +37,12 @@ class DeckListValidatorTest extends TestCase
             'PHF|118' => true,  // Lysandre's Trump Card (full art)
         ]);
 
-        $this->validator = new DeckListValidator($bannedCardRepo);
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $params = []): string => $id.' '.implode(' ', array_map('strval', array_values($params))),
+        );
+
+        $this->validator = new DeckListValidator($bannedCardRepo, $translator);
     }
 
     public function testValid60CardDeckPasses(): void
@@ -68,8 +74,7 @@ class DeckListValidatorTest extends TestCase
 
         self::assertFalse($result->isValid());
         self::assertCount(1, $result->errors);
-        self::assertStringContainsString('exactly 60 cards', $result->errors[0]);
-        self::assertStringContainsString('4', $result->errors[0]);
+        self::assertStringContainsString('app.deck.validation.card_count', $result->errors[0]);
     }
 
     public function testMoreThan4CopiesOfNonEnergyCardProducesError(): void
@@ -171,7 +176,7 @@ class DeckListValidatorTest extends TestCase
         $bannedError = false;
 
         foreach ($result->errors as $error) {
-            if (str_contains($error, 'Forest of Giant Plants') && str_contains($error, 'banned')) {
+            if (str_contains($error, 'Forest of Giant Plants') && str_contains($error, 'banned_card')) {
                 $bannedError = true;
             }
         }

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1792,6 +1792,33 @@
                 <target>Deck list imported (version %version%, %cards% cards). Card enrichment is processing in the background.</target>
                 <note>Success flash after importing deck list. %version% = version number, %cards% = card count</note>
             </trans-unit>
+            <!-- Deck list parsing errors -->
+            <trans-unit id="app.deck.parse.no_section_header">
+                <source>app.deck.parse.no_section_header</source>
+                <target>Line %line%: card line found before any section header: "%content%"</target>
+                <note>Parse error when a card line appears before a section (Pokémon/Trainer/Energy) header. %line% = line number, %content% = raw line</note>
+            </trans-unit>
+            <trans-unit id="app.deck.parse.unrecognized_format">
+                <source>app.deck.parse.unrecognized_format</source>
+                <target>Line %line%: unrecognized format: "%content%"</target>
+                <note>Parse error for a line that matches neither a section header nor a card line. %line% = line number, %content% = raw line</note>
+            </trans-unit>
+            <!-- Deck list validation errors -->
+            <trans-unit id="app.deck.validation.card_count">
+                <source>app.deck.validation.card_count</source>
+                <target>A deck must contain exactly %required% cards, but this list has %actual%.</target>
+                <note>Validation error for wrong card count. %required% = expected count (60), %actual% = actual count</note>
+            </trans-unit>
+            <trans-unit id="app.deck.validation.max_copies">
+                <source>app.deck.validation.max_copies</source>
+                <target>Card "%name%" appears %count% times, but the maximum is %max% copies.</target>
+                <note>Validation error for exceeding copy limit. %name% = card name, %count% = actual copies, %max% = maximum allowed</note>
+            </trans-unit>
+            <trans-unit id="app.deck.validation.banned_card">
+                <source>app.deck.validation.banned_card</source>
+                <target>Card "%name%" (%set% %number%) is banned in the Expanded format.</target>
+                <note>Validation error for banned card. %name% = card name, %set% = set code, %number% = card number</note>
+            </trans-unit>
             <trans-unit id="app.flash.auth.account_created">
                 <source>app.flash.auth.account_created</source>
                 <target>Your account has been created. Please check your email to verify your address.</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -1792,6 +1792,33 @@
                 <target>Liste de deck importée (version %version%, %cards% cartes). L&apos;enrichissement des cartes est en cours en arrière-plan.</target>
                 <note>Success flash after importing deck list. %version% = version number, %cards% = card count</note>
             </trans-unit>
+            <!-- Deck list parsing errors -->
+            <trans-unit id="app.deck.parse.no_section_header">
+                <source>app.deck.parse.no_section_header</source>
+                <target>Ligne %line% : ligne de carte trouvée avant un en-tête de section : « %content% »</target>
+                <note>Parse error when a card line appears before a section (Pokémon/Trainer/Energy) header. %line% = line number, %content% = raw line</note>
+            </trans-unit>
+            <trans-unit id="app.deck.parse.unrecognized_format">
+                <source>app.deck.parse.unrecognized_format</source>
+                <target>Ligne %line% : format non reconnu : « %content% »</target>
+                <note>Parse error for a line that matches neither a section header nor a card line. %line% = line number, %content% = raw line</note>
+            </trans-unit>
+            <!-- Deck list validation errors -->
+            <trans-unit id="app.deck.validation.card_count">
+                <source>app.deck.validation.card_count</source>
+                <target>Un deck doit contenir exactement %required% cartes, mais cette liste en contient %actual%.</target>
+                <note>Validation error for wrong card count. %required% = expected count (60), %actual% = actual count</note>
+            </trans-unit>
+            <trans-unit id="app.deck.validation.max_copies">
+                <source>app.deck.validation.max_copies</source>
+                <target>La carte « %name% » apparaît %count% fois, mais le maximum est de %max% exemplaires.</target>
+                <note>Validation error for exceeding copy limit. %name% = card name, %count% = actual copies, %max% = maximum allowed</note>
+            </trans-unit>
+            <trans-unit id="app.deck.validation.banned_card">
+                <source>app.deck.validation.banned_card</source>
+                <target>La carte « %name% » (%set% %number%) est bannie du format Expanded.</target>
+                <note>Validation error for banned card. %name% = card name, %set% = set code, %number% = card number</note>
+            </trans-unit>
             <trans-unit id="app.flash.auth.account_created">
                 <source>app.flash.auth.account_created</source>
                 <target>Votre compte a été créé. Veuillez vérifier votre email pour confirmer votre adresse.</target>


### PR DESCRIPTION
## Summary

- Replace hardcoded English strings in `DeckListParser` and `DeckListValidator` with translation keys
- Both services now inject `TranslatorInterface` and use `$this->translator->trans()` for all user-facing messages
- 5 new translation entries added to both `messages.en.xlf` and `messages.fr.xlf`
- Added "no hardcoded user-facing strings" rule to `CLAUDE.md`

## Translation keys added

| Key | EN | FR |
|-----|----|----|
| `app.deck.parse.no_section_header` | Line %line%: card line found before any section header: "%content%" | Ligne %line% : ligne de carte trouvée avant un en-tête de section : « %content% » |
| `app.deck.parse.unrecognized_format` | Line %line%: unrecognized format: "%content%" | Ligne %line% : format non reconnu : « %content% » |
| `app.deck.validation.card_count` | A deck must contain exactly %required% cards, but this list has %actual%. | Un deck doit contenir exactement %required% cartes, mais cette liste en contient %actual%. |
| `app.deck.validation.max_copies` | Card "%name%" appears %count% times, but the maximum is %max% copies. | La carte « %name% » apparaît %count% fois, mais le maximum est de %max% exemplaires. |
| `app.deck.validation.banned_card` | Card "%name%" (%set% %number%) is banned in the Expanded format. | La carte « %name% » (%set% %number%) est bannie du format Expanded. |

## Test plan

- [x] `DeckListParserTest` — mock translator, assertions updated to check translation keys
- [x] `DeckListValidatorTest` — mock translator, assertions updated to check translation keys
- [x] Full test suite: 509 tests, 2126 assertions
- [x] PHPStan level 10, CS-Fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)