### PR TITLE
:bug: fix: handle race condition in expandPrintings

### DIFF
--- a/src/Service/CardIdentity/CardIdentityResolver.php
+++ b/src/Service/CardIdentity/CardIdentityResolver.php
@@ -67,6 +67,8 @@ class CardIdentityResolver
     {
         $allPrintings = $this->apiClient->findAllPrintingsByName($identity->getName());
 
+        $newPrintings = [];
+
         foreach ($allPrintings as $tcgdexCard) {
             if ('' === $tcgdexCard->id) {
                 continue;
@@ -94,9 +96,22 @@ class CardIdentityResolver
 
             $printing = $this->createPrinting($identity, $tcgdexCard);
             $this->entityManager->persist($printing);
+            $newPrintings[] = $printing;
         }
 
-        $this->entityManager->flush();
+        if ([] === $newPrintings) {
+            return;
+        }
+
+        try {
+            $this->entityManager->flush();
+        } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException) {
+            // Race condition: another worker already inserted some of these printings.
+            // Detach the failed entities and continue — the data is already in the DB.
+            foreach ($newPrintings as $printing) {
+                $this->entityManager->detach($printing);
+            }
+        }
     }
 
     private function findOrCreateIdentity(TcgdexCard $tcgdexCard): CardIdentity


### PR DESCRIPTION
## Summary
- Fixes [EXPANDEDDECKS-E](https://expandeddecks.sentry.io/issues/EXPANDEDDECKS-E) — `UniqueConstraintViolationException` on `card_printing.uniq_tcgdex_id` for `A3a-067`
- Two concurrent Messenger workers (GenerateMinifiedMosaic + GenerateMinifiedList) both call `expandPrintings()` for the same card identity simultaneously, both pass the `findByTcgdexId` check (null), both try to insert the same tcgdexId → one crashes
- Fix: catch `UniqueConstraintViolationException` on flush and detach failed entities — the data is already in the DB from the other worker

## Test plan
- [ ] Flush enrichment and verify no crash during concurrent mosaic/minified generation
- [ ] Verify card printings are correctly populated after enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)