### PR TITLE
:sparkles: Feature: Cardmarket wishlist export (F6.11)

### DIFF
--- a/assets/components/DeckCardList.tsx
+++ b/assets/components/DeckCardList.tsx
@@ -12,6 +12,7 @@
  * @see docs/features.md F6.7 — Export deck list as PTCGL text
  * @see docs/features.md F6.8 — Minified deck list export
  * @see docs/features.md F6.6b — Minified mosaic
+ * @see docs/features.md F6.11 — Export deck list for Cardmarket wishlist
  */
 
 import React, { useCallback, useMemo, useRef, useState } from 'react';
@@ -25,7 +26,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
-import { IconCopy, IconCheck, IconShare } from '@tabler/icons-react';
+import { IconCopy, IconCheck, IconShare, IconShoppingCart } from '@tabler/icons-react';
 
 interface CardData {
     cardName: string;
@@ -54,6 +55,8 @@ interface Labels {
     tableSet: string;
     nameMatchWarningTitle: string;
     nameMatchWarningBody: string;
+    copyCardmarket: string;
+    copyCardmarketTooltip: string;
 }
 
 export interface DeckCardListProps {
@@ -63,6 +66,7 @@ export interface DeckCardListProps {
     minifiedMosaicUrl: string | null;
     rawList: string;
     minifiedList: string | null;
+    cardmarketWishlist: string | null;
     deckName: string;
     labels: Labels;
 }
@@ -184,6 +188,7 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
     minifiedMosaicUrl,
     rawList,
     minifiedList,
+    cardmarketWishlist,
     labels,
 }) => {
     const hasMinified = Object.keys(minifiedCards).length > 0 || minifiedList !== null;
@@ -194,8 +199,10 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
     const [variant, setVariant] = useState<Variant>(hasMinified ? 'minified' : 'original');
     const [viewMode, setViewMode] = useState<ViewMode>(hasMosaic ? 'mosaic' : 'table');
     const [copied, setCopied] = useState(false);
+    const [cardmarketCopied, setCardmarketCopied] = useState(false);
     const [mosaicModalOpen, setMosaicModalOpen] = useState(false);
     const copyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const cardmarketCopyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const activeCards = variant === 'minified' && Object.keys(minifiedCards).length > 0
         ? minifiedCards
@@ -224,6 +231,22 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
             copyTimeout.current = setTimeout(() => setCopied(false), 2000);
         });
     }, [activeList]);
+
+    const handleCopyCardmarket = useCallback(() => {
+        if (!cardmarketWishlist) {
+            return;
+        }
+
+        navigator.clipboard.writeText(cardmarketWishlist.trim()).then(() => {
+            setCardmarketCopied(true);
+
+            if (cardmarketCopyTimeout.current) {
+                clearTimeout(cardmarketCopyTimeout.current);
+            }
+
+            cardmarketCopyTimeout.current = setTimeout(() => setCardmarketCopied(false), 2000);
+        });
+    }, [cardmarketWishlist]);
 
     const handleShareMosaic = useCallback(async () => {
         if (!activeMosaicUrl) {
@@ -318,7 +341,19 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
                             </ActionIcon>
                         </Tooltip>
                     )}
-                    {copied && (
+                    {cardmarketWishlist && (
+                        <Tooltip label={cardmarketCopied ? labels.copied : labels.copyCardmarketTooltip}>
+                            <ActionIcon
+                                variant="subtle"
+                                color={cardmarketCopied ? 'green' : 'gray'}
+                                onClick={handleCopyCardmarket}
+                                size="lg"
+                            >
+                                {cardmarketCopied ? <IconCheck size={18} /> : <IconShoppingCart size={18} />}
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+                    {(copied || cardmarketCopied) && (
                         <Text size="sm" c="green">
                             {labels.copied}
                         </Text>

--- a/assets/deck-card-list.tsx
+++ b/assets/deck-card-list.tsx
@@ -11,6 +11,7 @@
  * @see docs/features.md F6.6 — Visual deck list (card mosaic)
  * @see docs/features.md F6.7 — Export deck list as PTCGL text
  * @see docs/features.md F6.8 — Minified deck list export
+ * @see docs/features.md F6.11 — Export deck list for Cardmarket wishlist
  */
 
 import React from 'react';
@@ -44,6 +45,8 @@ if (root) {
         tableSet: root.dataset.labelTableSet ?? 'Set',
         nameMatchWarningTitle: root.dataset.labelNameMatchWarningTitle ?? '',
         nameMatchWarningBody: root.dataset.labelNameMatchWarningBody ?? '',
+        copyCardmarket: root.dataset.labelCopyCardmarket ?? 'Copy for Cardmarket',
+        copyCardmarketTooltip: root.dataset.labelCopyCardmarketTooltip ?? 'Copy card list for Cardmarket wishlist import (basic energies excluded)',
     };
 
     createRoot(root).render(
@@ -55,6 +58,7 @@ if (root) {
                 minifiedMosaicUrl={root.dataset.minifiedMosaicUrl ?? null}
                 rawList={root.dataset.rawList ?? ''}
                 minifiedList={root.dataset.minifiedList ?? null}
+                cardmarketWishlist={root.dataset.cardmarketWishlist || null}
                 deckName={root.dataset.deckName ?? ''}
                 labels={labels}
             />

--- a/migrations/Version20260322085653.php
+++ b/migrations/Version20260322085653.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260322085653 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add show_cardmarket_export preference to user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `user` ADD show_cardmarket_export TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `user` DROP show_cardmarket_export');
+    }
+}

--- a/src/Controller/DeckShowController.php
+++ b/src/Controller/DeckShowController.php
@@ -22,6 +22,7 @@ use App\Repository\BorrowRepository;
 use App\Repository\EventDeckEntryRepository;
 use App\Repository\EventDeckRegistrationRepository;
 use App\Repository\EventRepository;
+use App\Service\DeckList\CardmarketWishlistFormatter;
 use App\Service\DeckList\MinifiedCardViewBuilder;
 use App\Service\DeckList\OriginalListFormatter;
 use App\Service\Label\PdfLabelGenerator;
@@ -50,6 +51,7 @@ class DeckShowController extends AbstractController
         EventDeckRegistrationRepository $eventDeckRegistrationRepository,
         MinifiedCardViewBuilder $minifiedCardViewBuilder,
         OriginalListFormatter $originalListFormatter,
+        CardmarketWishlistFormatter $cardmarketWishlistFormatter,
     ): Response {
         /** @var User|null $user */
         $user = $this->getUser();
@@ -181,11 +183,17 @@ class DeckShowController extends AbstractController
             ? $originalListFormatter->format($currentVersion)
             : '';
 
+        $showCardmarketExport = $user instanceof User && $user->isShowCardmarketExport();
+        $cardmarketWishlist = $showCardmarketExport && null !== $currentVersion && null !== $currentVersion->getMinifiedList()
+            ? $cardmarketWishlistFormatter->format($currentVersion)
+            : null;
+
         return $this->render('deck/show.html.twig', [
             'deck' => $deck,
             'groupedCards' => $orderedGroups,
             'minifiedGroupedCards' => $minifiedGroupedCards,
             'formattedOriginalList' => $formattedOriginalList,
+            'cardmarketWishlist' => $cardmarketWishlist,
             'isOwner' => $isOwner,
             'deckBorrows' => $deckBorrows,
             'totalBorrowCount' => $totalBorrowCount,

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -120,6 +120,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $notificationPreferences = null;
 
+    #[ORM\Column(options: ['default' => false])]
+    private bool $showCardmarketExport = false;
+
     /** @var Collection<int, Deck> */
     #[ORM\OneToMany(targetEntity: Deck::class, mappedBy: 'owner')]
     private Collection $ownedDecks;
@@ -548,6 +551,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setNotificationPreferences(?array $notificationPreferences): static
     {
         $this->notificationPreferences = $notificationPreferences;
+
+        return $this;
+    }
+
+    public function isShowCardmarketExport(): bool
+    {
+        return $this->showCardmarketExport;
+    }
+
+    public function setShowCardmarketExport(bool $showCardmarketExport): static
+    {
+        $this->showCardmarketExport = $showCardmarketExport;
 
         return $this;
     }

--- a/src/Form/ProfileFormType.php
+++ b/src/Form/ProfileFormType.php
@@ -15,6 +15,7 @@ namespace App\Form;
 
 use App\Entity\User;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
@@ -53,6 +54,10 @@ class ProfileFormType extends AbstractType
             ])
             ->add('timezone', TimezoneType::class, [
                 'label' => 'app.form.label.timezone',
+            ])
+            ->add('showCardmarketExport', CheckboxType::class, [
+                'label' => 'app.form.label.show_cardmarket_export',
+                'required' => false,
             ]);
     }
 

--- a/src/Service/DeckList/CardmarketExpansionNameMapper.php
+++ b/src/Service/DeckList/CardmarketExpansionNameMapper.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\DeckList;
+
+/**
+ * Maps PTCG set codes to Cardmarket expansion names.
+ *
+ * Cardmarket's "Add Decklist to Wants" textarea expects the full English
+ * expansion name (e.g. "Brilliant Stars"), not the abbreviated PTCG code
+ * (e.g. "BRS"). This service provides the mapping for all Expanded-legal sets.
+ *
+ * @see docs/features.md F6.11 — Export deck list for Cardmarket wishlist
+ */
+class CardmarketExpansionNameMapper
+{
+    /**
+     * PTCG set code → Cardmarket expansion name.
+     *
+     * Covers all sets from Black & White (BLW, 2011) onward,
+     * including promo and special sets encountered in the card database.
+     *
+     * @var array<string, string>
+     */
+    private const array PTCG_CODE_TO_EXPANSION_NAME = [
+        // Black & White era
+        'BLW' => 'Black & White',
+        'EPO' => 'Emerging Powers',
+        'NVI' => 'Noble Victories',
+        'NXD' => 'Next Destinies',
+        'DEX' => 'Dark Explorers',
+        'DRV' => 'Dragon Vault',
+        'BCR' => 'Boundaries Crossed',
+        'PLS' => 'Plasma Storm',
+        'PLF' => 'Plasma Freeze',
+        'PLB' => 'Plasma Blast',
+        'LTR' => 'Legendary Treasures',
+
+        // XY era
+        'XY' => 'XY',
+        'FLF' => 'Flashfire',
+        'FFI' => 'Furious Fists',
+        'PHF' => 'Phantom Forces',
+        'PRC' => 'Primal Clash',
+        'ROS' => 'Roaring Skies',
+        'AOR' => 'Ancient Origins',
+        'BKT' => 'BREAKthrough',
+        'BKP' => 'BREAKpoint',
+        'FCO' => 'Fates Collide',
+        'STS' => 'Steam Siege',
+        'EVO' => 'Evolutions',
+        'GEN' => 'Generations',
+
+        // Sun & Moon era
+        'SUM' => 'Sun & Moon',
+        'GRI' => 'Guardians Rising',
+        'BUS' => 'Burning Shadows',
+        'SLG' => 'Shining Legends',
+        'CIN' => 'Crimson Invasion',
+        'UPR' => 'Ultra Prism',
+        'FLI' => 'Forbidden Light',
+        'CES' => 'Celestial Storm',
+        'LOT' => 'Lost Thunder',
+        'TEU' => 'Team Up',
+        'UNB' => 'Unbroken Bonds',
+        'UNM' => 'Unified Minds',
+        'HIF' => 'Hidden Fates',
+        'CEC' => 'Cosmic Eclipse',
+        'PR-SM' => 'SM Black Star Promos',
+
+        // Sword & Shield era
+        'SSH' => 'Sword & Shield',
+        'RCL' => 'Rebel Clash',
+        'DAA' => 'Darkness Ablaze',
+        'CPA' => "Champion's Path",
+        'VIV' => 'Vivid Voltage',
+        'SHF' => 'Shining Fates',
+        'BST' => 'Battle Styles',
+        'CRE' => 'Chilling Reign',
+        'EVS' => 'Evolving Skies',
+        'CEL' => 'Celebrations',
+        'FST' => 'Fusion Strike',
+        'BRS' => 'Brilliant Stars',
+        'ASR' => 'Astral Radiance',
+        'PGO' => 'Pokémon GO',
+        'LOR' => 'Lost Origin',
+        'SIT' => 'Silver Tempest',
+        'CRZ' => 'Crown Zenith',
+        'PR-SW' => 'SWSH Black Star Promos',
+
+        // Scarlet & Violet era
+        'SVI' => 'Scarlet & Violet',
+        'PAL' => 'Paldea Evolved',
+        'MEG' => '151',
+        'OBF' => 'Obsidian Flames',
+        'PAR' => 'Paradox Rift',
+        'PAF' => 'Paldean Fates',
+        'TEF' => 'Temporal Forces',
+        'TWM' => 'Twilight Masquerade',
+        'SFA' => 'Shrouded Fable',
+        'SCR' => 'Stellar Crown',
+        'SSP' => 'Surging Sparks',
+        'PRE' => 'Prismatic Evolutions',
+        'JTG' => 'Journey Together',
+        'PR-SV' => 'SV Black Star Promos',
+
+        // Special / compilation sets
+        'KSS' => 'Kangaskhan-GX Box',
+        'ASC' => 'Astral Radiance',
+        'BLK' => 'Black & White',
+
+        // Energy sets (kept for completeness, though basic energies are excluded)
+        'MEE' => 'Match Energy Set',
+        'SVE' => 'Scarlet & Violet Energies',
+        'SME' => 'Sun & Moon Energies',
+        'XYE' => 'XY Energies',
+        'BWE' => 'Black & White Energies',
+
+        // Older sets that may appear in cross-printing lookups
+        'N1' => 'Neo Genesis',
+        'EM' => 'EX Emerald',
+        'HP' => 'EX Holon Phantoms',
+        'LM' => 'EX Legend Maker',
+        'GE' => 'Great Encounters',
+        'MD' => 'Majestic Dawn',
+        'MT' => 'Mysterious Treasures',
+        'UL' => 'HS—Unleashed',
+        'SS' => 'EX Sandstorm',
+        'P5' => 'Pop Series 5',
+        'P8' => 'Pop Series 8',
+        'TK3L' => 'Trainer Kit: Lycanroc & Alolan Raichu',
+    ];
+
+    /**
+     * Get the Cardmarket expansion name for a PTCG set code.
+     *
+     * @return string|null The expansion name, or null if the set code is unknown
+     */
+    public function getExpansionName(string $setCode): ?string
+    {
+        return self::PTCG_CODE_TO_EXPANSION_NAME[$setCode] ?? null;
+    }
+}

--- a/src/Service/DeckList/CardmarketWishlistFormatter.php
+++ b/src/Service/DeckList/CardmarketWishlistFormatter.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\DeckList;
+
+use App\Entity\DeckVersion;
+use App\Service\DeckListParser;
+
+/**
+ * Generates a Cardmarket-compatible wishlist text from a DeckVersion.
+ *
+ * Format: one line per card, `{qty}x {name} {expansion name}`.
+ * Basic energies are excluded. Uses lowest-rarity printings via MinifiedCardViewBuilder.
+ *
+ * @see docs/features.md F6.11 — Export deck list for Cardmarket wishlist
+ */
+class CardmarketWishlistFormatter
+{
+    /** @var array<string, true> */
+    private readonly array $basicEnergyNames;
+
+    public function __construct(
+        private readonly MinifiedCardViewBuilder $minifiedCardViewBuilder,
+        private readonly CardmarketExpansionNameMapper $expansionNameMapper,
+    ) {
+        $names = [];
+
+        foreach (array_keys(DeckListParser::DEFAULT_BASIC_ENERGY_PRINTINGS) as $name) {
+            $names[$name] = true;
+        }
+
+        $this->basicEnergyNames = $names;
+    }
+
+    /**
+     * Generate the Cardmarket wishlist text for a DeckVersion.
+     *
+     * @return string|null The formatted text, or null if minified card data is not available
+     */
+    public function format(DeckVersion $version): ?string
+    {
+        if ($version->getCards()->isEmpty()) {
+            return null;
+        }
+
+        $groupedCards = $this->minifiedCardViewBuilder->buildGrouped($version);
+
+        if ([] === $groupedCards) {
+            return null;
+        }
+
+        $lines = [];
+
+        foreach ($groupedCards as $cards) {
+            foreach ($cards as $card) {
+                if ($this->isBasicEnergy($card->getCardName())) {
+                    continue;
+                }
+
+                $expansionName = $this->expansionNameMapper->getExpansionName($card->getSetCode());
+
+                if (null === $expansionName) {
+                    // Fall back to the raw PTCG set code when no mapping exists
+                    $expansionName = $card->getSetCode();
+                }
+
+                $lines[] = \sprintf('%dx %s %s', $card->getQuantity(), $card->getCardName(), $expansionName);
+            }
+        }
+
+        if ([] === $lines) {
+            return null;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function isBasicEnergy(string $cardName): bool
+    {
+        return isset($this->basicEnergyNames[$cardName]);
+    }
+}

--- a/templates/deck/show.html.twig
+++ b/templates/deck/show.html.twig
@@ -318,7 +318,10 @@
              data-label-table-card="{{ 'app.deck.table_card'|trans }}"
              data-label-table-set="{{ 'app.deck.table_set'|trans }}"
              data-label-name-match-warning-title="{{ 'app.deck.name_match_warning_title'|trans }}"
-             data-label-name-match-warning-body="{{ 'app.deck.name_match_warning_body'|trans }}">
+             data-label-name-match-warning-body="{{ 'app.deck.name_match_warning_body'|trans }}"
+             data-cardmarket-wishlist="{{ cardmarketWishlist is not null ? cardmarketWishlist|e('html_attr') : '' }}"
+             data-label-copy-cardmarket="{{ 'app.deck.export_copy_cardmarket'|trans }}"
+             data-label-copy-cardmarket-tooltip="{{ 'app.deck.export_copy_cardmarket_tooltip'|trans }}">
         </div>
     {% else %}
         <div class="card shadow-sm">

--- a/templates/profile/edit.html.twig
+++ b/templates/profile/edit.html.twig
@@ -34,6 +34,11 @@
                         {{ form_row(form.preferredLocale) }}
                         {{ form_row(form.timezone) }}
 
+                        <hr>
+                        <h6 class="text-muted mb-3">{{ 'app.profile.features_section'|trans }}</h6>
+
+                        {{ form_row(form.showCardmarketExport) }}
+
                         <button type="submit" class="btn btn-gold w-100 mt-3">{{ 'app.profile.save_button'|trans }}</button>
                     {{ form_end(form) }}
                 </div>

--- a/tests/Service/DeckList/CardmarketExpansionNameMapperTest.php
+++ b/tests/Service/DeckList/CardmarketExpansionNameMapperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\DeckList;
+
+use App\Service\DeckList\CardmarketExpansionNameMapper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F6.11 — Export deck list for Cardmarket wishlist
+ */
+class CardmarketExpansionNameMapperTest extends TestCase
+{
+    private CardmarketExpansionNameMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new CardmarketExpansionNameMapper();
+    }
+
+    public function testKnownSetCodeReturnsExpansionName(): void
+    {
+        self::assertSame('Brilliant Stars', $this->mapper->getExpansionName('BRS'));
+        self::assertSame('Lost Origin', $this->mapper->getExpansionName('LOR'));
+        self::assertSame('Scarlet & Violet', $this->mapper->getExpansionName('SVI'));
+        self::assertSame('Black & White', $this->mapper->getExpansionName('BLW'));
+    }
+
+    public function testUnknownSetCodeReturnsNull(): void
+    {
+        self::assertNull($this->mapper->getExpansionName('UNKNOWN'));
+        self::assertNull($this->mapper->getExpansionName(''));
+    }
+
+    public function testSetCodeIsCaseSensitive(): void
+    {
+        self::assertNull($this->mapper->getExpansionName('brs'));
+        self::assertSame('Brilliant Stars', $this->mapper->getExpansionName('BRS'));
+    }
+}

--- a/tests/Service/DeckList/CardmarketWishlistFormatterTest.php
+++ b/tests/Service/DeckList/CardmarketWishlistFormatterTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\DeckList;
+
+use App\Entity\DeckCard;
+use App\Entity\DeckVersion;
+use App\Service\DeckList\CardmarketExpansionNameMapper;
+use App\Service\DeckList\CardmarketWishlistFormatter;
+use App\Service\DeckList\MinifiedCardView;
+use App\Service\DeckList\MinifiedCardViewBuilder;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F6.11 — Export deck list for Cardmarket wishlist
+ */
+class CardmarketWishlistFormatterTest extends TestCase
+{
+    private CardmarketWishlistFormatter $formatter;
+    private MinifiedCardViewBuilder $viewBuilder;
+
+    protected function setUp(): void
+    {
+        $this->viewBuilder = $this->createStub(MinifiedCardViewBuilder::class);
+        $mapper = new CardmarketExpansionNameMapper();
+        $this->formatter = new CardmarketWishlistFormatter($this->viewBuilder, $mapper);
+    }
+
+    public function testFormatProducesCorrectOutput(): void
+    {
+        $version = $this->createVersionWithCards();
+
+        $this->viewBuilder->method('buildGrouped')->willReturn([
+            'pokemon' => [
+                new MinifiedCardView('Arceus VSTAR', 3, 'BRS', '123', 'pokemon', null, null),
+                new MinifiedCardView('Comfey', 2, 'LOR', '79', 'pokemon', null, null),
+            ],
+            'trainer' => [
+                new MinifiedCardView('Battle VIP Pass', 4, 'FST', '225', 'trainer', 'item', null),
+            ],
+        ]);
+
+        $result = $this->formatter->format($version);
+
+        self::assertSame(
+            "3x Arceus VSTAR Brilliant Stars\n2x Comfey Lost Origin\n4x Battle VIP Pass Fusion Strike",
+            $result,
+        );
+    }
+
+    public function testBasicEnergiesAreExcluded(): void
+    {
+        $version = $this->createVersionWithCards();
+
+        $this->viewBuilder->method('buildGrouped')->willReturn([
+            'pokemon' => [
+                new MinifiedCardView('Comfey', 2, 'LOR', '79', 'pokemon', null, null),
+            ],
+            'energy' => [
+                new MinifiedCardView('Fire Energy', 11, 'MEE', '2', 'energy', null, null),
+                new MinifiedCardView('Psychic Energy', 4, 'MEE', '5', 'energy', null, null),
+            ],
+        ]);
+
+        $result = $this->formatter->format($version);
+
+        self::assertSame('2x Comfey Lost Origin', $result);
+    }
+
+    public function testSpecialEnergiesAreIncluded(): void
+    {
+        $version = $this->createVersionWithCards();
+
+        $this->viewBuilder->method('buildGrouped')->willReturn([
+            'energy' => [
+                new MinifiedCardView('Double Turbo Energy', 4, 'BRS', '151', 'energy', null, null),
+                new MinifiedCardView('Fire Energy', 8, 'MEE', '2', 'energy', null, null),
+            ],
+        ]);
+
+        $result = $this->formatter->format($version);
+
+        self::assertSame('4x Double Turbo Energy Brilliant Stars', $result);
+    }
+
+    public function testReturnsNullWhenNoCards(): void
+    {
+        $version = $this->createStub(DeckVersion::class);
+        $version->method('getCards')->willReturn(new ArrayCollection());
+
+        self::assertNull($this->formatter->format($version));
+    }
+
+    public function testReturnsNullWhenBuilderReturnsEmpty(): void
+    {
+        $version = $this->createVersionWithCards();
+        $this->viewBuilder->method('buildGrouped')->willReturn([]);
+
+        self::assertNull($this->formatter->format($version));
+    }
+
+    public function testUnknownSetCodeFallsBackToRawCode(): void
+    {
+        $version = $this->createVersionWithCards();
+
+        $this->viewBuilder->method('buildGrouped')->willReturn([
+            'pokemon' => [
+                new MinifiedCardView('Some Card', 1, 'ZZZZ', '1', 'pokemon', null, null),
+            ],
+        ]);
+
+        $result = $this->formatter->format($version);
+
+        self::assertSame('1x Some Card ZZZZ', $result);
+    }
+
+    public function testReturnsNullWhenOnlyBasicEnergies(): void
+    {
+        $version = $this->createVersionWithCards();
+
+        $this->viewBuilder->method('buildGrouped')->willReturn([
+            'energy' => [
+                new MinifiedCardView('Grass Energy', 8, 'MEE', '1', 'energy', null, null),
+                new MinifiedCardView('Water Energy', 4, 'MEE', '3', 'energy', null, null),
+            ],
+        ]);
+
+        self::assertNull($this->formatter->format($version));
+    }
+
+    private function createVersionWithCards(): DeckVersion
+    {
+        $version = $this->createStub(DeckVersion::class);
+        $card = $this->createStub(DeckCard::class);
+        $version->method('getCards')->willReturn(new ArrayCollection([$card]));
+
+        return $version;
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -534,6 +534,14 @@
                 <source>app.deck.export_copied</source>
                 <target>Copied!</target>
             </trans-unit>
+            <trans-unit id="app.deck.export_copy_cardmarket">
+                <source>app.deck.export_copy_cardmarket</source>
+                <target>Copy for Cardmarket</target>
+            </trans-unit>
+            <trans-unit id="app.deck.export_copy_cardmarket_tooltip">
+                <source>app.deck.export_copy_cardmarket_tooltip</source>
+                <target>Copy card list for Cardmarket wishlist import (basic energies excluded)</target>
+            </trans-unit>
             <trans-unit id="app.deck.view_toggle">
                 <source>app.deck.view_toggle</source>
                 <target>View mode</target>
@@ -2224,6 +2232,10 @@
                 <target>My profile</target>
                 <note>Profile page heading</note>
             </trans-unit>
+            <trans-unit id="app.profile.features_section">
+                <source>app.profile.features_section</source>
+                <target>Optional features</target>
+            </trans-unit>
             <trans-unit id="app.profile.save_button">
                 <source>app.profile.save_button</source>
                 <target>Save changes</target>
@@ -2290,6 +2302,10 @@
                 <source>app.form.label.timezone</source>
                 <target>Timezone</target>
                 <note>Form label for timezone selector</note>
+            </trans-unit>
+            <trans-unit id="app.form.label.show_cardmarket_export">
+                <source>app.form.label.show_cardmarket_export</source>
+                <target>Show "Copy for Cardmarket" button on deck pages</target>
             </trans-unit>
             <trans-unit id="app.form.label.location">
                 <source>app.form.label.location</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -534,6 +534,14 @@
                 <source>app.deck.export_copied</source>
                 <target>Copié !</target>
             </trans-unit>
+            <trans-unit id="app.deck.export_copy_cardmarket">
+                <source>app.deck.export_copy_cardmarket</source>
+                <target>Copier pour Cardmarket</target>
+            </trans-unit>
+            <trans-unit id="app.deck.export_copy_cardmarket_tooltip">
+                <source>app.deck.export_copy_cardmarket_tooltip</source>
+                <target>Copier la liste pour import dans les recherches Cardmarket (énergies de base exclues)</target>
+            </trans-unit>
             <trans-unit id="app.deck.view_toggle">
                 <source>app.deck.view_toggle</source>
                 <target>Mode d'affichage</target>
@@ -2224,6 +2232,10 @@
                 <target>Mon profil</target>
                 <note>Profile page heading</note>
             </trans-unit>
+            <trans-unit id="app.profile.features_section">
+                <source>app.profile.features_section</source>
+                <target>Fonctionnalités optionnelles</target>
+            </trans-unit>
             <trans-unit id="app.profile.save_button">
                 <source>app.profile.save_button</source>
                 <target>Enregistrer</target>
@@ -2290,6 +2302,10 @@
                 <source>app.form.label.timezone</source>
                 <target>Fuseau horaire</target>
                 <note>Form label for timezone selector</note>
+            </trans-unit>
+            <trans-unit id="app.form.label.show_cardmarket_export">
+                <source>app.form.label.show_cardmarket_export</source>
+                <target>Afficher le bouton « Copier pour Cardmarket » sur les pages de deck</target>
             </trans-unit>
             <trans-unit id="app.form.label.location">
                 <source>app.form.label.location</source>


### PR DESCRIPTION
## Summary

- **New "Copy for Cardmarket" button** on the deck detail page — generates a text list compatible with Cardmarket's "Add Decklist to Wants" textarea (`{qty}x {name} {expansion name}`)
- **Basic energies excluded** from the export (Grass, Fire, Water, Lightning, Psychic, Fighting, Darkness, Metal, Fairy)
- **Lowest-rarity printings** used via the CardIdentity/CardPrinting model, so users default to the cheapest version
- **PTCG set code → Cardmarket expansion name mapping** covering ~80 sets from BLW (2011) to JTG (2025)
- **Opt-in user preference** — new `showCardmarketExport` boolean on the User entity (default: `false`), toggled via the profile page under "Optional features"
- **Migration** adds the `show_cardmarket_export` column to the `user` table
- **10 unit tests** covering the expansion name mapper (3 tests) and wishlist formatter (7 tests)
- **Translations** for en + fr (button label, tooltip, profile form label, section header)

Closes #199

## Test plan
- [ ] Enable the preference in profile settings, verify checkbox saves correctly
- [ ] Visit a deck page with enriched cards — verify the Cardmarket shopping cart button appears
- [ ] Click the button — verify clipboard contains the correct `{qty}x {name} {expansion}` format
- [ ] Verify basic energies are absent from the copied text
- [ ] Verify special energies (e.g. Double Turbo Energy) are included
- [ ] Disable the preference — verify the button disappears from deck pages
- [ ] Visit a deck page as anonymous/non-opted-in user — verify no Cardmarket button
- [ ] Test with a deck whose card identity data is not yet available — verify button is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)