### PR TITLE
:wrench: Chore: make Sentry logs action level configurable

### DIFF
--- a/.env
+++ b/.env
@@ -75,4 +75,7 @@ APP_VERSION=dev
 SENTRY_DSN=
 # Performance tracing sample rate (0.0 = disabled, 1.0 = 100%).
 SENTRY_TRACES_SAMPLE_RATE=0
+# Minimum level that triggers the Sentry Logs fingers_crossed handler (error, info, debug…).
+# Lowering to "info" makes all logs visible in Sentry even without an error.
+SENTRY_LOGS_ACTION_LEVEL=error
 ###< sentry/sentry-symfony ###

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -62,7 +62,7 @@ when@prod:
                 level: error
             sentry_logs_fingers:
                 type: fingers_crossed
-                action_level: error
+                action_level: '%env(SENTRY_LOGS_ACTION_LEVEL)%'
                 handler: sentry_logs
                 excluded_http_codes: [400, 401, 403, 404, 405, 409, 410, 422, 429]
             sentry_logs:


### PR DESCRIPTION
## Summary
- Add `SENTRY_LOGS_ACTION_LEVEL` env var (defaults to `error`) to control the Sentry logs `fingers_crossed` handler threshold
- Replace hardcoded `action_level: error` in `monolog.yaml` with the new env var, allowing runtime configuration (e.g. set to `info` to send all logs to Sentry)

## Test plan
- [ ] Verify default behavior unchanged (`error` level triggers Sentry logs)
- [ ] Set `SENTRY_LOGS_ACTION_LEVEL=info` and verify info-level logs appear in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)