### PR TITLE
:wrench: Config: add GitHub link to footer

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -163,7 +163,9 @@
         <footer class="footer-pokemon py-3 mt-auto">
             <div class="container text-center">
                 &copy; {{ "now"|date("Y") }} {{ 'app.footer.copyright'|trans }}
-                <span class="ms-2" style="font-size: 0.75rem; opacity: 0.5;">{{ app_version }}</span>
+                <span class="ms-2" style="font-size: 0.75rem;">{{ app_version }}</span>
+                <span class="ms-2">·</span>
+                <a href="https://github.com/jbourdin/expandedDecks" class="ms-1" target="_blank" rel="noopener">GitHub</a>
             </div>
         </footer>
 


### PR DESCRIPTION
## Summary
- Add a link to the public GitHub repository (`https://github.com/jbourdin/expandedDecks`) in the page footer
- Remove `opacity: 0.5` from the version number so it matches the rest of the footer text (keep smaller font size only)
- Footer now reads: `© 2026 Copyright · v1.0.0-beta.8 · GitHub`

## Test plan
- [ ] Verify footer displays version number without reduced opacity
- [ ] Verify GitHub link opens the correct repository in a new tab
- [ ] Verify link hover color matches existing footer link style (gold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)