### PR TITLE
:bug: Fix: Dockerfile for serverless container deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,28 +75,41 @@ COPY . .
 # Install public assets (favicons, bundles, etc.)
 RUN php bin/console assets:install public --env=prod --no-debug
 
-# Remove dev files not needed in production
-RUN rm -rf tests/ .env.test .env.dev docker-compose.yml node_modules/ assets/ \
+# Remove dev files and .env (runtime env vars are injected by the container platform)
+RUN rm -rf tests/ .env .env.test .env.dev docker-compose.yml node_modules/ assets/ \
     webpack.config.js package.json package-lock.json .php-cs-fixer.dist.php \
-    phpstan.neon phpunit.xml.dist vitest.config.ts .eslintrc.js .stylelintrc.json
+    phpstan.neon phpunit.xml.dist vitest.config.ts .eslintrc.js .stylelintrc.json \
+    && printf '%s\n' \
+    'APP_ENV=prod' \
+    'APP_SECRET=change-me-at-runtime' \
+    'DEFAULT_URI=https://localhost' \
+    'DATABASE_URL=mysql://localhost/placeholder?serverVersion=8.0' \
+    'MAILER_DSN=null://null' \
+    'MESSENGER_WEBHOOK_SECRET=change-me' \
+    'MESSENGER_TRANSPORT_TRANSACTIONAL_EMAIL_DSN=sync://' \
+    'MESSENGER_TRANSPORT_DECK_ENRICHMENT_DSN=sync://' \
+    'MESSENGER_TRANSPORT_NOTIFICATION_DSN=sync://' \
+    'MESSENGER_TRANSPORT_BORROW_LIFECYCLE_DSN=sync://' \
+    'MESSENGER_TRANSPORT_FAILED_DSN=sync://' \
+    'MAIL_SENDER=noreply@localhost' \
+    'ADMIN_EMAIL=admin@localhost' \
+    > .env
 
 ENV APP_ENV=prod
-ENV APP_DEBUG=0
 ENV FRANKENPHP_CONFIG="worker ./public/index.php"
 ENV SERVER_NAME=":8080"
 
 # Ensure FrankenPHP data directories are writable
 RUN mkdir -p /data/caddy /config/caddy && chown -R www-data:www-data /data /config
 
-# Compile .env files for production (avoids parsing .env at runtime)
-COPY --from=composer /usr/bin/composer /usr/bin/composer
-RUN composer dump-env prod && rm /usr/bin/composer
+# Ensure var/ is writable by www-data for runtime cache compilation
+RUN mkdir -p /app/var/cache /app/var/log && chown -R www-data:www-data /app/var
 
-# Warm up Symfony cache with a dummy DATABASE_URL so the container can
-# compile without a real database connection. The actual DATABASE_URL is
-# provided at runtime via environment variables and overrides this.
-RUN DATABASE_URL="mysql://dummy:dummy@localhost/dummy?serverVersion=8.0" \
-    php bin/console cache:warmup --env=prod --no-debug
+# Startup script: clears and warms cache with actual runtime env vars
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile"]
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8080/health || exit 1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Clear and warm Symfony cache on startup with actual runtime env vars.
+# This ensures the compiled container matches the injected secrets.
+php bin/console cache:clear --env=prod --no-debug 2>/dev/null || true
+php bin/console cache:warmup --env=prod --no-debug
+
+# Execute the original FrankenPHP entrypoint
+exec "$@"


### PR DESCRIPTION
## Summary

Fix the Dockerfile so it works correctly on Scaleway Serverless Containers with runtime-injected environment variables.

- Replace dev `.env` with a minimal placeholder containing all required env var keys (actual values injected by the container platform at runtime)
- Remove `APP_DEBUG` from Docker `ENV` — controlled exclusively by platform env vars
- Remove `composer dump-env` and build-time `cache:warmup` — these baked dev values into the image, causing parameter resolution errors at runtime
- Add `docker-entrypoint.sh` that clears and warms the Symfony cache on cold start with actual runtime env vars
- Ensure `var/` is writable by `www-data` for runtime cache compilation

## Test plan
- [x] `docker buildx build --platform linux/amd64` — builds successfully
- [x] Deployed to Scaleway Serverless Containers
- [x] `GET /health` → `{"status":"ok"}`
- [x] `GET /health/ready` → healthy, DB latency 16ms
- [x] `GET /`, `/login`, `/deck` → 200
- [x] `make lint-yaml`, `make lint-container` — pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)