### PR TITLE
:sparkles: Feature: insert card image from reference in RTE

### DIFF
--- a/assets/components/InsertCardImageButton.tsx
+++ b/assets/components/InsertCardImageButton.tsx
@@ -1,0 +1,129 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { ActionIcon, Group, Loader, Popover, TextInput, Tooltip } from '@mantine/core';
+import { IconCheck } from '@tabler/icons-react';
+import type { Editor } from '@tiptap/react';
+
+/**
+ * Toolbar button that prompts for a card reference (e.g. "UPR-100"),
+ * resolves it to a TCGdex image URL via the backend, and inserts the
+ * image into the editor.
+ *
+ * @see docs/features.md F17.8 — Insert card image from reference in rich text editor
+ */
+
+const CARD_PATTERN = /^[A-Za-z0-9-]+$/;
+
+interface InsertCardImageButtonProps {
+    editor: Editor;
+    icon: React.ReactNode;
+    label: string;
+}
+
+export default function InsertCardImageButton({ editor, icon, label }: InsertCardImageButtonProps) {
+    const [opened, setOpened] = useState(false);
+    const [value, setValue] = useState('');
+    const [error, setError] = useState<string | false>(false);
+    const [loading, setLoading] = useState(false);
+
+    const handleSubmit = useCallback(async () => {
+        const trimmed = value.trim();
+        if (!trimmed || !CARD_PATTERN.test(trimmed)) {
+            setError('Invalid reference');
+
+            return;
+        }
+
+        setLoading(true);
+        setError(false);
+
+        try {
+            const response = await fetch(`/api/card/image-url?reference=${encodeURIComponent(trimmed)}`);
+
+            if (!response.ok) {
+                const data = await response.json();
+                setError((data.error as string) ?? 'Card not found');
+                setLoading(false);
+
+                return;
+            }
+
+            const data = await response.json();
+            const url = data.url as string;
+
+            editor
+                .chain()
+                .focus()
+                .setImage({ src: url, alt: trimmed, width: 180 })
+                .run();
+
+            setValue('');
+            setError(false);
+            setOpened(false);
+        } catch {
+            setError('Network error');
+        } finally {
+            setLoading(false);
+        }
+    }, [value, editor]);
+
+    const handleKeyDown = useCallback(
+        (event: React.KeyboardEvent) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                handleSubmit();
+            } else if (event.key === 'Escape') {
+                setOpened(false);
+                setValue('');
+                setError(false);
+            }
+        },
+        [handleSubmit],
+    );
+
+    return (
+        <Popover opened={opened} onChange={setOpened} position="bottom" withArrow trapFocus>
+            <Popover.Target>
+                <Tooltip label={label}>
+                    <ActionIcon
+                        variant="default"
+                        size="sm"
+                        onClick={() => setOpened((previous) => !previous)}
+                        aria-label={label}
+                    >
+                        {icon}
+                    </ActionIcon>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown>
+                <Group gap="xs">
+                    <TextInput
+                        size="xs"
+                        placeholder="SET-NUM"
+                        value={value}
+                        onChange={(event) => {
+                            setValue(event.currentTarget.value);
+                            setError(false);
+                        }}
+                        onKeyDown={handleKeyDown}
+                        error={error}
+                        autoFocus
+                        style={{ width: 160 }}
+                        disabled={loading}
+                    />
+                    <ActionIcon size="sm" variant="filled" onClick={handleSubmit} aria-label="Insert" disabled={loading}>
+                        {loading ? <Loader size={14} /> : <IconCheck size={14} />}
+                    </ActionIcon>
+                </Group>
+            </Popover.Dropdown>
+        </Popover>
+    );
+}

--- a/assets/components/MarkdownEditor.tsx
+++ b/assets/components/MarkdownEditor.tsx
@@ -15,7 +15,7 @@ import { useEditor } from '@tiptap/react';
 import type { Editor } from '@tiptap/core';
 import { FileHandler } from '@tiptap/extension-file-handler';
 import StarterKit from '@tiptap/starter-kit';
-import { IconCards, IconFloatCenter, IconFloatLeft, IconFloatNone, IconFloatRight, IconStack2, IconSword } from '@tabler/icons-react';
+import { IconCards, IconFloatCenter, IconFloatLeft, IconFloatNone, IconFloatRight, IconPhoto, IconStack2, IconSword } from '@tabler/icons-react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — tiptap-markdown types conflict with tiptap v3 private class properties
 import { Markdown } from 'tiptap-markdown';
@@ -25,6 +25,7 @@ import DeckReference from '../extensions/DeckReference';
 import HeadingWithId from '../extensions/HeadingWithId';
 import ResizableImage from '../extensions/ResizableImage';
 import ImageAlignButton from './ImageAlignButton';
+import InsertCardImageButton from './InsertCardImageButton';
 import InsertReferenceButton from './InsertReferenceButton';
 
 /**
@@ -252,6 +253,11 @@ export default function MarkdownEditor({ textareaSelector, initialContent, place
                             <ImageAlignButton editor={editor} icon={<IconFloatCenter size={16} />} label="Center" cssClass="mx-auto d-block" />
                             <ImageAlignButton editor={editor} icon={<IconFloatRight size={16} />} label="Float right" cssClass="float-end" />
                             <ImageAlignButton editor={editor} icon={<IconFloatNone size={16} />} label="No alignment" cssClass={null} />
+                            <InsertCardImageButton
+                                editor={editor}
+                                icon={<IconPhoto size={16} />}
+                                label="Insert card image"
+                            />
                         </RichTextEditor.ControlsGroup>
 
                         <RichTextEditor.ControlsGroup>

--- a/docs/features.md
+++ b/docs/features.md
@@ -279,3 +279,20 @@ Public REST API for third-party integrations, mobile clients, and AI-powered too
 | F16.6   | CMS Pages API                                | Medium   |        | CRUD on pages (`/api/v1/pages`) with per-locale translations (title, slug, content in Markdown, SEO fields). `cms:read` returns published pages; `cms:write` requires `ROLE_CMS_EDITOR`. Depends on F16.1, F11.1. |
 | F16.7   | CMS Menu Categories API                      | Medium   |        | CRUD on menu categories (`/api/v1/categories`) with translations. Deletion fails if pages are still attached. Scope: `cms:read`, `cms:write` (requires `ROLE_CMS_EDITOR`). Depends on F16.1, F11.2. |
 | F16.8   | MCP Server for AI Integration                | Low      |        | Model Context Protocol server at `/mcp` (Streamable HTTP transport). Exposes event and CMS tools to AI agents (Claude Desktop, etc.). OAuth2 bearer auth — effective permissions are the intersection of token scopes and user roles (same model as REST API). Tools: `list_events`, `get_event`, `create_event`, `update_event`, `engage_event`, `list_attendees`, `list_pages`, `get_page`, `create_page`, `update_page`, `list_categories`. Depends on F16.1, F16.3–F16.7. |
+
+---
+
+## F17 — Content Editing Experience
+
+Rich text editing for Markdown fields (archetype descriptions, CMS pages) with a Tiptap-based editor, custom extensions for project-specific tags, and image management.
+
+| ID      | Feature                                      | Priority | Status | Description |
+|---------|----------------------------------------------|----------|--------|-------------|
+| F17.1   | Rich text editor with Markdown               | High     | Done   | Tiptap-based WYSIWYG editor for Markdown fields with a toggle between rich text and raw Markdown modes. Bidirectional Markdown serialization via `tiptap-markdown`. Used on archetype and CMS page edit forms. |
+| F17.2   | Card and deck reference tags                 | High     | Done   | Custom Tiptap node extensions for `[[card:SET-NUM]]` and `[[deck:SHORT_TAG]]` inline tags. Rendered as badges in the editor, serialized to/from Markdown as double-bracket syntax. |
+| F17.3   | Archetype reference tags                     | High     | Done   | Custom Tiptap node extension for `[[archetype:slug]]` inline tags. Same badge UX and Markdown serialization pattern as F17.2. |
+| F17.4   | Image upload backend (Flysystem)             | High     | Done   | Server-side image upload endpoint (`POST /api/editor/upload-image`) using Flysystem storage. Returns a URL for the uploaded image. Max 5 MB, JPEG/PNG/GIF/WebP. |
+| F17.5   | Image drag-and-drop in the editor            | High     | Done   | Drag-and-drop and paste support for images in the editor. Shows base64 preview immediately, uploads asynchronously, then replaces with server URL. Uses `@tiptap/extension-file-handler`. |
+| F17.6   | Toolbar buttons to insert reference tags     | Medium   | Done   | Reusable `InsertReferenceButton` component with popover input for inserting card, archetype, and deck reference tags from the toolbar. Validates input format before insertion. |
+| F17.7   | Image float and alignment                    | Medium   | Done   | `ResizableImage` extension with CSS class-based alignment (float left, center, float right, none). Dimensions serialized as style attributes. `ImageAlignButton` toolbar controls. |
+| F17.8   | Insert card image from reference             | Medium   |        | Toolbar button that prompts for a card reference (e.g. `UPR-100`), resolves it to a TCGdex image URL via a backend endpoint (`GET /api/card/image-url`), and inserts the image into the editor as a standard image node. Supports resize and alignment like any other image. Markdown output: `![SET-NUM](url)`. |

--- a/src/Controller/CardImageUrlController.php
+++ b/src/Controller/CardImageUrlController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Repository\DeckCardRepository;
+use App\Service\Tcgdex\TcgdexApiClient;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Resolves a card reference (e.g. "UPR-100") to its TCGdex image URL.
+ *
+ * @see docs/features.md F17.8 — Insert card image from reference in rich text editor
+ */
+class CardImageUrlController extends AbstractController
+{
+    public function __construct(
+        private readonly DeckCardRepository $deckCardRepository,
+        private readonly TcgdexApiClient $tcgdexApiClient,
+    ) {
+    }
+
+    #[Route('/api/card/image-url', name: 'app_card_image_url', methods: ['GET'])]
+    #[IsGranted('ROLE_CMS_EDITOR')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $reference = $request->query->getString('reference');
+        if ('' === $reference) {
+            return $this->json(['error' => 'Missing "reference" query parameter.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $lastHyphen = strrpos($reference, '-');
+        if (false === $lastHyphen) {
+            return $this->json(['error' => 'Invalid reference format. Expected "SET-NUMBER".'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $setCode = substr($reference, 0, $lastHyphen);
+        $cardNumber = substr($reference, $lastHyphen + 1);
+
+        // Try local DB first (enriched cards with image URLs)
+        $deckCard = $this->deckCardRepository->findOneBySetCodeAndCardNumber($setCode, $cardNumber);
+        if (null !== $deckCard && null !== $deckCard->getImageUrl()) {
+            return $this->json(['url' => $deckCard->getImageUrl()]);
+        }
+
+        // Fall back to TCGdex API
+        $tcgdexCard = $this->tcgdexApiClient->findCard($setCode, $cardNumber);
+        if (null !== $tcgdexCard && null !== $tcgdexCard->imageUrl) {
+            return $this->json(['url' => $tcgdexCard->imageUrl]);
+        }
+
+        return $this->json(['error' => 'Card not found.'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Closes #279

## Summary
- Add `GET /api/card/image-url?reference=SET-NUM` endpoint that resolves a card reference to its TCGdex image URL (local DB first, TCGdex API fallback)
- Add `InsertCardImageButton` toolbar component with popover input, loading state, and error handling
- Wire the button (📷 icon) into the MarkdownEditor image controls group
- Inserted images default to `max-width: 180px` and support resize/alignment like any other editor image
- Document the full F17 (Content Editing Experience) feature section in `docs/features.md`

## Test plan
- [x] Open an archetype or CMS page edit form
- [x] Click the photo icon in the image toolbar group
- [x] Enter a valid card reference (e.g. `SFA-46`) and submit
- [x] Verify the card image is inserted with 180px max-width
- [x] Verify the image can be resized and aligned after insertion
- [x] Enter an invalid or unknown reference and verify error is shown
- [x] Switch to Markdown mode and verify output is `![SFA-46](url){style="max-width: 180px"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)