### PR TITLE
:bug: Fix: prevent recursive _target_path redirect loop

### DIFF
--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -88,7 +88,7 @@ class RegistrationController extends AbstractAppController
 
             $this->addFlash('success', 'app.flash.auth.account_created');
 
-            $loginParams = ('' !== $targetPath) ? ['_target_path' => $targetPath] : [];
+            $loginParams = ('' !== $targetPath && $this->isSafeRedirectPath($targetPath)) ? ['_target_path' => $targetPath] : [];
 
             return $this->redirectToRoute('app_login', $loginParams);
         }
@@ -102,6 +102,19 @@ class RegistrationController extends AbstractAppController
     {
         return str_starts_with($path, '/')
             && !str_starts_with($path, '//')
-            && !str_contains($path, '://');
+            && !str_contains($path, '://')
+            && !$this->containsNestedTargetPath($path);
+    }
+
+    private function containsNestedTargetPath(string $path): bool
+    {
+        $decoded = $path;
+
+        do {
+            $previous = $decoded;
+            $decoded = urldecode($decoded);
+        } while ($decoded !== $previous);
+
+        return str_contains($decoded, '_target_path');
     }
 }

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -51,7 +51,20 @@ class SecurityController extends AbstractController
     {
         return str_starts_with($path, '/')
             && !str_starts_with($path, '//')
-            && !str_contains($path, '://');
+            && !str_contains($path, '://')
+            && !$this->containsNestedTargetPath($path);
+    }
+
+    private function containsNestedTargetPath(string $path): bool
+    {
+        $decoded = $path;
+
+        do {
+            $previous = $decoded;
+            $decoded = urldecode($decoded);
+        } while ($decoded !== $previous);
+
+        return str_contains($decoded, '_target_path');
     }
 
     #[Route('/logout', name: 'app_logout')]

--- a/src/Security/SafeAuthenticationSuccessHandler.php
+++ b/src/Security/SafeAuthenticationSuccessHandler.php
@@ -49,6 +49,19 @@ class SafeAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandl
     {
         return str_starts_with($path, '/')
             && !str_starts_with($path, '//')
-            && !str_contains($path, '://');
+            && !str_contains($path, '://')
+            && !$this->containsNestedTargetPath($path);
+    }
+
+    private function containsNestedTargetPath(string $path): bool
+    {
+        $decoded = $path;
+
+        do {
+            $previous = $decoded;
+            $decoded = urldecode($decoded);
+        } while ($decoded !== $previous);
+
+        return str_contains($decoded, '_target_path');
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -137,10 +137,10 @@
                                 {% endif %}
                             {% endfor %}
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_login', {'_target_path': app.request.requestUri}) }}">{{ 'app.nav.login'|trans }}</a>
+                                <a class="nav-link" href="{{ path('app_login', {'_target_path': app.request.pathInfo}) }}">{{ 'app.nav.login'|trans }}</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_register', {'_target_path': app.request.requestUri}) }}">{{ 'app.nav.register'|trans }}</a>
+                                <a class="nav-link" href="{{ path('app_register', {'_target_path': app.request.pathInfo}) }}">{{ 'app.nav.register'|trans }}</a>
                             </li>
                         {% endif %}
                     </ul>

--- a/tests/Functional/RegistrationControllerCoverageTest.php
+++ b/tests/Functional/RegistrationControllerCoverageTest.php
@@ -73,4 +73,17 @@ class RegistrationControllerCoverageTest extends AbstractFunctionalTest
 
         self::assertResponseRedirects('/dashboard');
     }
+
+    /**
+     * When a logged-in user visits /register with a recursive _target_path,
+     * they should be redirected to the dashboard (recursive targets are unsafe).
+     */
+    public function testRegisterIgnoresRecursiveTargetPathWhenLoggedIn(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/register?_target_path=/login%3F_target_path%3D/register');
+
+        self::assertResponseRedirects('/dashboard');
+    }
 }

--- a/tests/Functional/SecurityControllerCoverageTest.php
+++ b/tests/Functional/SecurityControllerCoverageTest.php
@@ -75,4 +75,39 @@ class SecurityControllerCoverageTest extends AbstractFunctionalTest
 
         self::assertResponseRedirects('/dashboard');
     }
+
+    /**
+     * A _target_path containing a nested _target_path is treated as unsafe
+     * to prevent crawler redirect loops.
+     */
+    public function testLoginPageIgnoresRecursiveTargetPath(): void
+    {
+        $this->client->request('GET', '/login?_target_path=/register%3F_target_path%3D/login');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('form');
+    }
+
+    /**
+     * A _target_path with deeply percent-encoded _target_path is still rejected.
+     */
+    public function testLoginPageIgnoresDeeplyEncodedRecursiveTargetPath(): void
+    {
+        $this->client->request('GET', '/login?_target_path=/register%3F_target_path%253D/login');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('form');
+    }
+
+    /**
+     * Logged-in user with recursive target path should redirect to dashboard.
+     */
+    public function testLoginPageRedirectsToDashboardWhenLoggedInWithRecursiveTarget(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/login?_target_path=/register%3F_target_path%3D/deck');
+
+        self::assertResponseRedirects('/dashboard');
+    }
 }


### PR DESCRIPTION
## Summary
- **Template fix**: Use `pathInfo` instead of `requestUri` for login/register nav links in `base.html.twig`, preventing query string nesting that seeds the redirect loop
- **Server-side guard**: Add `containsNestedTargetPath()` to `isSafeRedirectPath()` in `SecurityController`, `RegistrationController`, and `SafeAuthenticationSuccessHandler` — fully URL-decodes all percent-encoding levels before checking for nested `_target_path`
- **Forward guard**: Validate `_target_path` with `isSafeRedirectPath()` before forwarding it in the post-registration redirect to `/login`
- **Tests**: Add 4 functional tests covering recursive target path rejection (single-encoded, deeply-encoded, logged-in redirect)

### Context
Bots were bouncing between `/login` and `/register`, each time nesting the `_target_path` query param deeper with additional percent-encoding. This generated ~400k requests in 7 days (98% of all traffic), all cache MISSes hitting origin.

## Test plan
- [ ] Visit `/login?_target_path=/deck` → login form renders, after login redirects to `/deck`
- [ ] Visit `/login?_target_path=/register%3F_target_path%3D/login` → recursive target is ignored, login form renders normally
- [ ] Visit `/register?_target_path=/deck` → after registration, redirects to `/login?_target_path=/deck`
- [ ] Check nav links on any page while logged out → `_target_path` contains only the path (no query string)
- [ ] Verify no redirect loop when clicking between login/register links

🤖 Generated with [Claude Code](https://claude.com/claude-code)