### PR TITLE
:white_check_mark: Tests: improve coverage for notification and admin command

### DIFF
--- a/tests/Command/CreateAdminCommandTest.php
+++ b/tests/Command/CreateAdminCommandTest.php
@@ -129,6 +129,32 @@ final class CreateAdminCommandTest extends TestCase
         self::assertStringContainsString('Passwords do not match', $this->tester->getDisplay());
     }
 
+    public function testNotBlankRejectsEmptyString(): void
+    {
+        $method = new \ReflectionMethod(CreateAdminCommand::class, 'notBlank');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('cannot be blank');
+
+        $method->invoke(null, '');
+    }
+
+    public function testNotBlankRejectsNull(): void
+    {
+        $method = new \ReflectionMethod(CreateAdminCommand::class, 'notBlank');
+
+        $this->expectException(\RuntimeException::class);
+
+        $method->invoke(null, null);
+    }
+
+    public function testNotBlankReturnsValidString(): void
+    {
+        $method = new \ReflectionMethod(CreateAdminCommand::class, 'notBlank');
+
+        self::assertSame('hello', $method->invoke(null, 'hello'));
+    }
+
     public function testValidationErrorReturnsFailure(): void
     {
         $violation = new ConstraintViolation(

--- a/tests/Service/BorrowEmailPreferenceTest.php
+++ b/tests/Service/BorrowEmailPreferenceTest.php
@@ -87,6 +87,15 @@ class BorrowEmailPreferenceTest extends TestCase
         $this->service->sendBorrowApproved($borrow);
     }
 
+    public function testSendBorrowApprovedSendsWhenEmailEnabled(): void
+    {
+        $borrow = $this->createBorrow();
+
+        $this->mailer->expects(self::once())->method('send');
+
+        $this->service->sendBorrowApproved($borrow);
+    }
+
     public function testSendBorrowDeniedSkipsWhenEmailDisabled(): void
     {
         $borrow = $this->createBorrow();


### PR DESCRIPTION
## Summary

- Add `testSendBorrowApprovedSendsWhenEmailEnabled` — the enabled path for `sendBorrowApproved()` was untested (only the disabled/skip path had coverage)
- Add 3 unit tests for `CreateAdminCommand::notBlank()` — blank string, null, and valid string inputs via reflection
- Unit test count: 461 → 465

### Expected coverage impact
- `BorrowNotificationEmailService`: 83.33% → 100% method coverage
- `CreateAdminCommand`: 66.67% → 100% method coverage

## Test plan
- [x] `make cs-fix` — no style issues
- [x] `make phpstan` — Level 10, no errors
- [x] `make test.unit` — 465 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)