### PR TITLE
:memo: Docs: Update coding and naming standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,10 @@ PHP-CS-Fixer enforces this header automatically via the `header_comment` rule.
 - Constructor injection, autowiring, thin controllers
 - Doctrine entities use PHP 8 attributes (not annotations)
 - Symfony best practices: service autowiring, param binding, env vars for config
+- Prefer PHP attributes over YAML configuration when possible (e.g. `#[AsEventListener]`, `#[AutoconfigureTag]`, `#[AsCommand]`)
+- Prefer `$variable instanceof Class` over `null !== $variable` when checking types
 - **No hardcoded user-facing strings**: all text displayed to end users (flash messages, validation errors, form labels, email subjects/bodies, UI labels) **MUST** use translation keys and be defined in the XLIFF translation files (`translations/messages.en.xlf` and `translations/messages.fr.xlf`). Services that produce user-facing messages must inject `TranslatorInterface` and call `$this->translator->trans()`. CLI command output (developer-facing) is exempt.
+- **No abbreviations or acronyms in identifiers**: whatever the language, never name a variable, method, class, or constant with an acronym or abbreviation that is not widely known (e.g. `VAT` is fine) or already used in the project. Use full, descriptive names. Examples: `$column` not `$col`; `values.find((value) => value === 'foo')` not `values.find((v) => v === 'foo')`.
 - **Feature traceability**: methods implementing a documented feature rule **MUST** reference the feature ID in their PHPDoc (`@see`) or JSDoc. This links code back to the feature specification.
 
 PHP example:
@@ -114,6 +117,13 @@ JS example:
  */
 function useScannerDetection(onScan) {
 ```
+
+### JavaScript / TypeScript
+
+- Use `const` and `let`, never `var`
+- Use arrow functions `() => {}` for anonymous functions
+- Use template literals `` `Hello ${name}` `` instead of string concatenation
+- Never use jQuery or other DOM manipulation libraries, unless interacting with a third-party library that requires it. Use vanilla JS or React instead
 
 ## Version Control
 

--- a/docs/standards/coding.md
+++ b/docs/standards/coding.md
@@ -49,8 +49,13 @@ use const App\BORROW_STATUS_PENDING;
 - **Thin controllers**: business logic belongs in services, not controllers
 - **Doctrine entities** use PHP 8 attributes (not annotations)
 - **Service configuration**: autowiring + param binding in `services.yaml`
+- **Prefer PHP attributes over YAML configuration** when possible (e.g. `#[AsEventListener]`, `#[AutoconfigureTag]`, `#[AsCommand]`, `#[Route]`)
 - **Environment variables** for all external configuration (no hardcoded values)
 - **Visibility required** on all class constants, methods, and properties
+
+### Type Checking
+
+- Prefer `$variable instanceof Class` over `null !== $variable` when checking types
 
 ### Testing
 
@@ -66,6 +71,10 @@ use const App\BORROW_STATUS_PENDING;
 - **TypeScript** for all frontend code (strict mode enabled in `tsconfig.json`)
 - **ESLint** for linting — flat config format (`eslint.config.mjs`)
 - **React** as the UI framework, via Webpack Encore
+- Use `const` and `let`, never `var`
+- Use arrow functions `() => {}` for anonymous functions
+- Use template literals `` `Hello ${name}` `` instead of string concatenation
+- Never use jQuery or other DOM manipulation libraries, unless interacting with a third-party library that requires it. Use vanilla JS or React instead
 
 ### React
 
@@ -78,6 +87,15 @@ use const App\BORROW_STATUS_PENDING;
 - **Webpack Encore** for asset compilation
 - Entry point: `assets/app.tsx`
 - Run: `make assets` (build), `make assets.watch` (dev watch mode)
+
+## Localization
+
+All text displayed to end users **MUST** use translation keys defined in the XLIFF translation files (`translations/messages.en.xlf` and `translations/messages.fr.xlf`). This includes flash messages, validation errors, form labels, email subjects/bodies, and UI labels.
+
+- PHP services that produce user-facing messages must inject `TranslatorInterface` and call `$this->translator->trans()`
+- Twig templates use `{{ 'app.key'|trans }}` or `{% trans %}` blocks
+- React components use `react-i18next` with JSON translation files in `assets/translations/`
+- CLI command output (developer-facing) is exempt
 
 ## Feature Traceability
 

--- a/docs/standards/naming.md
+++ b/docs/standards/naming.md
@@ -25,6 +25,18 @@
 | Doc files         | snake_case        | `file_headers.md`                |
 | Git branches      | kebab-case        | `feature/deck-borrow-workflow`   |
 
+## No Abbreviations
+
+Whatever the language, never name a variable, method, class, or constant with an acronym or abbreviation that is not widely known (e.g. `VAT` is fine) or already used in the project. Use full, descriptive names.
+
+| Do | Don't |
+|----|-------|
+| `$column` | `$col` |
+| `$repository` | `$repo` |
+| `$transaction` | `$tx` |
+| `values.find((value) => value === 'foo')` | `values.find((v) => v === 'foo')` |
+| `notifications.map((notification) => ...)` | `notifications.map((n) => ...)` |
+
 ## PHP Namespace Structure
 
 ```


### PR DESCRIPTION
## Summary

- Add JavaScript/TypeScript coding rules (`const`/`let`, arrow functions, template literals, no jQuery)
- Add no-abbreviations rule to naming conventions with do/don't examples
- Add PHP attributes over YAML preference (`#[AsEventListener]`, `#[AutoconfigureTag]`)
- Add `instanceof` over null-check preference
- Add localization section requiring translation keys for all user-facing strings

## Files updated

- `CLAUDE.md` — all new rules added inline
- `docs/standards/coding.md` — JS/TS section, Symfony conventions, type checking, localization
- `docs/standards/naming.md` — no-abbreviations section

## Test plan

- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)