### PR TITLE
:memo: Docs: add --latest flag to release-create skill

### DIFF
--- a/.claude/commands/release-create.md
+++ b/.claude/commands/release-create.md
@@ -112,7 +112,7 @@ EOF
 Print the PR URL and remind the user of the remaining release steps:
 - Wait for CI to pass
 - Merge the PR (merge commit, not squash)
-- Create GitHub release with `gh release create`
+- Create GitHub release with `gh release create` (use `--latest` if the version is higher than the current latest)
 - Back-merge `main` into `develop`
 - These steps can be done with `/ci`
 


### PR DESCRIPTION
## Summary
- Add reminder to use `--latest` flag when creating GitHub releases with an incremented version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)