### PR TITLE
:sparkles: Feature: deck catalog archetype filter UX (F2.17)

### DIFF
--- a/assets/catalog-filters.tsx
+++ b/assets/catalog-filters.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { MantineProvider } from '@mantine/core';
+import ArchetypeFilterSelect from './components/ArchetypeFilterSelect';
 import AsyncAutocomplete from './components/AsyncAutocomplete';
 
 import '@mantine/core/styles.css';
@@ -17,31 +18,29 @@ import '@mantine/core/styles.css';
 /**
  * Mantine autocomplete entry point for all deck catalog filters.
  *
- * Mounts AsyncAutocomplete instances for archetype, event, and owner
- * search fields in the catalog filter bar.
+ * Mounts ArchetypeFilterSelect for the archetype dropdown and
+ * AsyncAutocomplete instances for event and owner search fields
+ * in the catalog filter bar.
  *
  * @see docs/features.md F2.4 — Deck Catalog (Browse & Search)
+ * @see docs/features.md F2.17 — Deck catalog archetype filter UX
  */
 
 document.querySelectorAll<HTMLElement>('[data-catalog-archetype]').forEach((root) => {
-    const searchUrl = root.dataset.searchUrl ?? '';
+    const catalogUrl = root.dataset.catalogUrl ?? '';
     const hiddenInput = root.dataset.hiddenInput ?? 'archetype';
-    const placeholder = root.dataset.placeholder ?? 'Search archetype...';
+    const placeholder = root.dataset.placeholder ?? 'Select archetype...';
     const initialValue = root.dataset.initialValue ?? '';
-    const initialId = root.dataset.initialId ?? '';
+    const initialLabel = root.dataset.initialLabel ?? '';
 
     createRoot(root).render(
         <MantineProvider>
-            <AsyncAutocomplete
-                searchUrl={searchUrl}
+            <ArchetypeFilterSelect
+                catalogUrl={catalogUrl}
                 hiddenInputName={hiddenInput}
                 placeholder={placeholder}
                 initialValue={initialValue}
-                initialHiddenValue={initialId}
-                mapResult={(item) => ({
-                    value: item.slug as string,
-                    label: item.name as string,
-                })}
+                initialLabel={initialLabel}
             />
         </MantineProvider>,
     );

--- a/assets/components/ArchetypeFilterSelect.tsx
+++ b/assets/components/ArchetypeFilterSelect.tsx
@@ -1,0 +1,168 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { CloseButton, Combobox, Group, InputBase, Text, useCombobox } from '@mantine/core';
+
+interface ArchetypeOption {
+    name: string;
+    slug: string;
+    pokemonSlugs: string[];
+}
+
+interface ArchetypeFilterSelectProps {
+    catalogUrl: string;
+    hiddenInputName: string;
+    placeholder?: string;
+    initialValue?: string;
+    initialLabel?: string;
+}
+
+/**
+ * Searchable archetype dropdown for the deck catalog filter bar.
+ *
+ * Loads all published archetypes with public decks on mount, displays
+ * sprites alongside names, and supports client-side type-ahead filtering.
+ *
+ * @see docs/features.md F2.17 — Deck catalog archetype filter UX
+ */
+export default function ArchetypeFilterSelect({
+    catalogUrl,
+    hiddenInputName,
+    placeholder = 'Select archetype...',
+    initialValue = '',
+    initialLabel = '',
+}: ArchetypeFilterSelectProps) {
+    const [archetypes, setArchetypes] = useState<ArchetypeOption[]>([]);
+    const [search, setSearch] = useState(initialLabel);
+    const [selectedSlug, setSelectedSlug] = useState(initialValue);
+    const selectedSlugRef = useRef(initialValue);
+
+    const combobox = useCombobox({
+        onDropdownClose: () => {
+            combobox.resetSelectedOption();
+            const selected = archetypes.find((archetype) => archetype.slug === selectedSlugRef.current);
+            setSearch(selected?.name ?? '');
+        },
+        onDropdownOpen: () => {
+            combobox.updateSelectedOptionIndex();
+        },
+    });
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        fetch(catalogUrl, { signal: controller.signal })
+            .then((response) => {
+                if (!response.ok) {
+                    return [];
+                }
+
+                return response.json();
+            })
+            .then((data: ArchetypeOption[]) => {
+                 
+                setArchetypes(data);
+            })
+            .catch(() => {
+                // Aborted or network error
+            });
+
+        return () => controller.abort();
+    }, [catalogUrl]);
+
+    const filteredArchetypes = search
+        ? archetypes.filter((archetype) =>
+            archetype.name.toLowerCase().includes(search.toLowerCase()),
+        )
+        : archetypes;
+
+    const options = filteredArchetypes.map((archetype) => (
+        <Combobox.Option value={archetype.slug} key={archetype.slug}>
+            <Group gap="xs" wrap="nowrap">
+                {archetype.pokemonSlugs.length > 0 && (
+                    <span style={{ display: 'inline-flex', flexShrink: 0, alignItems: 'center' }}>
+                        {archetype.pokemonSlugs.map((pokemonSlug) => (
+                            <img
+                                key={pokemonSlug}
+                                src={`/build/sprites/pokemon/${pokemonSlug}.png`}
+                                alt={pokemonSlug.replace(/-/g, ' ')}
+                                style={{ height: 24, imageRendering: 'pixelated' }}
+                                loading="lazy"
+                            />
+                        ))}
+                    </span>
+                )}
+                <Text size="sm" fw={600}>{archetype.name}</Text>
+            </Group>
+        </Combobox.Option>
+    ));
+
+    return (
+        <>
+            <input type="hidden" name={hiddenInputName} value={selectedSlug} />
+            <Combobox
+                store={combobox}
+                onOptionSubmit={(slug) => {
+                    const found = archetypes.find((archetype) => archetype.slug === slug);
+                    if (found) {
+                        selectedSlugRef.current = found.slug;
+                        setSelectedSlug(found.slug);
+                        setSearch(found.name);
+                    }
+                    combobox.closeDropdown();
+                }}
+            >
+                <Combobox.Target>
+                    <InputBase
+                        value={search}
+                        onChange={(event) => {
+                            const value = event.currentTarget.value;
+                            setSearch(value);
+                            if (value === '') {
+                                selectedSlugRef.current = '';
+                                setSelectedSlug('');
+                            }
+                            combobox.openDropdown();
+                            combobox.updateSelectedOptionIndex();
+                        }}
+                        onClick={() => combobox.openDropdown()}
+                        onFocus={() => combobox.openDropdown()}
+                        onBlur={() => combobox.closeDropdown()}
+                        placeholder={placeholder}
+                        rightSection={
+                            selectedSlug
+                                ? <CloseButton
+                                    size="sm"
+                                    onMouseDown={(event) => event.preventDefault()}
+                                    onClick={() => {
+                                        selectedSlugRef.current = '';
+                                        setSelectedSlug('');
+                                        setSearch('');
+                                    }}
+                                    aria-label="Clear selection"
+                                />
+                                : <Combobox.Chevron />
+                        }
+                        rightSectionPointerEvents={selectedSlug ? 'all' : 'none'}
+                    />
+                </Combobox.Target>
+
+                <Combobox.Dropdown>
+                    <Combobox.Options mah={280} style={{ overflowY: 'auto' }}>
+                        {options}
+                        {options.length === 0 && (
+                            <Combobox.Empty>No archetypes found</Combobox.Empty>
+                        )}
+                    </Combobox.Options>
+                </Combobox.Dropdown>
+            </Combobox>
+        </>
+    );
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,7 +198,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F2.12 | Archetype sprite pictograms    | Low      | Done        | F2.6             |
 | F2.15 | Archetype playstyle tags       | Low      | Done        | F2.10            |
 | F2.16 | Archetype catalog              | Medium   | Not started | F2.10, F2.15     |
-| F2.17 | Deck catalog archetype filter UX | Medium | Not started | F2.4             |
+| F2.17 | Deck catalog archetype filter UX | Medium | Done        | F2.4             |
 | F2.18 | Admin archetype create/edit form | Medium | Done        | F2.6             |
 | F13.3 | Bookmark an archetype          | Low      | Not started | F2.16            |
 
@@ -257,7 +257,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F13.1 | Bookmark a deck                         | Low      | Not started | F2.4             |
 | F13.2 | Bookmark an event                       | Low      | Not started | F3.2             |
 
-**Progress: 14/34 done · 0 partial · 20 not started**
+**Progress: 15/34 done · 0 partial · 19 not started**
 
 **Deliverable:** Auth hardening (flexible login, password strength scoring, MFA, Pokemon SSO). Managed archetype catalogue with detail pages, sprite pictograms, and backlinking across the UI. CMS content pages with Markdown, translations, and menu categories. Anonymous homepage with CMS-driven welcome block and news. Event tags for grouping and filtering, iCal feeds, deck version history, card mosaic view, overdue tracking, friend delegation for borrow completion, notification preferences, bookmarks for quick access to decks and events, and audit log.
 
@@ -339,10 +339,10 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
 | 7     | Engagement, Results & Discovery   | 10   | 0       | 0           | 10    |
 | 8     | Admin, Homepage & Polish          | 6    | 0       | 0           | 6     |
-| 9     | Content, Archetypes & Low Priority | 14  | 0       | 20          | 34    |
+| 9     | Content, Archetypes & Low Priority | 15  | 0       | 19          | 34    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **71** | **0**  | **33**      | **104** |
+|       | **Total**                         | **72** | **0**  | **32**      | **104** |
 
 All 104 features from [features.md](features.md) are represented exactly once.

--- a/src/Controller/ArchetypeSearchController.php
+++ b/src/Controller/ArchetypeSearchController.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * Public archetype search endpoint for autocomplete widgets.
+ * Public archetype search endpoints for autocomplete widgets.
  *
  * Separated from ArchetypeController (which requires ROLE_USER) so that
  * the catalog filter can search archetypes without authentication.
@@ -45,6 +45,26 @@ class ArchetypeSearchController extends AbstractController
             'id' => $a->getId(),
             'name' => $a->getName(),
             'slug' => $a->getSlug(),
+        ], $archetypes);
+
+        return $this->json($data);
+    }
+
+    /**
+     * Returns all published archetypes that have at least one public deck,
+     * including pokemon slugs for sprite rendering in the filter dropdown.
+     *
+     * @see docs/features.md F2.17 — Deck catalog archetype filter UX
+     */
+    #[Route('/api/archetype/catalog', name: 'app_archetype_catalog', methods: ['GET'])]
+    public function catalog(ArchetypeRepository $archetypeRepository): JsonResponse
+    {
+        $archetypes = $archetypeRepository->findPublishedWithPublicDecks();
+
+        $data = array_map(static fn (Archetype $archetype): array => [
+            'name' => $archetype->getName(),
+            'slug' => $archetype->getSlug(),
+            'pokemonSlugs' => $archetype->getPokemonSlugs(),
         ], $archetypes);
 
         return $this->json($data);

--- a/src/Repository/ArchetypeRepository.php
+++ b/src/Repository/ArchetypeRepository.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Archetype;
+use App\Enum\DeckStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -40,6 +41,34 @@ class ArchetypeRepository extends ServiceEntityRepository
             ->setParameter('query', '%'.$query.'%')
             ->orderBy('a.name', 'ASC')
             ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $archetypes;
+    }
+
+    /**
+     * Find all published archetypes that have at least one public, non-retired deck.
+     *
+     * @see docs/features.md F2.17 — Deck catalog archetype filter UX
+     *
+     * @return list<Archetype>
+     */
+    public function findPublishedWithPublicDecks(): array
+    {
+        /** @var list<Archetype> $archetypes */
+        $archetypes = $this->createQueryBuilder('a')
+            ->where('a.isPublished = :published')
+            ->andWhere('EXISTS (
+                SELECT d.id FROM App\Entity\Deck d
+                WHERE d.archetype = a
+                AND d.public = :public
+                AND d.status != :retired
+            )')
+            ->setParameter('published', true)
+            ->setParameter('public', true)
+            ->setParameter('retired', DeckStatus::Retired)
+            ->orderBy('a.name', 'ASC')
             ->getQuery()
             ->getResult();
 

--- a/templates/deck/list.html.twig
+++ b/templates/deck/list.html.twig
@@ -42,12 +42,12 @@
                         <div class="col-md-4">
                             <label class="form-label">{{ 'app.deck.archetype_filter'|trans }}</label>
                             <div data-catalog-archetype
-                                 data-search-url="{{ path('app_archetype_search') }}"
+                                 data-catalog-url="{{ path('app_archetype_catalog') }}"
                                  data-hidden-input="archetype"
-                                 data-placeholder="Search archetype..."
+                                 data-placeholder="{{ 'app.deck.archetype_filter_placeholder'|trans }}"
                                  {% if (filters.archetype ?? '') != '' %}
-                                     data-initial-value="{{ archetypeName }}"
-                                     data-initial-id="{{ filters.archetype }}"
+                                     data-initial-value="{{ filters.archetype }}"
+                                     data-initial-label="{{ archetypeName }}"
                                  {% endif %}
                             ></div>
                         </div>

--- a/tests/Functional/DeckCatalogControllerTest.php
+++ b/tests/Functional/DeckCatalogControllerTest.php
@@ -59,6 +59,34 @@ class DeckCatalogControllerTest extends AbstractFunctionalTest
         self::assertArrayHasKey('slug', $data[0]);
     }
 
+    /**
+     * @see docs/features.md F2.17 — Deck catalog archetype filter UX
+     */
+    public function testArchetypeCatalogEndpointReturnsPublishedWithPublicDecks(): void
+    {
+        $this->client->request('GET', '/api/archetype/catalog');
+
+        self::assertResponseIsSuccessful();
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertNotEmpty($data);
+        self::assertArrayHasKey('name', $data[0]);
+        self::assertArrayHasKey('slug', $data[0]);
+        self::assertArrayHasKey('pokemonSlugs', $data[0]);
+        self::assertIsArray($data[0]['pokemonSlugs']);
+    }
+
+    /**
+     * @see docs/features.md F2.17 — Deck catalog archetype filter UX
+     */
+    public function testArchetypeCatalogEndpointIsPubliclyAccessible(): void
+    {
+        // No login — should still work
+        $this->client->request('GET', '/api/archetype/catalog');
+
+        self::assertResponseIsSuccessful();
+    }
+
     public function testOnlyPublicDecksAreListed(): void
     {
         $this->client->request('GET', '/deck');

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -505,6 +505,11 @@
                 <target>Archetype</target>
                 <note>Catalog filter label</note>
             </trans-unit>
+            <trans-unit id="app.deck.archetype_filter_placeholder">
+                <source>app.deck.archetype_filter_placeholder</source>
+                <target>Select archetype…</target>
+                <note>Catalog archetype filter placeholder</note>
+            </trans-unit>
             <trans-unit id="app.deck.event_filter">
                 <source>app.deck.event_filter</source>
                 <target>Event</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -505,6 +505,11 @@
                 <target>Archétype</target>
                 <note>Catalog filter label</note>
             </trans-unit>
+            <trans-unit id="app.deck.archetype_filter_placeholder">
+                <source>app.deck.archetype_filter_placeholder</source>
+                <target>Sélectionner un archétype…</target>
+                <note>Catalog archetype filter placeholder</note>
+            </trans-unit>
             <trans-unit id="app.deck.event_filter">
                 <source>app.deck.event_filter</source>
                 <target>Événement</target>


### PR DESCRIPTION
## Summary
- Replace the archetype async text-search autocomplete in the deck catalog with a **searchable dropdown** pre-populated from published archetypes that have at least one public deck
- Each option displays **Pokemon sprites** alongside the archetype name for quick visual identification
- Client-side type-ahead filtering (no minimum character requirement)
- **Clear button** (×) to reset the selection in one click
- New public API endpoint `GET /api/archetype/catalog` returning eligible archetypes with their `pokemonSlugs`

## Test plan
- [ ] Open the deck catalog `/deck` — the archetype filter should show a dropdown instead of a text search
- [ ] Click the archetype dropdown — all published archetypes with public decks appear with sprites
- [ ] Type to filter — options narrow down client-side
- [ ] Select an archetype and submit — catalog filters correctly
- [ ] Verify the × button clears the selection
- [ ] Verify the filter works when returning to the page with an archetype pre-selected (URL param)
- [ ] Test on mobile — dropdown is scrollable and sprites render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)