### PR TITLE
:sparkles: Feature: archetype catalog (F2.16)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -197,7 +197,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F2.11 | Archetype backlinking          | Low      | Done        | F2.10            |
 | F2.12 | Archetype sprite pictograms    | Low      | Done        | F2.6             |
 | F2.15 | Archetype playstyle tags       | Low      | Done        | F2.10            |
-| F2.16 | Archetype catalog              | Medium   | Not started | F2.10, F2.15     |
+| F2.16 | Archetype catalog              | Medium   | Done        | F2.10, F2.15     |
 | F2.17 | Deck catalog archetype filter UX | Medium | Done        | F2.4             |
 | F2.18 | Admin archetype create/edit form | Medium | Done        | F2.6             |
 | F13.3 | Bookmark an archetype          | Low      | Not started | F2.16            |
@@ -257,7 +257,7 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | F13.1 | Bookmark a deck                         | Low      | Not started | F2.4             |
 | F13.2 | Bookmark an event                       | Low      | Not started | F3.2             |
 
-**Progress: 15/34 done · 0 partial · 19 not started**
+**Progress: 16/34 done · 0 partial · 18 not started**
 
 **Deliverable:** Auth hardening (flexible login, password strength scoring, MFA, Pokemon SSO). Managed archetype catalogue with detail pages, sprite pictograms, and backlinking across the UI. CMS content pages with Markdown, translations, and menu categories. Anonymous homepage with CMS-driven welcome block and news. Event tags for grouping and filtering, iCal feeds, deck version history, card mosaic view, overdue tracking, friend delegation for borrow completion, notification preferences, bookmarks for quick access to decks and events, and audit log.
 
@@ -339,10 +339,10 @@ Each feature carries a **State** that must be kept up to date as work progresses
 | 6     | Localization                      | 5    | 0       | 0           | 5     |
 | 7     | Engagement, Results & Discovery   | 10   | 0       | 0           | 10    |
 | 8     | Admin, Homepage & Polish          | 6    | 0       | 0           | 6     |
-| 9     | Content, Archetypes & Low Priority | 15  | 0       | 19          | 34    |
+| 9     | Content, Archetypes & Low Priority | 16  | 0       | 18          | 34    |
 | 10    | Labels & Scanning                 | 0    | 0       | 7           | 7     |
 | 11    | Play Pokemon QR Integration       | 0    | 0       | 2           | 2     |
 | 12    | Quality & Security Consolidation  | 0    | 0       | 2           | 2     |
-|       | **Total**                         | **72** | **0**  | **32**      | **104** |
+|       | **Total**                         | **73** | **0**  | **31**      | **104** |
 
 All 104 features from [features.md](features.md) are represented exactly once.

--- a/src/Controller/ArchetypeCatalogController.php
+++ b/src/Controller/ArchetypeCatalogController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Repository\ArchetypeRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * @see docs/features.md F2.16 — Archetype catalog
+ */
+class ArchetypeCatalogController extends AbstractController
+{
+    /**
+     * @see docs/features.md F2.16 — Archetype catalog
+     */
+    #[Route('/archetypes', name: 'app_archetype_list', methods: ['GET'], priority: 10)]
+    public function list(Request $request, ArchetypeRepository $archetypeRepository): Response
+    {
+        /** @var list<string> $tags */
+        $tags = $request->query->all('tags');
+        $tags = array_values(array_filter($tags, static fn (string $tag): bool => '' !== $tag));
+        $sort = $request->query->getString('sort', 'name');
+
+        if (!\in_array($sort, ['name', 'decks'], true)) {
+            $sort = 'name';
+        }
+
+        $results = $archetypeRepository->findPublishedWithDeckCounts($tags, $sort);
+        $allTags = $archetypeRepository->findAllPublishedPlaystyleTags();
+
+        return $this->render('archetype/list.html.twig', [
+            'results' => $results,
+            'allTags' => $allTags,
+            'currentTags' => $tags,
+            'currentSort' => $sort,
+        ]);
+    }
+}

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -512,7 +512,10 @@ MARKDOWN, true, ['Combo', 'Lock', 'Toolbox']);
         $archetype->setPokemonSlugs($pokemonSlugs);
         $archetype->setDescription($description);
         $archetype->setIsPublished($isPublished);
-        $archetype->setPlaystyleTags($playstyleTags);
+        $archetype->setPlaystyleTags(array_map(
+            static fn (string $tag): string => mb_convert_case(trim($tag), \MB_CASE_TITLE),
+            $playstyleTags,
+        ));
 
         $manager->persist($archetype);
 

--- a/src/Repository/ArchetypeRepository.php
+++ b/src/Repository/ArchetypeRepository.php
@@ -76,6 +76,86 @@ class ArchetypeRepository extends ServiceEntityRepository
     }
 
     /**
+     * Find all published archetypes with their public deck count.
+     *
+     * Returns an array of [archetype => Archetype, deckCount => int] rows,
+     * optionally filtered by playstyle tags (OR logic) and sorted by the given criteria.
+     *
+     * @see docs/features.md F2.16 — Archetype catalog
+     *
+     * @param list<string> $tags playstyle tags to filter by (OR: matches any)
+     *
+     * @return list<array{archetype: Archetype, deckCount: int}>
+     */
+    public function findPublishedWithDeckCounts(array $tags = [], string $sort = 'name'): array
+    {
+        $qb = $this->createQueryBuilder('a')
+            ->select('a AS archetype')
+            ->addSelect('(
+                SELECT COUNT(d.id) FROM App\Entity\Deck d
+                WHERE d.archetype = a
+                AND d.public = :public
+                AND d.status != :retired
+            ) AS deckCount')
+            ->where('a.isPublished = :published')
+            ->setParameter('published', true)
+            ->setParameter('public', true)
+            ->setParameter('retired', DeckStatus::Retired);
+
+        if ([] !== $tags) {
+            $tagConditions = [];
+            foreach ($tags as $index => $tag) {
+                $paramName = 'tag'.$index;
+                $tagConditions[] = 'a.playstyleTags LIKE :'.$paramName;
+                $qb->setParameter($paramName, '%"'.$tag.'"%');
+            }
+            $qb->andWhere(implode(' OR ', $tagConditions));
+        }
+
+        if ('decks' === $sort) {
+            $qb->orderBy('deckCount', 'DESC')
+                ->addOrderBy('a.name', 'ASC');
+        } else {
+            $qb->orderBy('a.name', 'ASC');
+        }
+
+        /** @var list<array{archetype: Archetype, deckCount: int}> $results */
+        $results = $qb->getQuery()->getResult();
+
+        return $results;
+    }
+
+    /**
+     * Collect all unique playstyle tags from published archetypes.
+     *
+     * @see docs/features.md F2.16 — Archetype catalog
+     *
+     * @return list<string>
+     */
+    public function findAllPublishedPlaystyleTags(): array
+    {
+        /** @var list<array{playstyleTags: list<string>}> $rows */
+        $rows = $this->createQueryBuilder('a')
+            ->select('a.playstyleTags')
+            ->where('a.isPublished = :published')
+            ->setParameter('published', true)
+            ->getQuery()
+            ->getResult();
+
+        $tags = [];
+        foreach ($rows as $row) {
+            foreach ($row['playstyleTags'] as $tag) {
+                $tags[$tag] = true;
+            }
+        }
+
+        $tagList = array_keys($tags);
+        sort($tagList);
+
+        return $tagList;
+    }
+
+    /**
      * @see docs/features.md F2.10 — Archetype detail page
      */
     public function findPublishedBySlug(string $slug): ?Archetype

--- a/templates/archetype/list.html.twig
+++ b/templates/archetype/list.html.twig
@@ -1,0 +1,89 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'app.archetype.catalog_title'|trans }} — Expanded Decks{% endblock %}
+
+{% block body %}
+    <h1 class="mb-4">{{ 'app.archetype.catalog_title'|trans }}</h1>
+
+    {# Filter / sort bar #}
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="row g-2 align-items-end">
+                <div class="col-md-6">
+                    <label class="form-label">{{ 'app.archetype.filter_by_tag'|trans }}</label>
+                    <div class="d-flex flex-wrap gap-1">
+                        <a href="{{ path('app_archetype_list', {sort: currentSort}) }}" class="btn btn-sm {{ currentTags|length == 0 ? 'btn-gold' : 'btn-outline-secondary' }}">
+                            {{ 'app.common.all'|trans }}
+                        </a>
+                        {% for tag in allTags %}
+                            {% set isActive = tag in currentTags %}
+                            {% if isActive %}
+                                {% set newTags = currentTags|filter(selectedTag => selectedTag != tag) %}
+                            {% else %}
+                                {% set newTags = currentTags|merge([tag]) %}
+                            {% endif %}
+                            <a href="{{ path('app_archetype_list', {'tags': newTags, sort: currentSort}) }}" class="btn btn-sm {{ isActive ? 'btn-gold' : 'btn-outline-secondary' }}">
+                                {{ tag }}
+                            </a>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="col-md-3 ms-auto">
+                    <label class="form-label">{{ 'app.archetype.sort_by'|trans }}</label>
+                    <select class="form-select form-select-sm" onchange="window.location.href=this.value">
+                        <option value="{{ path('app_archetype_list', {'tags': currentTags, sort: 'name'}) }}" {{ currentSort == 'name' ? 'selected' }}>
+                            {{ 'app.archetype.sort_name'|trans }}
+                        </option>
+                        <option value="{{ path('app_archetype_list', {'tags': currentTags, sort: 'decks'}) }}" {{ currentSort == 'decks' ? 'selected' }}>
+                            {{ 'app.archetype.sort_decks'|trans }}
+                        </option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {# Result count #}
+    <p class="text-muted mb-3">{{ 'app.archetype.results_count'|trans({'%count%': results|length}) }}</p>
+
+    {% if results|length > 0 %}
+        <div class="row">
+            {% for row in results %}
+                {% set archetype = row.archetype %}
+                {% set deckCount = row.deckCount %}
+                <div class="col-sm-6 col-lg-4 mb-4">
+                    <a href="{{ path('app_archetype_show', {slug: archetype.slug}) }}" class="text-decoration-none">
+                        <div class="card h-100 shadow-sm">
+                            <div class="card-body">
+                                <h5 class="card-title mb-2">
+                                    {{ archetype_sprites(archetype) }}
+                                    {{ archetype.name }}
+                                </h5>
+                                {% if archetype.playstyleTags|length > 0 %}
+                                    <div class="mb-2">
+                                        {% for tag in archetype.playstyleTags %}
+                                            <span class="badge bg-secondary">{{ tag }}</span>
+                                        {% endfor %}
+                                    </div>
+                                {% endif %}
+                                <p class="card-text text-muted mb-0">
+                                    {{ 'app.archetype.deck_count'|trans({'%count%': deckCount}) }}
+                                </p>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="alert alert-info">{{ 'app.archetype.no_results'|trans }}</div>
+    {% endif %}
+{% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -32,6 +32,9 @@
                                 <a class="nav-link" href="{{ path('app_dashboard') }}">{{ 'app.nav.dashboard'|trans }}</a>
                             </li>
                             <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_archetype_list') }}">{{ 'app.nav.archetypes'|trans }}</a>
+                            </li>
+                            <li class="nav-item">
                                 <a class="nav-link" href="{{ path('app_deck_list') }}">{{ 'app.nav.decks'|trans }}</a>
                             </li>
                             <li class="nav-item">
@@ -96,6 +99,9 @@
                                 </ul>
                             </li>
                         {% else %}
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_archetype_list') }}">{{ 'app.nav.archetypes'|trans }}</a>
+                            </li>
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('app_deck_list') }}">{{ 'app.nav.decks'|trans }}</a>
                             </li>

--- a/tests/Functional/ArchetypeCatalogControllerTest.php
+++ b/tests/Functional/ArchetypeCatalogControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+/**
+ * @see docs/features.md F2.16 — Archetype catalog
+ */
+class ArchetypeCatalogControllerTest extends AbstractFunctionalTest
+{
+    public function testCatalogIsPubliclyAccessible(): void
+    {
+        $this->client->request('GET', '/archetypes');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'Archetypes');
+    }
+
+    public function testCatalogDisplaysPublishedArchetypes(): void
+    {
+        $crawler = $this->client->request('GET', '/archetypes');
+
+        self::assertResponseIsSuccessful();
+        // Fixture data has published archetypes with public decks
+        $cards = $crawler->filter('.card-title');
+        self::assertGreaterThan(0, $cards->count());
+    }
+
+    public function testCatalogShowsArchetypeSprites(): void
+    {
+        $this->client->request('GET', '/archetypes');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('.archetype-sprites');
+    }
+
+    public function testCatalogShowsDeckCount(): void
+    {
+        $crawler = $this->client->request('GET', '/archetypes');
+
+        self::assertResponseIsSuccessful();
+        // Each card should display a deck count
+        $deckCounts = $crawler->filter('.card-text');
+        self::assertGreaterThan(0, $deckCounts->count());
+    }
+
+    public function testCatalogLinksToDetailPage(): void
+    {
+        $crawler = $this->client->request('GET', '/archetypes');
+
+        self::assertResponseIsSuccessful();
+        $links = $crawler->filter('a[href^="/archetypes/"]');
+        self::assertGreaterThan(0, $links->count());
+    }
+
+    public function testSortByDecks(): void
+    {
+        $this->client->request('GET', '/archetypes?sort=decks');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testSortByName(): void
+    {
+        $this->client->request('GET', '/archetypes?sort=name');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testInvalidSortDefaultsToName(): void
+    {
+        $this->client->request('GET', '/archetypes?sort=invalid');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testFilterBySingleTag(): void
+    {
+        $this->client->request('GET', '/archetypes?tags[]=Aggro');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testFilterByMultipleTagsUsesOrLogic(): void
+    {
+        $this->client->request('GET', '/archetypes?tags[]=Aggro&tags[]=Control');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testFilterByNonExistentTagShowsEmptyState(): void
+    {
+        $this->client->request('GET', '/archetypes?tags[]=NonExistentTag');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('.alert-info');
+    }
+
+    public function testCatalogShowsPlaystyleTagBadges(): void
+    {
+        $crawler = $this->client->request('GET', '/archetypes');
+
+        self::assertResponseIsSuccessful();
+        $badges = $crawler->filter('.badge.bg-secondary');
+        self::assertGreaterThan(0, $badges->count());
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -8,6 +8,11 @@
                 <target>Dashboard</target>
                 <note>Main navigation bar link</note>
             </trans-unit>
+            <trans-unit id="app.nav.archetypes">
+                <source>app.nav.archetypes</source>
+                <target>Archetypes</target>
+                <note>Main navigation bar link</note>
+            </trans-unit>
             <trans-unit id="app.nav.decks">
                 <source>app.nav.decks</source>
                 <target>Decks</target>
@@ -3116,6 +3121,48 @@
                 <source>app.archetype.browse_all_decks</source>
                 <target>Browse all %count% decks</target>
                 <note>CTA to see all decks with this archetype in catalog</note>
+            </trans-unit>
+
+            <!-- Archetype catalog (F2.16) -->
+            <trans-unit id="app.archetype.catalog_title">
+                <source>app.archetype.catalog_title</source>
+                <target>Archetypes</target>
+                <note>Public archetype catalog page title</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.filter_by_tag">
+                <source>app.archetype.filter_by_tag</source>
+                <target>Tag</target>
+                <note>Label for tag filter on archetype catalog</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.sort_by">
+                <source>app.archetype.sort_by</source>
+                <target>Sort by</target>
+                <note>Label for sort dropdown on archetype catalog</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.sort_name">
+                <source>app.archetype.sort_name</source>
+                <target>Name</target>
+                <note>Sort option: alphabetical by name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.sort_decks">
+                <source>app.archetype.sort_decks</source>
+                <target>Most decks</target>
+                <note>Sort option: by number of available decks descending</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.results_count">
+                <source>app.archetype.results_count</source>
+                <target>%count% archetype found|%count% archetypes found</target>
+                <note>Result count on archetype catalog. %count% = number of archetypes</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.deck_count">
+                <source>app.archetype.deck_count</source>
+                <target>%count% deck|%count% decks</target>
+                <note>Deck count displayed on archetype catalog card. %count% = number of public decks</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.no_results">
+                <source>app.archetype.no_results</source>
+                <target>No archetypes match your filter.</target>
+                <note>Empty state on archetype catalog when filters yield no results</note>
             </trans-unit>
 
             <!-- Admin: User management -->

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -8,6 +8,11 @@
                 <target>Tableau de bord</target>
                 <note>Main navigation bar link</note>
             </trans-unit>
+            <trans-unit id="app.nav.archetypes">
+                <source>app.nav.archetypes</source>
+                <target>Archétypes</target>
+                <note>Main navigation bar link</note>
+            </trans-unit>
             <trans-unit id="app.nav.decks">
                 <source>app.nav.decks</source>
                 <target>Decks</target>
@@ -3116,6 +3121,48 @@
                 <source>app.archetype.browse_all_decks</source>
                 <target>Parcourir les %count% decks</target>
                 <note>CTA to see all decks with this archetype in catalog</note>
+            </trans-unit>
+
+            <!-- Archetype catalog (F2.16) -->
+            <trans-unit id="app.archetype.catalog_title">
+                <source>app.archetype.catalog_title</source>
+                <target>Archétypes</target>
+                <note>Public archetype catalog page title</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.filter_by_tag">
+                <source>app.archetype.filter_by_tag</source>
+                <target>Étiquette</target>
+                <note>Label for tag filter on archetype catalog</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.sort_by">
+                <source>app.archetype.sort_by</source>
+                <target>Trier par</target>
+                <note>Label for sort dropdown on archetype catalog</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.sort_name">
+                <source>app.archetype.sort_name</source>
+                <target>Nom</target>
+                <note>Sort option: alphabetical by name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.sort_decks">
+                <source>app.archetype.sort_decks</source>
+                <target>Plus de decks</target>
+                <note>Sort option: by number of available decks descending</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.results_count">
+                <source>app.archetype.results_count</source>
+                <target>%count% archétype trouvé|%count% archétypes trouvés</target>
+                <note>Result count on archetype catalog. %count% = number of archetypes</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.deck_count">
+                <source>app.archetype.deck_count</source>
+                <target>%count% deck|%count% decks</target>
+                <note>Deck count displayed on archetype catalog card. %count% = number of public decks</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.no_results">
+                <source>app.archetype.no_results</source>
+                <target>Aucun archétype ne correspond à votre filtre.</target>
+                <note>Empty state on archetype catalog when filters yield no results</note>
             </trans-unit>
 
             <!-- Admin: User management -->


### PR DESCRIPTION
## Summary
- New public page at `/archetypes` listing all published archetypes with sprites, playstyle tag badges, and deck counts
- **Multi-select tag filtering** with OR logic — clicking multiple tags shows archetypes matching any of them
- **Sorting** by name (default) or most decks
- **Navbar entry** "Archetypes" added before "Decks" for both authenticated and anonymous users
- Fixture tag normalization enforces title case via `mb_convert_case(MB_CASE_TITLE)`
- 12 new functional tests, 10 new translation keys (EN + FR)

## Test plan
- [x] Visit `/archetypes` — published archetypes with sprites, tags, and deck counts are displayed
- [x] Click a tag button — filters to archetypes matching that tag
- [x] Click multiple tag buttons — shows archetypes matching ANY selected tag (OR)
- [x] Click "All" — clears tag filter
- [x] Change sort to "Most decks" — archetypes reorder by deck count
- [x] Tag selection is preserved when changing sort
- [x] Each archetype card links to its detail page
- [x] Navbar shows "Archetypes" before "Decks" (both logged in and anonymous)
- [x] Test in FR locale — labels show "Archétypes", "Étiquette", etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)