### PR TITLE
fix: update Sentry monolog handler for sentry-symfony 5.x

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -48,9 +48,9 @@ when@prod:
                 level: debug
                 formatter: monolog.formatter.json
             sentry:
-                type: sentry
+                type: service
+                id: Sentry\Monolog\Handler
                 level: error
-                hub_id: Sentry\State\HubInterface
             console:
                 type: console
                 process_psr_3_messages: false

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,3 +29,8 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+    Sentry\Monolog\Handler:
+        arguments:
+            $hub: '@Sentry\State\HubInterface'
+            $level: !php/const Monolog\Level::Error


### PR DESCRIPTION
## Summary
- Remove deprecated `type: sentry` and `hub_id` monolog handler config that was removed in sentry-symfony 5.x
- Register `Sentry\Monolog\Handler` as an explicit service in `services.yaml`
- Reference it via `type: service` in the monolog production config

## Test plan
- [x] Docker image builds successfully with this change
- [ ] Verify Sentry error reporting works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)