### PR TITLE
:bug: Fix: remove ambiguous route default from favicon redirect

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -8,6 +8,5 @@ app_favicon_redirect:
     path: /favicon.ico
     controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
     defaults:
-        route: ''
         path: /favicon.svg
         permanent: true


### PR DESCRIPTION
## Summary
- Remove empty `route: ''` default from the favicon redirect route config — it conflicted with the `path` default, causing a `RuntimeException` in `RedirectController`

## Test plan
- [ ] Verify `/favicon.ico` returns a 301 redirect to `/favicon.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)