### PR TITLE
:bug: Fix: trust X-Forwarded-Host from CDN proxy

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -2,9 +2,12 @@
 framework:
     secret: '%env(APP_SECRET)%'
 
+    # Trust X-Forwarded-Host from the CDN proxy so Symfony generates
+    # URLs with the correct domain (not the container's internal hostname).
+    trusted_headers: ['x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port']
+
     # Note that the session will be started ONLY if you read or write from it.
     # Both dev and prod use database-backed sessions (via DATABASE_URL).
-    # Override SESSION_HANDLER_DSN in production for Redis: redis://host:port
     session:
         handler_id: '%env(DATABASE_URL)%'
 


### PR DESCRIPTION
## Summary

- Add `trusted_headers` config to `framework.yaml` to trust `X-Forwarded-Host` from Bunny CDN
- Fixes login redirect going to the Scaleway container internal hostname instead of `expandeddecks.app`

## Test plan
- [x] `make lint-yaml`, `make lint-container`, `make test.unit` — pass
- [x] Deployed to production: login redirect now goes to `https://expandeddecks.app/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)