### PR TITLE
:memo: Docs: add F9.6 archetype localization and content pages

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,31 @@
+# Expanded Decks
+
+## A shared deck library for the Pokemon TCG community
+
+Expanded Decks is a web application built for Pokemon TCG players and organizers who want to keep the Expanded format accessible and thriving. It serves as a shared library of physical decks — a place where community members can register their decks, browse what's available, and coordinate loans for tournaments and casual play.
+
+The philosophy behind the project is straightforward: building a competitive Expanded collection is expensive and time-consuming. Many players want to try the format, revisit classic archetypes, or simply play something different for a day — but they don't have the cards. Meanwhile, experienced collectors often have decks sitting in a box between events. Expanded Decks bridges that gap by giving communities a transparent, organized way to share their collections.
+
+The project is fully open-source and available on GitHub: [github.com/jbourdin/expandedDecks](https://github.com/jbourdin/expandedDecks)
+
+## For players
+
+The deck catalog is the heart of the application. Every registered deck has a full, versioned deck list imported from the standard PTCG text format — the same format you'd paste into PTCGO or Live. Card data is automatically enriched with images and metadata from TCGdex, so you can visually browse what each deck contains before deciding to borrow it.
+
+When an event is coming up, you can browse available decks by archetype, check what's not already spoken for, and submit a borrow request. The deck owner receives a notification and can approve or decline. Once both sides confirm the hand-off, the system tracks the loan until the deck is returned. If multiple people request the same deck for the same event, conflicting requests are handled automatically — no awkward back-and-forth needed.
+
+Deck owners can register as many decks as they like, update their lists when they make changes, and keep a full version history. If you swap out a tech card or rebuild a deck for a new metagame, the previous versions are still visible for reference.
+
+## For organizers
+
+Running an Expanded event means making sure players have decks to play with. Expanded Decks gives organizers a clear view of which decks are registered in the community library, which ones are available for a given event, and which ones are already committed to other players.
+
+You can create events, invite staff, and manage engagements. The borrow system integrates with the event calendar, so when an event is cancelled, outstanding borrows are automatically handled. Staff members can be assigned roles and permissions to help manage the logistics on the day.
+
+The application also supports label printing for physical deck boxes — either via home-printable PDF labels or professional Zebra thermal printers — so each deck can be quickly identified and scanned at check-in.
+
+## Built for the community
+
+Expanded Decks is available in English and French, with full translation support for adding more languages. It runs as a modern web application accessible from any device — phone, tablet, or desktop. There's no app to install; just open the site and start browsing.
+
+The project welcomes contributions from developers, translators, and anyone with ideas for making Expanded more accessible. Check out the repository, open an issue, or just come say hello.

--- a/content/about_fr.md
+++ b/content/about_fr.md
@@ -1,0 +1,31 @@
+# Expanded Decks
+
+## Une bibliothèque de decks partagée pour la communauté Pokemon TCG
+
+Expanded Decks est une application web pensée pour les joueurs et organisateurs de Pokemon TCG qui souhaitent rendre le format Expanded plus accessible et vivant. Elle fonctionne comme une bibliothèque partagée de decks physiques — un espace où les membres d'une communauté peuvent enregistrer leurs decks, consulter ceux qui sont disponibles et organiser des prêts pour les tournois ou le jeu libre.
+
+L'idée de départ est simple : se constituer une collection compétitive en Expanded, ça coûte cher et ça prend du temps. Beaucoup de joueurs aimeraient découvrir le format, rejouer d'anciens archétypes ou tout simplement essayer autre chose le temps d'une journée — mais ils n'ont pas les cartes. En parallèle, des collectionneurs expérimentés ont souvent des decks qui dorment dans un placard entre deux événements. Expanded Decks fait le lien en offrant aux communautés un moyen clair et organisé de partager leurs collections.
+
+Le projet est entièrement open-source et disponible sur GitHub : [github.com/jbourdin/expandedDecks](https://github.com/jbourdin/expandedDecks)
+
+## Pour les joueurs
+
+Le catalogue de decks est au cœur de l'application. Chaque deck enregistré dispose d'une liste complète et versionnée, importée depuis le format texte PTCG standard — le même que celui utilisé dans PTCGO ou Live. Les données des cartes sont automatiquement enrichies avec les images et métadonnées de TCGdex, ce qui permet de parcourir visuellement le contenu de chaque deck avant de décider de l'emprunter.
+
+À l'approche d'un événement, vous pouvez consulter les decks disponibles par archétype, vérifier lesquels ne sont pas encore réservés et soumettre une demande d'emprunt. Le propriétaire du deck reçoit une notification et peut accepter ou refuser. Une fois que les deux parties confirment la remise en main propre, le système suit le prêt jusqu'au retour du deck. Si plusieurs personnes demandent le même deck pour le même événement, les demandes concurrentes sont gérées automatiquement — pas besoin d'échanges interminables pour se mettre d'accord.
+
+Les propriétaires peuvent enregistrer autant de decks qu'ils le souhaitent, mettre à jour leurs listes quand ils font des changements et conserver un historique complet des versions. Si vous remplacez une tech ou reconstruisez un deck pour un nouveau métagame, les versions précédentes restent consultables.
+
+## Pour les organisateurs
+
+Organiser un événement Expanded, c'est aussi s'assurer que les joueurs auront des decks pour jouer. Expanded Decks offre aux organisateurs une vue claire des decks enregistrés dans la bibliothèque communautaire, de ceux qui sont disponibles pour un événement donné et de ceux qui sont déjà attribués à d'autres joueurs.
+
+Vous pouvez créer des événements, inviter du staff et gérer les inscriptions. Le système d'emprunt s'intègre au calendrier des événements : si un événement est annulé, les emprunts en cours sont automatiquement pris en charge. Les membres du staff peuvent se voir attribuer des rôles et des permissions pour aider à gérer la logistique le jour J.
+
+L'application prend également en charge l'impression d'étiquettes pour les boîtes de deck — soit via des étiquettes PDF imprimables à domicile, soit via des imprimantes thermiques Zebra — afin que chaque deck puisse être rapidement identifié et scanné à l'accueil.
+
+## Fait pour la communauté
+
+Expanded Decks est disponible en français et en anglais, avec une prise en charge complète de la traduction pour ajouter d'autres langues. C'est une application web moderne, accessible depuis n'importe quel appareil — téléphone, tablette ou ordinateur. Aucune application à installer : il suffit d'ouvrir le site et de commencer à naviguer.
+
+Le projet accueille volontiers les contributions de développeurs, traducteurs et de toute personne ayant des idées pour rendre l'Expanded plus accessible. N'hésitez pas à consulter le dépôt, ouvrir une issue ou simplement venir dire bonjour.

--- a/content/archetype_placeholder_en.md
+++ b/content/archetype_placeholder_en.md
@@ -1,0 +1,5 @@
+This archetype doesn't have a detailed description yet.
+
+Each archetype page can feature an in-depth breakdown — how the deck works, key cards and their roles, common matchups, tips for piloting it, and what makes it stand out in the Expanded format. Think of it as a mini-guide for anyone picking up the deck for the first time.
+
+Writing these takes someone who knows the deck well. If you've played this archetype and want to share what you've learned, we'd love your help. Reach out to contribute — even a few paragraphs make a big difference for players discovering the deck through the library.

--- a/content/archetype_placeholder_fr.md
+++ b/content/archetype_placeholder_fr.md
@@ -1,0 +1,5 @@
+Cet archétype n'a pas encore de description détaillée.
+
+Chaque page d'archétype peut accueillir une analyse complète — comment le deck fonctionne, les cartes clés et leur rôle, les match-ups courants, des conseils pour le piloter et ce qui le distingue dans le format Expanded. L'idée, c'est d'offrir un petit guide à toute personne qui découvre le deck via la bibliothèque.
+
+Rédiger ce genre de contenu demande quelqu'un qui connaît bien le deck. Si vous avez joué cet archétype et que vous souhaitez partager votre expérience, votre aide est la bienvenue. N'hésitez pas à nous contacter pour contribuer — même quelques paragraphes font une vraie différence pour les joueurs qui découvrent le deck.

--- a/content/news_beta_launch_en.md
+++ b/content/news_beta_launch_en.md
@@ -1,0 +1,57 @@
+# Expanded Decks is live — beta release
+
+We're excited to announce that Expanded Decks is now available online in its first public beta. After months of development, the application is deployed and ready for early adopters to try out.
+
+This is a beta release, which means things are still actively being developed, tested, and improved. We're putting it in your hands now because the core features are solid enough to be useful — but expect rough edges, ongoing changes, and the occasional bug.
+
+## What's available today
+
+The beta ships with a full set of features covering the three main pillars of the application: deck management, event coordination, and the borrow workflow.
+
+### Deck library
+
+You can register your decks, import deck lists by pasting the standard PTCG text format, and browse the community catalog. Card data is automatically enriched with images from TCGdex. Each deck is tied to an archetype — browse the archetype catalog to discover decks by playstyle, or filter the deck list by archetype directly.
+
+Deck lists are versioned: when you update a deck, the previous version is preserved and you can compare them side by side. Decks can be retired when they're no longer in active rotation, and reactivated later.
+
+### Events
+
+Create events, set dates and locations, manage staff roles, and track which players are engaged. The event system integrates tightly with the borrow workflow — players can request decks specifically for an event, and if an event is cancelled, related borrows are handled automatically.
+
+Event results can be published for the community to see.
+
+### Borrow workflow
+
+The full lending and borrowing lifecycle is in place: request a deck, get notified when the owner responds, confirm the hand-off, and track the return. Competing requests for the same deck are resolved automatically. The dashboard shows you at a glance what you need to act on — pending requests, borrows to return, events coming up.
+
+### Notifications and email
+
+In-app notifications keep you informed about borrow requests, approvals, and event updates. Transactional emails are sent for critical actions like password resets and account verification.
+
+### CMS pages
+
+Organizers and editors can publish content pages with a simple CMS — useful for rules, guidelines, or community announcements. Pages are organized into menu categories and support both English and French.
+
+### Internationalization
+
+The entire application is available in English and French. User preferences are respected for both the UI language and email communications.
+
+## What's coming next
+
+The beta covers the essential workflows, but there's more on the roadmap. Here's a glimpse of what we're working toward:
+
+- **PDF labels and camera scanning** — generate printable labels with QR codes for your deck boxes, and scan them with your phone camera to quickly identify decks at events.
+- **Zebra label printing** — for communities that want professional thermal labels, with USB barcode scanner support for high-throughput check-in.
+- **Bookmarks and overdue tracking** — bookmark your favorite decks, events, and archetypes. Get reminders when a borrowed deck is overdue.
+- **iCal feeds** — sync events to your calendar app.
+- **Visual deck lists** — a card mosaic view as an alternative to the text-based list.
+- **Play! Pokemon QR integration** — scan player QR codes for quick identification.
+- **Multi-factor authentication** — TOTP-based MFA for accounts that want extra security.
+
+## Work in progress
+
+This is a living project. Features are being added, existing ones are being refined, and we're actively testing in real conditions. If you encounter a bug, have a suggestion, or want to contribute, the project is open-source on GitHub:
+
+[github.com/jbourdin/expandedDecks](https://github.com/jbourdin/expandedDecks)
+
+Your feedback during this beta phase is invaluable — it shapes what gets prioritized and how the tool evolves. Thanks for being part of this.

--- a/content/news_beta_launch_fr.md
+++ b/content/news_beta_launch_fr.md
@@ -1,0 +1,57 @@
+# Expanded Decks est en ligne — version bêta
+
+Nous avons le plaisir d'annoncer qu'Expanded Decks est désormais accessible en ligne dans sa première version bêta publique. Après plusieurs mois de développement, l'application est déployée et prête à être utilisée par les premiers utilisateurs.
+
+Il s'agit d'une version bêta, ce qui signifie que le développement, les tests et les améliorations sont toujours en cours. Si nous la mettons entre vos mains dès maintenant, c'est parce que les fonctionnalités essentielles sont suffisamment abouties pour être utiles — mais attendez-vous à quelques aspérités, des évolutions régulières et un bug de temps en temps.
+
+## Ce qui est disponible aujourd'hui
+
+La bêta embarque un ensemble complet de fonctionnalités couvrant les trois piliers de l'application : la gestion des decks, la coordination des événements et le circuit d'emprunt.
+
+### Bibliothèque de decks
+
+Vous pouvez enregistrer vos decks, importer vos listes en collant le format texte PTCG standard et parcourir le catalogue communautaire. Les données des cartes sont automatiquement enrichies avec les images de TCGdex. Chaque deck est rattaché à un archétype — explorez le catalogue d'archétypes pour découvrir des decks par style de jeu, ou filtrez directement la liste par archétype.
+
+Les listes de decks sont versionnées : lorsque vous mettez à jour un deck, la version précédente est conservée et vous pouvez les comparer côte à côte. Les decks peuvent être retirés quand ils ne sont plus en rotation active, puis réactivés plus tard.
+
+### Événements
+
+Créez des événements, définissez les dates et lieux, gérez les rôles du staff et suivez les joueurs inscrits. Le système d'événements s'intègre étroitement au circuit d'emprunt — les joueurs peuvent demander un deck spécifiquement pour un événement, et si celui-ci est annulé, les emprunts associés sont pris en charge automatiquement.
+
+Les résultats des événements peuvent être publiés pour la communauté.
+
+### Circuit d'emprunt
+
+L'ensemble du cycle de prêt et d'emprunt est en place : demander un deck, être notifié de la réponse du propriétaire, confirmer la remise en main propre et suivre le retour. Les demandes concurrentes sur un même deck sont résolues automatiquement. Le tableau de bord vous montre en un coup d'œil ce qui nécessite votre attention — demandes en attente, decks à rendre, événements à venir.
+
+### Notifications et emails
+
+Les notifications intégrées vous tiennent informé des demandes d'emprunt, des acceptations et des mises à jour d'événements. Des emails transactionnels sont envoyés pour les actions critiques comme la réinitialisation du mot de passe et la vérification de compte.
+
+### Pages CMS
+
+Les organisateurs et éditeurs peuvent publier des pages de contenu via un CMS simple — utile pour les règlements, les consignes ou les annonces communautaires. Les pages sont organisées en catégories de menu et disponibles en français et en anglais.
+
+### Internationalisation
+
+L'intégralité de l'application est disponible en français et en anglais. Les préférences de chaque utilisateur sont respectées tant pour la langue de l'interface que pour les communications par email.
+
+## Ce qui arrive ensuite
+
+La bêta couvre les flux essentiels, mais la feuille de route prévoit encore beaucoup de choses. Voici un aperçu de ce qui est en préparation :
+
+- **Étiquettes PDF et scan par caméra** — générez des étiquettes imprimables avec QR code pour vos boîtes de deck, et scannez-les avec l'appareil photo de votre téléphone pour identifier rapidement un deck lors d'un événement.
+- **Impression d'étiquettes Zebra** — pour les communautés qui souhaitent des étiquettes thermiques professionnelles, avec prise en charge des lecteurs de codes-barres USB pour un enregistrement rapide.
+- **Favoris et suivi des retards** — mettez en favori vos decks, événements et archétypes préférés. Recevez des rappels quand un deck emprunté est en retard.
+- **Flux iCal** — synchronisez les événements avec votre application de calendrier.
+- **Listes visuelles** — une vue mosaïque de cartes comme alternative à la liste textuelle.
+- **Intégration QR Play! Pokemon** — scannez les QR codes des joueurs pour une identification rapide.
+- **Authentification multi-facteur** — MFA basée sur TOTP pour les comptes souhaitant une sécurité renforcée.
+
+## Un projet en mouvement
+
+C'est un projet vivant. Des fonctionnalités sont ajoutées, les existantes sont affinées, et nous testons activement en conditions réelles. Si vous rencontrez un bug, avez une suggestion ou souhaitez contribuer, le projet est open-source sur GitHub :
+
+[github.com/jbourdin/expandedDecks](https://github.com/jbourdin/expandedDecks)
+
+Vos retours pendant cette phase bêta sont précieux — ils orientent les priorités et l'évolution de l'outil. Merci de faire partie de l'aventure.

--- a/docs/features.md
+++ b/docs/features.md
@@ -173,6 +173,7 @@ Both email (via Symfony Mailer + Messenger async transport) and in-app (stored i
 | F9.3   | Application translation              | Medium   | Symfony Translation component (YAML catalogues) for backend strings and `react-i18next` (JSON catalogues) for frontend strings. Initial languages: `en`, `fr`. Dot-notation keys (e.g. `app.deck.status.available`). All user-facing strings wrapped in translation calls (`trans()` / `t()`). |
 | F9.4   | UTC datetime storage                 | High     | All database datetimes stored in **UTC**. Event dates are displayed in the event's `timezone` field (see [Event model](models/event.md)). When the user's timezone differs from the event's timezone, a user-relative hint is shown — e.g. "10:00 CET (16:00 your time)". Borrow and notification timestamps displayed in the user's timezone (F9.2). |
 | F9.5   | Weblate integration                  | Low      | Cloud-hosted Weblate instance for collaborative editing of translation files (XLIFF catalogues). Translators edit via Weblate web UI; changes sync back to the repository via automated PRs. |
+| F9.6   | Archetype localization               | Medium   | Archetype names and Markdown descriptions are translatable per locale. The `Archetype` entity stores locale-specific content (name, description) so that the archetype catalog, detail pages, and deck labels display in the user's preferred language. Admin form allows editing content for each supported locale. Falls back to the default locale when a translation is missing. |
 
 ## F11 — CMS Content Pages
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,10 +74,11 @@ F14.1, F14.2, F14.3, F14.4, F14.5, F14.6
 | F13.1 | Bookmark a deck                         | Low      | F2.4             |
 | F13.2 | Bookmark an event                       | Low      | F3.2             |
 | F13.3 | Bookmark an archetype                   | Low      | F2.16            |
+| F9.6  | Archetype localization                  | Medium   | F2.6, F9.3       |
 
-**Progress: 0/6 done**
+**Progress: 0/7 done**
 
-**Deliverable:** Overdue tracking with automated reminders, bookmarks for quick access to decks/events/archetypes, registered decks aggregate view for organizers, and a visual card mosaic alternative for deck lists.
+**Deliverable:** Overdue tracking with automated reminders, bookmarks for quick access to decks/events/archetypes, registered decks aggregate view for organizers, a visual card mosaic alternative for deck lists, and localized archetype names and descriptions.
 
 ---
 
@@ -198,13 +199,13 @@ F14.1, F14.2, F14.3, F14.4, F14.5, F14.6
 | Phase | Name                            | Features | Target       |
 |-------|---------------------------------|----------|--------------|
 | 0     | Deployment Readiness            | 6 (Done) | 1.0.0-beta.2 |
-| A     | UX Polish & Overdue Tracking    | 6        |              |
+| A     | UX Polish & Overdue Tracking    | 7        |              |
 | B     | Event Enrichment                | 4        |              |
 | C     | PDF Labels & Camera Scanning    | 2        |              |
 | D     | Zebra Labels & HID Scanning     | 5        |              |
 | E     | Auth Hardening & Delegation     | 4        |              |
 | F     | Play Pokemon QR Integration     | 3        |              |
 | G     | Operational Excellence          | 4        |              |
-|       | **Total remaining**             | **28**   |              |
+|       | **Total remaining**             | **29**   |              |
 
-81 features done · 28 remaining.
+81 features done · 29 remaining.


### PR DESCRIPTION
## Summary
- Add **F9.6 — Archetype localization** to feature list and roadmap (Phase A, medium priority)
- Add content drafts in `content/` directory:
  - About page (EN + FR) — project overview for CMS publication
  - Beta launch news (EN + FR) — announcement of the first live version
  - Archetype placeholder description (EN + FR) — call for contributors
- Update roadmap counts (Phase A: 6 → 7, total remaining: 28 → 29)

## Test plan
- [ ] Verify feature description in `docs/features.md` is consistent with existing F9.x entries
- [ ] Verify roadmap counts are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)