### PR TITLE
:sparkles: Feature: deck show activity pagination (F5.12)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -241,7 +241,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 
 | ID    | Feature                                 | Priority | State       | Depends on       |
 |-------|-----------------------------------------|----------|-------------|------------------|
-| F5.12 | Deck show activity pagination           | Medium   | Not started | F2.3             |
+| F5.12 | Deck show activity pagination           | Medium   | Done        | F2.3             |
 | F7.4  | Dashboard action reminders              | Medium   | Not started | F7.1             |
 | F7.5  | Registered decks aggregate view         | Low      | Not started | F7.1             |
 
@@ -252,7 +252,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F13.1 | Bookmark a deck                         | Low      | Not started | F2.4             |
 | F13.2 | Bookmark an event                       | Low      | Not started | F3.2             |
 
-**Progress: 6/29 done · 3 partial · 20 not started**
+**Progress: 7/29 done · 3 partial · 19 not started**
 
 **Deliverable:** Auth hardening (flexible login, password strength scoring, MFA, Pokemon SSO). Managed archetype catalogue with detail pages, sprite pictograms, and backlinking across the UI. CMS content pages with Markdown, translations, and menu categories. Anonymous homepage with CMS-driven welcome block and news. Event tags for grouping and filtering, iCal feeds, deck version history, card mosaic view, overdue tracking, friend delegation for borrow completion, notification preferences, bookmarks for quick access to decks and events, and audit log.
 
@@ -334,10 +334,10 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
 | 7     | Engagement, Results & Discovery   | 10   | 0       | 0           | 10    |
 | 8     | Admin, Homepage & Polish          | 6    | 0       | 0           | 6     |
-| 9     | Content, Archetypes & Low Priority | 6   | 3       | 20          | 29    |
+| 9     | Content, Archetypes & Low Priority | 7   | 3       | 19          | 29    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **63** | **3**  | **33**      | **99** |
+|       | **Total**                         | **64** | **3**  | **32**      | **99** |
 
 All 99 features from [features.md](features.md) are represented exactly once.

--- a/src/Controller/DeckBorrowHistoryController.php
+++ b/src/Controller/DeckBorrowHistoryController.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Entity\Deck;
+use App\Entity\User;
+use App\Repository\BorrowRepository;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @see docs/features.md F5.12 — Deck show activity pagination
+ */
+#[IsGranted('ROLE_USER')]
+class DeckBorrowHistoryController extends AbstractController
+{
+    private const int PER_PAGE = 20;
+
+    #[Route('/deck/{short_tag}/borrows', name: 'app_deck_borrow_history', methods: ['GET'], requirements: ['short_tag' => '[A-HJ-NP-Z0-9]{6}'])]
+    public function __invoke(
+        #[MapEntity(mapping: ['short_tag' => 'shortTag'])] Deck $deck,
+        Request $request,
+        BorrowRepository $borrowRepository,
+    ): Response {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $this->denyAccessUnlessCanViewDeck($deck, $user);
+
+        $page = max(1, $request->query->getInt('page', 1));
+
+        $queryBuilder = $borrowRepository->createDeckForUserQueryBuilder($deck, $user);
+        $queryBuilder->setFirstResult(($page - 1) * self::PER_PAGE)
+            ->setMaxResults(self::PER_PAGE);
+
+        $paginator = new Paginator($queryBuilder, fetchJoinCollection: true);
+        $totalItems = \count($paginator);
+        $totalPages = max(1, (int) ceil($totalItems / self::PER_PAGE));
+
+        return $this->render('deck/borrow_history.html.twig', [
+            'deck' => $deck,
+            'borrows' => $paginator,
+            'totalItems' => $totalItems,
+            'currentPage' => $page,
+            'totalPages' => $totalPages,
+        ]);
+    }
+
+    private function denyAccessUnlessCanViewDeck(Deck $deck, User $user): void
+    {
+        if ($deck->isPublic()) {
+            return;
+        }
+
+        if ($deck->getOwner()->getId() === $user->getId() || $this->isGranted('ROLE_ADMIN')) {
+            return;
+        }
+
+        foreach ($deck->getEventRegistrations() as $registration) {
+            if ($registration->getEvent()->isOrganizerOrStaff($user)) {
+                return;
+            }
+        }
+
+        throw $this->createAccessDeniedException();
+    }
+}

--- a/src/Controller/DeckShowController.php
+++ b/src/Controller/DeckShowController.php
@@ -31,9 +31,12 @@ use Symfony\Component\Routing\Attribute\Route;
  * @see docs/features.md F2.3 — Detail view
  * @see docs/features.md F2.14 — Deck event status overview
  * @see docs/features.md F4.5 — Borrow history
+ * @see docs/features.md F5.12 — Deck show activity pagination
  */
 class DeckShowController extends AbstractController
 {
+    private const int ACTIVITY_PREVIEW_LIMIT = 5;
+
     #[Route('/deck/{short_tag}', name: 'app_deck_show', methods: ['GET'], requirements: ['short_tag' => '[A-HJ-NP-Z0-9]{6}'])]
     public function show(
         #[MapEntity(mapping: ['short_tag' => 'shortTag'])] Deck $deck,
@@ -103,11 +106,16 @@ class DeckShowController extends AbstractController
 
         // Anonymous users get empty borrow data
         $deckBorrows = [];
+        $totalBorrowCount = 0;
         $eligibleEvents = [];
         $eventStatusOverview = [];
 
         if (null !== $user) {
-            $deckBorrows = $borrowRepository->findByDeckForUser($deck, $user);
+            $deckBorrows = $borrowRepository->findByDeckForUser($deck, $user, self::ACTIVITY_PREVIEW_LIMIT);
+            $totalBorrowCount = (int) $borrowRepository->createDeckForUserQueryBuilder($deck, $user)
+                ->select('COUNT(b.id)')
+                ->getQuery()
+                ->getSingleScalarResult();
 
             // Only show eligible events if deck is not retired, user is not owner, and deck has a version
             if (!$isOwner && DeckStatus::Retired !== $deck->getStatus() && null !== $currentVersion) {
@@ -150,6 +158,7 @@ class DeckShowController extends AbstractController
             'groupedCards' => $orderedGroups,
             'isOwner' => $isOwner,
             'deckBorrows' => $deckBorrows,
+            'totalBorrowCount' => $totalBorrowCount,
             'eligibleEvents' => $eligibleEvents,
             'eventStatusOverview' => $eventStatusOverview,
             'versionCount' => $deck->getVersions()->count(),

--- a/src/Repository/BorrowRepository.php
+++ b/src/Repository/BorrowRepository.php
@@ -485,13 +485,30 @@ class BorrowRepository extends ServiceEntityRepository
      * Borrows for a deck visible to the given user (owner, borrower, or event organizer).
      *
      * @see docs/features.md F4.5 — Borrow history
+     * @see docs/features.md F5.12 — Deck show activity pagination
      *
      * @return list<Borrow>
      */
-    public function findByDeckForUser(Deck $deck, User $user): array
+    public function findByDeckForUser(Deck $deck, User $user, ?int $limit = null): array
     {
+        $qb = $this->createDeckForUserQueryBuilder($deck, $user);
+
+        if (null !== $limit) {
+            $qb->setMaxResults($limit);
+        }
+
         /** @var list<Borrow> $borrows */
-        $borrows = $this->createQueryBuilder('b')
+        $borrows = $qb->getQuery()->getResult();
+
+        return $borrows;
+    }
+
+    /**
+     * @see docs/features.md F5.12 — Deck show activity pagination
+     */
+    public function createDeckForUserQueryBuilder(Deck $deck, User $user): QueryBuilder
+    {
+        return $this->createQueryBuilder('b')
             ->join('b.deck', 'd')
             ->join('b.event', 'e')
             ->join('b.borrower', 'u')
@@ -500,11 +517,7 @@ class BorrowRepository extends ServiceEntityRepository
             ->andWhere('d.owner = :user OR b.borrower = :user OR e.organizer = :user')
             ->setParameter('deck', $deck)
             ->setParameter('user', $user)
-            ->orderBy('b.requestedAt', 'DESC')
-            ->getQuery()
-            ->getResult();
-
-        return $borrows;
+            ->orderBy('b.requestedAt', 'DESC');
     }
 
     /**

--- a/templates/deck/borrow_history.html.twig
+++ b/templates/deck/borrow_history.html.twig
@@ -1,0 +1,56 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'app.deck.borrow_history_title'|trans({'%name%': deck.name}) }} — Expanded Decks{% endblock %}
+
+{% block body %}
+    {# Breadcrumb #}
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ path('app_deck_list') }}">{{ 'app.nav.decks'|trans }}</a></li>
+            <li class="breadcrumb-item"><a href="{{ path('app_deck_show', {short_tag: deck.shortTag}) }}">{{ deck.name }}</a></li>
+            <li class="breadcrumb-item active" aria-current="page">{{ 'app.deck.borrow_history'|trans }}</li>
+        </ol>
+    </nav>
+
+    <div class="card shadow-sm mb-3">
+        <div class="card-header card-header-themed">
+            <h5 class="mb-0">{{ 'app.deck.borrow_history_title'|trans({'%name%': deck.name}) }}</h5>
+        </div>
+        <div class="card-body">
+            {% if borrows|length > 0 %}
+                {% include 'borrow/_activity_list.html.twig' with {
+                    borrows: borrows,
+                    columns: ['event', 'borrower', 'status', 'date']
+                } only %}
+            {% else %}
+                <p class="text-muted mb-0">{{ 'app.deck.no_borrow_history'|trans }}</p>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if totalPages > 1 %}
+        <nav>
+            <ul class="pagination justify-content-center">
+                <li class="page-item {% if currentPage <= 1 %}disabled{% endif %}">
+                    <a class="page-link" href="{{ path('app_deck_borrow_history', {short_tag: deck.shortTag, page: currentPage - 1}) }}">{{ 'app.common.previous'|trans }}</a>
+                </li>
+                {% for p in 1..totalPages %}
+                    <li class="page-item {% if p == currentPage %}active{% endif %}">
+                        <a class="page-link" href="{{ path('app_deck_borrow_history', {short_tag: deck.shortTag, page: p}) }}">{{ p }}</a>
+                    </li>
+                {% endfor %}
+                <li class="page-item {% if currentPage >= totalPages %}disabled{% endif %}">
+                    <a class="page-link" href="{{ path('app_deck_borrow_history', {short_tag: deck.shortTag, page: currentPage + 1}) }}">{{ 'app.common.next'|trans }}</a>
+                </li>
+            </ul>
+        </nav>
+    {% endif %}
+{% endblock %}

--- a/templates/deck/show.html.twig
+++ b/templates/deck/show.html.twig
@@ -141,6 +141,14 @@
                             borrows: deckBorrows,
                             columns: ['event', 'borrower', 'status', 'date']
                         } only %}
+
+                        {% if totalBorrowCount > deckBorrows|length %}
+                            <div class="text-center mt-2">
+                                <a href="{{ path('app_deck_borrow_history', {short_tag: deck.shortTag}) }}" class="btn btn-sm btn-outline-secondary">
+                                    {{ 'app.deck.see_more_activity'|trans({'%count%': totalBorrowCount}) }}
+                                </a>
+                            </div>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/tests/Functional/DeckBorrowHistoryControllerTest.php
+++ b/tests/Functional/DeckBorrowHistoryControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\Deck;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F5.12 — Deck show activity pagination
+ */
+class DeckBorrowHistoryControllerTest extends AbstractFunctionalTest
+{
+    public function testBorrowHistoryRedirectsForAnonymous(): void
+    {
+        $shortTag = $this->getDeckShortTag('Iron Thorns');
+        $this->client->request('GET', '/deck/'.$shortTag.'/borrows');
+
+        self::assertResponseRedirects('/login');
+    }
+
+    public function testBorrowHistoryAccessibleByOwner(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $shortTag = $this->getDeckShortTag('Iron Thorns');
+        $this->client->request('GET', '/deck/'.$shortTag.'/borrows');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h5', 'Iron Thorns');
+    }
+
+    public function testBorrowHistoryAccessibleByBorrower(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $shortTag = $this->getDeckShortTag('Iron Thorns');
+        $this->client->request('GET', '/deck/'.$shortTag.'/borrows');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testBorrowHistoryDeniedForUnrelatedUserOnPrivateDeck(): void
+    {
+        $this->loginAs('lender@example.com');
+
+        $shortTag = $this->getDeckShortTag('Ancient Box');
+        $this->client->request('GET', '/deck/'.$shortTag.'/borrows');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testBorrowHistoryShowsEmptyState(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $shortTag = $this->getDeckShortTag('Lugia Archeops');
+        $this->client->request('GET', '/deck/'.$shortTag.'/borrows');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testBorrowHistoryPaginationParam(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $shortTag = $this->getDeckShortTag('Iron Thorns');
+        $this->client->request('GET', '/deck/'.$shortTag.'/borrows?page=1');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    private function getDeckShortTag(string $name): string
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        /** @var Deck $deck */
+        $deck = $entityManager->getRepository(Deck::class)->findOneBy(['name' => $name]);
+
+        return $deck->getShortTag();
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -586,6 +586,28 @@
                 <note>Badge label for deck not registered at event</note>
             </trans-unit>
 
+            <!-- Deck activity pagination (F5.12) -->
+            <trans-unit id="app.deck.see_more_activity">
+                <source>app.deck.see_more_activity</source>
+                <target>See all activity (%count%)</target>
+                <note>Link to full borrow history. %count% = total borrow count</note>
+            </trans-unit>
+            <trans-unit id="app.deck.borrow_history">
+                <source>app.deck.borrow_history</source>
+                <target>Borrow history</target>
+                <note>Breadcrumb label for deck borrow history page</note>
+            </trans-unit>
+            <trans-unit id="app.deck.borrow_history_title">
+                <source>app.deck.borrow_history_title</source>
+                <target>Borrow history — %name%</target>
+                <note>Page title for deck borrow history. %name% = deck name</note>
+            </trans-unit>
+            <trans-unit id="app.deck.no_borrow_history">
+                <source>app.deck.no_borrow_history</source>
+                <target>No borrow activity for this deck.</target>
+                <note>Empty state on borrow history page</note>
+            </trans-unit>
+
             <!-- Deck version history (F2.9) -->
             <trans-unit id="app.deck.version_history">
                 <source>app.deck.version_history</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -586,6 +586,28 @@
                 <note>Badge label for deck not registered at event</note>
             </trans-unit>
 
+            <!-- Deck activity pagination (F5.12) -->
+            <trans-unit id="app.deck.see_more_activity">
+                <source>app.deck.see_more_activity</source>
+                <target>Voir toute l'activité (%count%)</target>
+                <note>Link to full borrow history. %count% = total borrow count</note>
+            </trans-unit>
+            <trans-unit id="app.deck.borrow_history">
+                <source>app.deck.borrow_history</source>
+                <target>Historique des emprunts</target>
+                <note>Breadcrumb label for deck borrow history page</note>
+            </trans-unit>
+            <trans-unit id="app.deck.borrow_history_title">
+                <source>app.deck.borrow_history_title</source>
+                <target>Historique des emprunts — %name%</target>
+                <note>Page title for deck borrow history. %name% = deck name</note>
+            </trans-unit>
+            <trans-unit id="app.deck.no_borrow_history">
+                <source>app.deck.no_borrow_history</source>
+                <target>Aucune activité d'emprunt pour ce deck.</target>
+                <note>Empty state on borrow history page</note>
+            </trans-unit>
+
             <!-- Deck version history (F2.9) -->
             <trans-unit id="app.deck.version_history">
                 <source>app.deck.version_history</source>


### PR DESCRIPTION
## Summary

- **Limit deck show page** to the 5 most recent borrow activity entries (was unbounded)
- **"See all activity" link** shown when there are more than 5 borrows, with total count
- **New paginated borrow history page** at `/deck/{shortTag}/borrows` (20 per page, Doctrine Paginator)
- Extracted `BorrowRepository::createDeckForUserQueryBuilder()` for reuse between the preview and full history
- **Translations**: 4 new keys in en + fr
- **Tests**: 6 functional tests for the new controller (auth, access control, empty state, pagination)

## Test plan

- [ ] Visit a deck with borrows → only 5 most recent shown
- [ ] "See all activity (N)" link visible when N > 5
- [ ] Click link → paginated borrow history page with breadcrumb
- [ ] Pagination controls work (page 1, 2, etc.)
- [ ] Anonymous users redirected to login
- [ ] Non-owner on private deck gets 403
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)