### PR TITLE
:memo: Docs: add Awaiting Validation and Ready for Release columns

### DIFF
--- a/.claude/commands/next.md
+++ b/.claude/commands/next.md
@@ -60,6 +60,5 @@ Include a one-line summary of each runner-up from features.md.
 6. **When the user picks a feature to start**, move the issue to the **"In Progress"** column on the project board:
 
    ```bash
-   # Get the project item ID and field/option IDs, then update
-   gh project item-edit --project-id <PROJECT_ID> --id <ITEM_ID> --field-id <STATUS_FIELD_ID> --single-select-option-id <IN_PROGRESS_OPTION_ID>
+   gh project item-edit --project-id PVT_kwHOABmPPc4BSa9t --id <ITEM_ID> --field-id PVTSSF_lAHOABmPPc4BSa9tzg_9eC4 --single-select-option-id 9c44dd90
    ```

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -92,7 +92,24 @@ EOF
 )"
 ```
 
-### 5. Report result
+### 5. Move linked issues to "Awaiting Validation"
+
+If the PR body contains `Closes #<number>` or `Fixes #<number>` references, move each linked issue to the **"Awaiting Validation"** column on the project board:
+
+1. Fetch the project item ID for the issue:
+   ```bash
+   gh project item-list 1 --owner jbourdin --format json --limit 100
+   ```
+   Find the item where `content.number` matches the issue number.
+
+2. Update its status to "Awaiting Validation":
+   ```bash
+   gh project item-edit --project-id PVT_kwHOABmPPc4BSa9t --id <ITEM_ID> --field-id PVTSSF_lAHOABmPPc4BSa9tzg_9eC4 --single-select-option-id fc347211
+   ```
+
+If no issue references are found in the PR body, skip this step.
+
+### 6. Report result
 
 Print the PR URL so the user can review it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,14 +218,18 @@ make test          # Run test suite
 
 ### Project Tracking
 
-The project uses a [GitHub Project board](https://github.com/users/jbourdin/projects/1) with Kanban columns (Backlog → Next → In Progress → Testing → Done). When implementing a feature or fix:
+The project uses a [GitHub Project board](https://github.com/users/jbourdin/projects/1) with Kanban columns (Backlog → Next → In Progress → Awaiting Validation → Testing → Ready for Release → Done). When implementing a feature or fix:
 
 1. **Move the issue** to "In Progress" when work starts
 2. **Update code and documentation** in the same PR (docs must stay in sync)
-3. **Move the issue** to "Testing" when the PR is ready for manual verification
-5. **Move the issue** to "Done" when the PR is merged after user confirmation
+3. **Move the issue** to "Awaiting Validation" when the PR is pushed and awaiting CI and code review
+4. **Move the issue** to "Testing" when the PR is merged and awaiting manual verification
+5. **Move the issue** to "Ready for Release" when the user confirms the feature works
+6. **Move the issue** to "Done" only when the release containing it is published
 
 When creating new features or backlog items, create a GitHub issue with the feature ID, assign it to the correct milestone, and add it to the project board.
+
+**Board ordering:** items within each column are manually sorted by **milestone** (Phase A first, then B, C, … J, then no milestone) and then by **priority** (high → medium → low) within a milestone. When adding or moving an issue, place it at the correct position using the `updateProjectV2ItemPosition` GraphQL mutation (`afterId: null` for first position, or `afterId: "<previous-item-id>"` to insert after a specific item).
 
 ## Make Commands
 
@@ -371,7 +375,7 @@ Entry point: **[docs/docs.md](docs/docs.md)** — full technical documentation i
 
 ### Roadmap & Changelog Maintenance
 
-- Feature status is tracked on the [GitHub Project board](https://github.com/users/jbourdin/projects/1) — move issues between columns (Backlog → Next → In Progress → Testing → Done) instead of editing `docs/roadmap.md`
+- Feature status is tracked on the [GitHub Project board](https://github.com/users/jbourdin/projects/1) — move issues between columns (Backlog → Next → In Progress → Awaiting Validation → Testing → Ready for Release → Done) instead of editing `docs/roadmap.md`
 - `docs/changelog.md` entry is required for every tagged release
 
 ## Slash Commands

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,15 +8,17 @@ The [GitHub Project board](https://github.com/users/jbourdin/projects/1) is the 
 
 ## Project Board
 
-The Kanban board organizes work into five columns:
+The Kanban board organizes work into seven columns:
 
-| Column        | Meaning                                                    |
-|---------------|------------------------------------------------------------|
-| **Backlog**   | Accepted work, not yet scheduled                           |
-| **Next**      | Prioritized and ready to pick up                           |
-| **In Progress** | Actively being worked on                                 |
-| **Testing**   | PR ready, awaiting manual verification                     |
-| **Done**      | Merged and deployed                                        |
+| Column                    | Meaning                                                    |
+|---------------------------|------------------------------------------------------------|
+| **Backlog**               | Accepted work, not yet scheduled                           |
+| **Next**                  | Prioritized and ready to pick up                           |
+| **In Progress**           | Actively being worked on                                   |
+| **Awaiting Validation**   | PR open, awaiting CI and code review                       |
+| **Testing**               | PR merged, awaiting manual verification                    |
+| **Ready for Release**     | Tested and approved, included in next release              |
+| **Done**                  | Released                                                   |
 
 **Views:**
 


### PR DESCRIPTION
## Summary

- **Add "Awaiting Validation" column** to the project board workflow — PR is open, awaiting CI and code review (between In Progress and Testing)
- **Add "Ready for Release" column** — feature tested and approved, waiting for the next release (between Testing and Done)
- **Update `/pr` skill** to move linked issues to "Awaiting Validation" on PR creation
- **Update `/next` skill** with current project board option IDs
- **Document board ordering convention** in CLAUDE.md: items sorted by milestone (A→J→none) then priority (high→medium→low), maintained via `updateProjectV2ItemPosition` mutation
- **Update `docs/roadmap.md`** column table to 7 columns

## Test plan
- [ ] Verify `/pr` moves linked issues to "Awaiting Validation"
- [ ] Verify `/next` uses correct "In Progress" option ID
- [ ] Verify roadmap.md column table matches actual board

🤖 Generated with [Claude Code](https://claude.com/claude-code)