### PR TITLE
:white_check_mark: Test: add coverage for flush, retry command, promo codes

### DIFF
--- a/tests/Command/EnrichRetryCommandTest.php
+++ b/tests/Command/EnrichRetryCommandTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Command;
+
+use App\Command\EnrichRetryCommand;
+use App\Entity\Deck;
+use App\Entity\DeckVersion;
+use App\Message\EnrichDeckVersionMessage;
+use App\Repository\DeckVersionRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @see docs/features.md F6.2 — TCGdex card data enrichment
+ */
+class EnrichRetryCommandTest extends TestCase
+{
+    public function testNoVersionsNeedEnrichment(): void
+    {
+        $repository = $this->createStub(DeckVersionRepository::class);
+        $repository->method('findNotEnriched')->willReturn([]);
+
+        $messageBus = $this->createStub(MessageBusInterface::class);
+
+        $command = new EnrichRetryCommand($repository, $messageBus);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('No deck versions need enrichment', $tester->getDisplay());
+    }
+
+    public function testDispatchesMessagesForPendingVersions(): void
+    {
+        $deck = $this->createStub(Deck::class);
+        $deck->method('getName')->willReturn('Test Deck');
+
+        $version = $this->createStub(DeckVersion::class);
+        $version->method('getId')->willReturn(42);
+        $version->method('getDeck')->willReturn($deck);
+        $version->method('getVersionNumber')->willReturn(1);
+        $version->method('getEnrichmentStatus')->willReturn('pending');
+
+        $repository = $this->createStub(DeckVersionRepository::class);
+        $repository->method('findNotEnriched')->willReturn([$version]);
+
+        $dispatchedMessages = [];
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $message) use (&$dispatchedMessages): Envelope {
+                $dispatchedMessages[] = $message;
+
+                return new Envelope($message);
+            });
+
+        $command = new EnrichRetryCommand($repository, $messageBus);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertCount(1, $dispatchedMessages);
+        self::assertInstanceOf(EnrichDeckVersionMessage::class, $dispatchedMessages[0]);
+        self::assertSame(42, $dispatchedMessages[0]->deckVersionId);
+        self::assertStringContainsString('1 enrichment message(s) dispatched', $tester->getDisplay());
+    }
+
+    public function testDispatchesForMultipleVersions(): void
+    {
+        $deck = $this->createStub(Deck::class);
+        $deck->method('getName')->willReturn('Deck');
+
+        $version1 = $this->createStub(DeckVersion::class);
+        $version1->method('getId')->willReturn(1);
+        $version1->method('getDeck')->willReturn($deck);
+        $version1->method('getVersionNumber')->willReturn(1);
+        $version1->method('getEnrichmentStatus')->willReturn('pending');
+
+        $version2 = $this->createStub(DeckVersion::class);
+        $version2->method('getId')->willReturn(2);
+        $version2->method('getDeck')->willReturn($deck);
+        $version2->method('getVersionNumber')->willReturn(2);
+        $version2->method('getEnrichmentStatus')->willReturn('failed');
+
+        $repository = $this->createStub(DeckVersionRepository::class);
+        $repository->method('findNotEnriched')->willReturn([$version1, $version2]);
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
+
+        $command = new EnrichRetryCommand($repository, $messageBus);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        self::assertStringContainsString('2 enrichment message(s) dispatched', $tester->getDisplay());
+    }
+}

--- a/tests/Service/EnrichmentFlushServiceTest.php
+++ b/tests/Service/EnrichmentFlushServiceTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service;
+
+use App\Service\EnrichmentFlushService;
+use Doctrine\DBAL\Connection;
+use League\Flysystem\DirectoryListing;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * @see docs/features.md F6.2 — TCGdex card data enrichment
+ */
+class EnrichmentFlushServiceTest extends TestCase
+{
+    public function testFlushClearsDeckCardEnrichmentFields(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $storage = $this->createStub(FilesystemOperator::class);
+        $storage->method('listContents')->willReturn(new DirectoryListing(new \EmptyIterator()));
+
+        $connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturnCallback(static function (string $sql): int {
+                static $callIndex = 0;
+
+                if (0 === $callIndex++) {
+                    self::assertStringContainsString('deck_card', $sql);
+                    self::assertStringContainsString('tcgdex_id = NULL', $sql);
+                    self::assertStringContainsString('image_url = NULL', $sql);
+                    self::assertStringContainsString('trainer_subtype = NULL', $sql);
+                    self::assertStringContainsString('card_printing_id = NULL', $sql);
+                }
+
+                return 0;
+            });
+
+        $service = new EnrichmentFlushService($connection, $storage, new NullLogger());
+        $service->flush();
+    }
+
+    public function testFlushResetsDeckVersionFieldsIncludingMinifiedCardViews(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $storage = $this->createStub(FilesystemOperator::class);
+        $storage->method('listContents')->willReturn(new DirectoryListing(new \EmptyIterator()));
+
+        $executedStatements = [];
+        $connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturnCallback(static function (string $sql) use (&$executedStatements): int {
+                $executedStatements[] = $sql;
+
+                return 0;
+            });
+
+        $service = new EnrichmentFlushService($connection, $storage, new NullLogger());
+        $service->flush();
+
+        // Second statement is the DeckVersion reset
+        $deckVersionSql = $executedStatements[1];
+        self::assertStringContainsString('deck_version', $deckVersionSql);
+        self::assertStringContainsString("enrichment_status = 'pending'", $deckVersionSql);
+        self::assertStringContainsString('mosaic_image_url = NULL', $deckVersionSql);
+        self::assertStringContainsString('minified_list = NULL', $deckVersionSql);
+        self::assertStringContainsString('minified_card_views = NULL', $deckVersionSql);
+        self::assertStringContainsString('minified_mosaic_image_url = NULL', $deckVersionSql);
+    }
+
+    public function testFlushDeletesCardPrintingAndCardIdentity(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $storage = $this->createStub(FilesystemOperator::class);
+        $storage->method('listContents')->willReturn(new DirectoryListing(new \EmptyIterator()));
+
+        $executedStatements = [];
+        $connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturnCallback(static function (string $sql) use (&$executedStatements): int {
+                $executedStatements[] = $sql;
+
+                return 0;
+            });
+
+        $service = new EnrichmentFlushService($connection, $storage, new NullLogger());
+        $service->flush();
+
+        self::assertSame('DELETE FROM card_printing', $executedStatements[2]);
+        self::assertSame('DELETE FROM card_identity', $executedStatements[3]);
+    }
+
+    public function testFlushExecutesStatementsInCorrectOrder(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $storage = $this->createStub(FilesystemOperator::class);
+        $storage->method('listContents')->willReturn(new DirectoryListing(new \EmptyIterator()));
+
+        $executedStatements = [];
+        $connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturnCallback(static function (string $sql) use (&$executedStatements): int {
+                $executedStatements[] = $sql;
+
+                return 0;
+            });
+
+        $service = new EnrichmentFlushService($connection, $storage, new NullLogger());
+        $service->flush();
+
+        // Order matters: cards → versions → printings (FK) → identities
+        self::assertStringContainsString('deck_card', $executedStatements[0]);
+        self::assertStringContainsString('deck_version', $executedStatements[1]);
+        self::assertStringContainsString('card_printing', $executedStatements[2]);
+        self::assertStringContainsString('card_identity', $executedStatements[3]);
+    }
+}

--- a/tests/Service/Tcgdex/TcgdexApiClientTest.php
+++ b/tests/Service/Tcgdex/TcgdexApiClientTest.php
@@ -59,6 +59,53 @@ class TcgdexApiClientTest extends TestCase
         self::assertSame('swshp', $mapping['PR-SW']);
     }
 
+    public function testGetSetMappingIncludesPtcgoShortPromoCodes(): void
+    {
+        $repository = $this->createStub(TcgdexSetMappingRepository::class);
+        $repository->method('getForwardMapping')->willReturn([]);
+
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $client = new TcgdexApiClient($httpClient, new ArrayAdapter(), $repository);
+        $mapping = $client->getSetMapping();
+
+        // PTCGO short codes map to the same TCGdex IDs as the PR-XX codes
+        self::assertSame('svp', $mapping['SVP']);
+        self::assertSame('swshp', $mapping['SWP']);
+        self::assertSame('smp', $mapping['SMP']);
+        self::assertSame('xyp', $mapping['XYP']);
+        self::assertSame('bwp', $mapping['BWP']);
+
+        // Verify consistency: short codes and PR-XX codes resolve to the same TCGdex ID
+        self::assertSame($mapping['PR-SV'], $mapping['SVP']);
+        self::assertSame($mapping['PR-SW'], $mapping['SWP']);
+        self::assertSame($mapping['PR-SM'], $mapping['SMP']);
+        self::assertSame($mapping['PR-XY'], $mapping['XYP']);
+        self::assertSame($mapping['PR-BW'], $mapping['BWP']);
+    }
+
+    public function testFindCardResolvesPtcgoShortPromoCode(): void
+    {
+        // SMP 217 (Trevenant & Dusknoir-GX) should resolve to smp-SM217
+        $httpClient = $this->createCardMockClient([
+            'smp-SM217' => [
+                'status' => 200,
+                'body' => [
+                    'id' => 'smp-SM217',
+                    'name' => 'Trevenant & Dusknoir GX',
+                    'category' => 'Pokemon',
+                    'image' => 'https://assets.tcgdex.net/en/sm/smp/SM217',
+                    'legal' => ['expanded' => true],
+                ],
+            ],
+        ]);
+
+        $client = new TcgdexApiClient($httpClient, new ArrayAdapter(), $this->createRepositoryStub([]));
+        $card = $client->findCard('SMP', '217');
+
+        self::assertNotNull($card);
+        self::assertSame('smp-SM217', $card->id);
+    }
+
     public function testGetSetMappingReadsFromRepository(): void
     {
         $repository = $this->createStub(TcgdexSetMappingRepository::class);


### PR DESCRIPTION
## Summary

- **EnrichmentFlushServiceTest** (4 tests) — verifies all fields cleared including `minified_card_views`, correct SQL execution order, `card_printing`/`card_identity` deletion
- **EnrichRetryCommandTest** (3 tests) — CommandTester coverage for no-op, single dispatch, multiple dispatches
- **TcgdexApiClientTest** (2 new tests) — PTCGO short promo codes (`SMP`/`SWP`/`SVP`/`XYP`/`BWP`) resolve consistently with `PR-XX` codes; `SMP 217` resolves to `smp-SM217`

571 → 580 tests

## Test plan

- [x] `make test.unit` — 580 tests pass
- [x] PHPStan clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)