### PR TITLE
:sparkles: Feature: technical admin dashboard

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -12,7 +12,8 @@ security:
         ROLE_ARCHETYPE_EDITOR: ROLE_USER
         ROLE_CMS_EDITOR: ROLE_USER
         ROLE_ORGANIZER: ROLE_USER
-        ROLE_ADMIN: [ROLE_ORGANIZER, ROLE_CMS_EDITOR, ROLE_ARCHETYPE_EDITOR]
+        ROLE_TECHNICAL_ADMIN: ROLE_USER
+        ROLE_ADMIN: [ROLE_ORGANIZER, ROLE_CMS_EDITOR, ROLE_ARCHETYPE_EDITOR, ROLE_TECHNICAL_ADMIN]
 
     firewalls:
         dev:
@@ -57,6 +58,7 @@ security:
         - { path: '^/event/\d+/results$', roles: PUBLIC_ACCESS }
         - { path: ^/health, roles: PUBLIC_ACCESS }
         - { path: ^/webhook/messenger/, roles: PUBLIC_ACCESS }
+        - { path: ^/admin/technical, roles: ROLE_TECHNICAL_ADMIN }
         - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/dashboard, roles: ROLE_USER }
         - { path: ^/deck, roles: ROLE_USER }

--- a/src/Controller/AdminTechnicalController.php
+++ b/src/Controller/AdminTechnicalController.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Message\EnrichDeckVersionMessage;
+use App\Repository\BannedCardRepository;
+use App\Repository\DeckVersionRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[Route('/admin/technical')]
+#[IsGranted('ROLE_TECHNICAL_ADMIN')]
+class AdminTechnicalController extends AbstractAppController
+{
+    public function __construct(
+        TranslatorInterface $translator,
+        private readonly DeckVersionRepository $deckVersionRepository,
+        private readonly BannedCardRepository $bannedCardRepository,
+        private readonly MessageBusInterface $messageBus,
+    ) {
+        parent::__construct($translator);
+    }
+
+    #[Route('', name: 'app_admin_technical_dashboard', methods: ['GET'])]
+    public function dashboard(): Response
+    {
+        $pendingEnrichments = $this->deckVersionRepository->findNotEnriched();
+        $bannedCardCount = $this->bannedCardRepository->count();
+
+        return $this->render('admin/technical/dashboard.html.twig', [
+            'pendingEnrichments' => $pendingEnrichments,
+            'bannedCardCount' => $bannedCardCount,
+        ]);
+    }
+
+    #[Route('/enrich-retry', name: 'app_admin_technical_enrich_retry', methods: ['POST'])]
+    public function enrichRetry(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('technical-enrich-retry', $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        $versions = $this->deckVersionRepository->findNotEnriched();
+
+        if ([] === $versions) {
+            $this->addFlash('info', 'app.admin.technical.enrich.none_pending');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        foreach ($versions as $version) {
+            /** @var int $id */
+            $id = $version->getId();
+            $this->messageBus->dispatch(new EnrichDeckVersionMessage($id));
+        }
+
+        $this->addFlash('success', 'app.admin.technical.enrich.dispatched', ['%count%' => \count($versions)]);
+
+        return $this->redirectToRoute('app_admin_technical_dashboard');
+    }
+
+    #[Route('/banned-cards-sync', name: 'app_admin_technical_banned_cards_sync', methods: ['POST'])]
+    public function bannedCardsSync(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('technical-banned-cards-sync', $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        $process = new Process(['symfony', 'console', 'app:banned-cards:sync'], $this->getParameter('kernel.project_dir'));
+        $process->setTimeout(60);
+        $process->run();
+
+        if ($process->isSuccessful()) {
+            $this->addFlash('success', 'app.admin.technical.banned_cards.synced');
+        } else {
+            $this->addFlash('danger', 'app.admin.technical.banned_cards.failed');
+        }
+
+        return $this->redirectToRoute('app_admin_technical_dashboard');
+    }
+}

--- a/src/Controller/AdminUserController.php
+++ b/src/Controller/AdminUserController.php
@@ -144,6 +144,6 @@ class AdminUserController extends AbstractAppController
      */
     private function getAssignableRoles(): array
     {
-        return ['ROLE_ADMIN', 'ROLE_ORGANIZER', 'ROLE_CMS_EDITOR', 'ROLE_ARCHETYPE_EDITOR'];
+        return ['ROLE_ADMIN', 'ROLE_ORGANIZER', 'ROLE_CMS_EDITOR', 'ROLE_ARCHETYPE_EDITOR', 'ROLE_TECHNICAL_ADMIN'];
     }
 }

--- a/templates/admin/technical/dashboard.html.twig
+++ b/templates/admin/technical/dashboard.html.twig
@@ -1,0 +1,85 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'app.admin.technical.title'|trans }} — Expanded Decks{% endblock %}
+
+{% block body %}
+    <h2 class="mb-4">{{ 'app.admin.technical.title'|trans }}</h2>
+
+    {# Deck enrichment card #}
+    <div class="card shadow-sm mb-3">
+        <div class="card-header card-header-themed">
+            <h5 class="mb-0">{{ 'app.admin.technical.enrich.title'|trans }}</h5>
+        </div>
+        <div class="card-body">
+            <p>{{ 'app.admin.technical.enrich.description'|trans }}</p>
+
+            {% if pendingEnrichments|length > 0 %}
+                <div class="alert alert-warning">
+                    {{ 'app.admin.technical.enrich.pending_count'|trans({'%count%': pendingEnrichments|length}) }}
+                </div>
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th>{{ 'app.admin.technical.enrich.table.deck'|trans }}</th>
+                            <th>{{ 'app.admin.technical.enrich.table.version'|trans }}</th>
+                            <th>{{ 'app.admin.technical.enrich.table.status'|trans }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for version in pendingEnrichments %}
+                            <tr>
+                                <td>{{ version.deck.name }}</td>
+                                <td>v{{ version.versionNumber }}</td>
+                                <td>
+                                    <span class="badge bg-{{ version.enrichmentStatus == 'failed' ? 'danger' : 'secondary' }}">
+                                        {{ version.enrichmentStatus }}
+                                    </span>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <form method="post" action="{{ path('app_admin_technical_enrich_retry') }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('technical-enrich-retry') }}">
+                    <button type="submit" class="btn btn-gold">
+                        {{ 'app.admin.technical.enrich.retry_button'|trans }}
+                    </button>
+                </form>
+            {% else %}
+                <div class="alert alert-success mb-0">
+                    {{ 'app.admin.technical.enrich.all_done'|trans }}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+
+    {# Banned cards sync card #}
+    <div class="card shadow-sm mb-3">
+        <div class="card-header card-header-themed">
+            <h5 class="mb-0">{{ 'app.admin.technical.banned_cards.title'|trans }}</h5>
+        </div>
+        <div class="card-body">
+            <p>{{ 'app.admin.technical.banned_cards.description'|trans }}</p>
+
+            <div class="mb-3">
+                {{ 'app.admin.technical.banned_cards.current_count'|trans({'%count%': bannedCardCount}) }}
+            </div>
+
+            <form method="post" action="{{ path('app_admin_technical_banned_cards_sync') }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('technical-banned-cards-sync') }}">
+                <button type="submit" class="btn btn-gold"
+                        onclick="return confirm('{{ 'app.admin.technical.banned_cards.confirm_sync'|trans|e('js') }}')">
+                    {{ 'app.admin.technical.banned_cards.sync_button'|trans }}
+                </button>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -87,6 +87,12 @@
                                         <li><a class="dropdown-item" href="{{ path('app_admin_user_list') }}">{{ 'app.nav.admin_users'|trans }}</a></li>
                                         <li><a class="dropdown-item" href="{{ path('app_admin_archetype_list') }}">{{ 'app.nav.admin_archetypes'|trans }}</a></li>
                                     {% endif %}
+                                    {% if is_granted('ROLE_TECHNICAL_ADMIN') %}
+                                        {% if not is_granted('ROLE_ADMIN') %}
+                                            <li><hr class="dropdown-divider"></li>
+                                        {% endif %}
+                                        <li><a class="dropdown-item" href="{{ path('app_admin_technical_dashboard') }}">{{ 'app.nav.admin_technical'|trans }}</a></li>
+                                    {% endif %}
                                     {% if is_granted('ROLE_CMS_EDITOR') %}
                                         {% if not is_granted('ROLE_ADMIN') %}
                                             <li><hr class="dropdown-divider"></li>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -3689,6 +3689,82 @@
                 <source>app.event.scope_staffing</source>
                 <target>My events</target>
             </trans-unit>
+            <trans-unit id="app.nav.admin_technical">
+                <source>app.nav.admin_technical</source>
+                <target>Technical</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.title">
+                <source>app.admin.technical.title</source>
+                <target>Technical Administration</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.title">
+                <source>app.admin.technical.enrich.title</source>
+                <target>Deck Enrichment</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.description">
+                <source>app.admin.technical.enrich.description</source>
+                <target>Redispatch enrichment messages for deck versions that are still pending or failed.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.pending_count">
+                <source>app.admin.technical.enrich.pending_count</source>
+                <target>%count% deck version(s) pending enrichment.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.table.deck">
+                <source>app.admin.technical.enrich.table.deck</source>
+                <target>Deck</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.table.version">
+                <source>app.admin.technical.enrich.table.version</source>
+                <target>Version</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.table.status">
+                <source>app.admin.technical.enrich.table.status</source>
+                <target>Status</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.retry_button">
+                <source>app.admin.technical.enrich.retry_button</source>
+                <target>Retry all enrichments</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.all_done">
+                <source>app.admin.technical.enrich.all_done</source>
+                <target>All deck versions are enriched.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.none_pending">
+                <source>app.admin.technical.enrich.none_pending</source>
+                <target>No deck versions need enrichment.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.dispatched">
+                <source>app.admin.technical.enrich.dispatched</source>
+                <target>%count% enrichment message(s) dispatched.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.title">
+                <source>app.admin.technical.banned_cards.title</source>
+                <target>Banned Cards Sync</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.description">
+                <source>app.admin.technical.banned_cards.description</source>
+                <target>Fetch the official Expanded banned card list from pokemon.com and sync it to the database.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.current_count">
+                <source>app.admin.technical.banned_cards.current_count</source>
+                <target>Currently %count% banned card(s) in database.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.sync_button">
+                <source>app.admin.technical.banned_cards.sync_button</source>
+                <target>Sync banned cards</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.confirm_sync">
+                <source>app.admin.technical.banned_cards.confirm_sync</source>
+                <target>This will fetch and sync the banned card list. Continue?</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.synced">
+                <source>app.admin.technical.banned_cards.synced</source>
+                <target>Banned cards synced successfully.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.failed">
+                <source>app.admin.technical.banned_cards.failed</source>
+                <target>Banned cards sync failed. Check the logs for details.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -3689,6 +3689,82 @@
                 <source>app.event.scope_staffing</source>
                 <target>Mes événements</target>
             </trans-unit>
+            <trans-unit id="app.nav.admin_technical">
+                <source>app.nav.admin_technical</source>
+                <target>Technique</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.title">
+                <source>app.admin.technical.title</source>
+                <target>Administration technique</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.title">
+                <source>app.admin.technical.enrich.title</source>
+                <target>Enrichissement des decks</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.description">
+                <source>app.admin.technical.enrich.description</source>
+                <target>Renvoyer les messages d'enrichissement pour les versions de deck en attente ou en erreur.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.pending_count">
+                <source>app.admin.technical.enrich.pending_count</source>
+                <target>%count% version(s) de deck en attente d'enrichissement.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.table.deck">
+                <source>app.admin.technical.enrich.table.deck</source>
+                <target>Deck</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.table.version">
+                <source>app.admin.technical.enrich.table.version</source>
+                <target>Version</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.table.status">
+                <source>app.admin.technical.enrich.table.status</source>
+                <target>Statut</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.retry_button">
+                <source>app.admin.technical.enrich.retry_button</source>
+                <target>Relancer tous les enrichissements</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.all_done">
+                <source>app.admin.technical.enrich.all_done</source>
+                <target>Toutes les versions de deck sont enrichies.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.none_pending">
+                <source>app.admin.technical.enrich.none_pending</source>
+                <target>Aucune version de deck n'a besoin d'enrichissement.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.enrich.dispatched">
+                <source>app.admin.technical.enrich.dispatched</source>
+                <target>%count% message(s) d'enrichissement envoyé(s).</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.title">
+                <source>app.admin.technical.banned_cards.title</source>
+                <target>Synchronisation des cartes bannies</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.description">
+                <source>app.admin.technical.banned_cards.description</source>
+                <target>Récupérer la liste officielle des cartes bannies en Expanded depuis pokemon.com et synchroniser la base de données.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.current_count">
+                <source>app.admin.technical.banned_cards.current_count</source>
+                <target>Actuellement %count% carte(s) bannie(s) en base de données.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.sync_button">
+                <source>app.admin.technical.banned_cards.sync_button</source>
+                <target>Synchroniser les cartes bannies</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.confirm_sync">
+                <source>app.admin.technical.banned_cards.confirm_sync</source>
+                <target>Cela va récupérer et synchroniser la liste des cartes bannies. Continuer ?</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.synced">
+                <source>app.admin.technical.banned_cards.synced</source>
+                <target>Cartes bannies synchronisées avec succès.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.banned_cards.failed">
+                <source>app.admin.technical.banned_cards.failed</source>
+                <target>La synchronisation des cartes bannies a échoué. Vérifiez les logs.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
## Summary
- Add `ROLE_TECHNICAL_ADMIN` role with dedicated access to `/admin/technical`
- Create `AdminTechnicalController` with dashboard, enrich-retry, and banned-cards-sync actions
- Dashboard shows pending/failed deck enrichments with a retry button (dispatches messages via Messenger)
- Dashboard shows banned card count with a sync button (runs `app:banned-cards:sync` command)
- Add navigation link in user dropdown menu (visible to `ROLE_TECHNICAL_ADMIN` holders)
- `ROLE_ADMIN` inherits `ROLE_TECHNICAL_ADMIN` automatically
- `ROLE_TECHNICAL_ADMIN` is assignable via the user management page
- All user-facing strings translated in EN and FR

## Test plan
- [ ] Assign `ROLE_TECHNICAL_ADMIN` to a non-admin user and verify they can access `/admin/technical` but not other admin pages
- [ ] Verify admin users see the "Technical" link in their dropdown menu
- [ ] Test the "Retry all enrichments" button with pending/failed deck versions
- [ ] Test the "Sync banned cards" button and verify it updates the count
- [ ] Verify CSRF protection on both POST actions
- [ ] Check FR locale renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)