### PR TITLE
feat: replace cron-based jobs with Supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ FROM dunglas/frankenphp:php8.5 AS runtime
 #   docker build --build-arg APP_VERSION=$(git describe --tags --always) .
 ARG APP_VERSION=dev
 
+# Install Supervisor (manages FrankenPHP + Messenger workers)
+RUN apt-get update && apt-get install -y --no-install-recommends supervisor && rm -rf /var/lib/apt/lists/*
+
 # Install required PHP extensions
 RUN install-php-extensions \
     pdo_mysql \
@@ -67,8 +70,8 @@ opcache.validate_timestamps=0\n\
 opcache.preload_user=www-data\n\
 ' > "$PHP_INI_DIR/conf.d/opcache-prod.ini"
 
-# Raise memory limit for mosaic image generation (default 128M is too low)
-RUN echo 'memory_limit=512M' > "$PHP_INI_DIR/conf.d/memory-limit.ini"
+# Raise memory limit for mosaic image generation and deck enrichment workers
+RUN echo 'memory_limit=768M' > "$PHP_INI_DIR/conf.d/memory-limit.ini"
 
 # Use production php.ini
 RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
@@ -116,11 +119,13 @@ RUN mkdir -p /data/caddy /config/caddy && chown -R www-data:www-data /data /conf
 # Ensure var/ is writable by www-data for runtime cache compilation
 RUN mkdir -p /app/var/cache /app/var/log && chown -R www-data:www-data /app/var
 
-# Startup script: clears and warms cache with actual runtime env vars
+# Supervisor config
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Startup script: clears and warms cache, then execs Supervisor
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile"]
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8080/health || exit 1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,5 +6,5 @@ set -e
 php bin/console cache:clear --env=prod --no-debug 2>/dev/null || true
 php bin/console cache:warmup --env=prod --no-debug
 
-# Execute the original FrankenPHP entrypoint
-exec "$@"
+# Launch Supervisor (manages FrankenPHP + Messenger workers)
+exec supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,64 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
+
+[program:frankenphp]
+command=frankenphp run --config /etc/frankenphp/Caddyfile
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=true
+priority=10
+stopsignal=TERM
+stopwaitsecs=30
+
+[program:worker-transactional-email]
+command=php bin/console messenger:consume transactional_email --time-limit=3600 --memory-limit=256 --env=prod --no-debug
+directory=/app
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=true
+priority=20
+stopsignal=TERM
+stopwaitsecs=30
+
+[program:worker-deck-enrichment]
+command=php bin/console messenger:consume deck_enrichment --time-limit=3600 --memory-limit=512 --limit=5 --env=prod --no-debug
+directory=/app
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=true
+priority=20
+stopsignal=TERM
+stopwaitsecs=30
+
+[program:worker-notification]
+command=php bin/console messenger:consume notification --time-limit=3600 --memory-limit=256 --env=prod --no-debug
+directory=/app
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=true
+priority=20
+stopsignal=TERM
+stopwaitsecs=30
+
+[program:worker-borrow-lifecycle]
+command=php bin/console messenger:consume borrow_lifecycle --time-limit=3600 --memory-limit=256 --env=prod --no-debug
+directory=/app
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=true
+priority=20
+stopsignal=TERM
+stopwaitsecs=30


### PR DESCRIPTION
## Summary
- Add Supervisor to manage both FrankenPHP and Messenger workers in a single container
- Eliminates the separate Serverless Job cron, reducing deploy complexity and message processing latency
- Deck enrichment worker gets 512MB memory limit and 5-message cap to prevent leaks from mosaic generation

## Test plan
- [ ] Build Docker image and verify Supervisor starts FrankenPHP + all 4 workers
- [ ] Verify HTTP health check passes
- [ ] Dispatch messages to each queue and confirm processing
- [ ] Test graceful shutdown (SIGTERM) — workers finish in-flight messages

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)