### PR TITLE
:ambulance: Hotfix: escape JSON labels in deck-found data attribute

### DIFF
--- a/templates/deck/show.html.twig
+++ b/templates/deck/show.html.twig
@@ -125,7 +125,7 @@
              data-is-logged-in="{{ app.user ? '1' : '' }}"
              data-owner-discord="{{ deck.owner.discordUsername ?? '' }}"
              data-sitekey="{{ friendly_captcha_sitekey }}"
-             data-labels='{{ {
+             data-labels="{{ {
                  button: 'app.deck.found_button'|trans,
                  title: 'app.deck.found_modal_title'|trans,
                  anonymousLabel: 'app.deck.found_anonymous_label'|trans,
@@ -136,7 +136,7 @@
                  submit: 'app.deck.found_submit'|trans,
                  success: 'app.deck.found_success'|trans,
                  error: 'app.deck.found_error'|trans,
-             }|json_encode|raw }}'
+             }|json_encode|e('html_attr') }}"
         ></div>
     {% endif %}
 

--- a/templates/deck/show_limited.html.twig
+++ b/templates/deck/show_limited.html.twig
@@ -58,7 +58,7 @@
          data-is-logged-in="{{ app.user ? '1' : '' }}"
          data-owner-discord="{{ deck.owner.discordUsername ?? '' }}"
          data-sitekey="{{ friendly_captcha_sitekey }}"
-         data-labels='{{ {
+         data-labels="{{ {
              button: 'app.deck.found_button'|trans,
              title: 'app.deck.found_modal_title'|trans,
              anonymousLabel: 'app.deck.found_anonymous_label'|trans,
@@ -69,6 +69,6 @@
              submit: 'app.deck.found_submit'|trans,
              success: 'app.deck.found_success'|trans,
              error: 'app.deck.found_error'|trans,
-         }|json_encode|raw }}'
+         }|json_encode|e('html_attr') }}"
     ></div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- French translations containing apostrophes (e.g. "J'ai trouvé", "l'accueil") broke the single-quoted `data-labels` HTML attribute, causing a `SyntaxError: JSON Parse error: Unterminated string` that prevented the "I found this deck" React island from mounting.
- Fix: use `|e('html_attr')` with double-quoted attribute instead of `|raw` with single-quoted attribute in both `show.html.twig` and `show_limited.html.twig`.

## Test plan
- [ ] View a deck page in French locale — "I found this deck" button renders
- [ ] Open the modal — all labels display correctly with apostrophes
- [ ] No JS console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)