### PR TITLE
feat: enable Sentry structured logs

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -51,6 +51,9 @@ when@prod:
                 type: service
                 id: Sentry\Monolog\Handler
                 level: error
+            sentry_logs:
+                type: service
+                id: Sentry\SentryBundle\Monolog\LogsHandler
             console:
                 type: console
                 process_psr_3_messages: false

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -7,6 +7,7 @@ sentry:
         environment: '%kernel.environment%'
         send_default_pii: false
         traces_sample_rate: '%env(float:SENTRY_TRACES_SAMPLE_RATE)%'
+        enable_logs: true
 
 when@dev:
     sentry:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -34,3 +34,7 @@ services:
         arguments:
             $hub: '@Sentry\State\HubInterface'
             $level: !php/const Monolog\Level::Error
+
+    Sentry\SentryBundle\Monolog\LogsHandler:
+        arguments:
+            - !php/const Monolog\Level::Info


### PR DESCRIPTION
## Summary
- Enable Sentry Logs to send application logs (INFO+) alongside errors and traces
- Register `Sentry\SentryBundle\Monolog\LogsHandler` service in `services.yaml`
- Add `sentry_logs` monolog handler in prod config
- 5 GB/month included free, $0.50/GB beyond that

## Test plan
- [x] Docker image builds successfully
- [ ] Deploy and verify logs appear in Sentry Logs UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)