### PR TITLE
:sparkles: Feature: footer category management

### DIFF
--- a/assets/admin-menu-category-list.ts
+++ b/assets/admin-menu-category-list.ts
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Drag-and-drop category reordering using SortableJS.
+ * Also handles accessible up/down arrow buttons as a fallback.
+ *
+ * @see docs/features.md F11.2 — Menu categories
+ */
+
+import Sortable from 'sortablejs';
+
+function getCategoryIds(tbody: HTMLTableSectionElement): number[] {
+    return Array.from(tbody.querySelectorAll<HTMLTableRowElement>('tr[data-category-id]'))
+        .map((row) => Number(row.dataset.categoryId));
+}
+
+function persistOrder(tbody: HTMLTableSectionElement): void {
+    const url = tbody.dataset.reorderUrl;
+    if (!url) {
+        return;
+    }
+
+    const categoryIds = getCategoryIds(tbody);
+
+    fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(categoryIds),
+    }).catch((error) => {
+        console.error('Reorder failed:', error);
+    });
+}
+
+function initSortable(): void {
+    const tbody = document.getElementById('sortable-categories') as HTMLTableSectionElement | null;
+    if (!tbody) {
+        return;
+    }
+
+    Sortable.create(tbody, {
+        handle: '.sortable-handle',
+        animation: 150,
+        ghostClass: 'table-active',
+        onEnd: () => {
+            persistOrder(tbody);
+        },
+    });
+
+    tbody.addEventListener('click', (event) => {
+        const target = event.target as HTMLElement;
+        const button = target.closest('.move-up-btn, .move-down-btn') as HTMLButtonElement | null;
+        if (!button) {
+            return;
+        }
+
+        const row = button.closest('tr') as HTMLTableRowElement;
+        if (!row) {
+            return;
+        }
+
+        if (button.classList.contains('move-up-btn') && row.previousElementSibling) {
+            row.parentNode?.insertBefore(row, row.previousElementSibling);
+            persistOrder(tbody);
+        } else if (button.classList.contains('move-down-btn') && row.nextElementSibling) {
+            row.parentNode?.insertBefore(row.nextElementSibling, row);
+            persistOrder(tbody);
+        }
+    });
+}
+
+initSortable();

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -531,6 +531,13 @@ footer {
 
     a {
         color: rgba(#fff, .7);
+        text-decoration: none;
         &:hover { color: $ed-gold; }
+    }
+
+    h6 {
+        color: rgba(#fff, .85);
+        font-weight: 600;
+        letter-spacing: .05em;
     }
 }

--- a/docs/models/cms.md
+++ b/docs/models/cms.md
@@ -18,13 +18,15 @@ Admin-managed grouping for content pages. Displayed in site navigation or footer
 |--------------|--------------------|----------|-------------|
 | `id`         | `int` (auto)       | No       | Primary key |
 | `position`   | `int`              | No       | Display order (ascending). Default: `0`. |
+| `isFooter`   | `bool`             | No       | Whether to display this category in the site footer instead of the navigation bar. Default: `false`. |
 | `createdAt`  | `DateTimeImmutable` | No      | Creation timestamp. |
 | `updatedAt`  | `DateTimeImmutable` | No      | Last modification timestamp. |
 
 ### Constraints
 
 - `position`: required, >= 0. Unique values recommended but not enforced (ties sorted by `id`).
-- Categories without any published page are hidden from the navigation.
+- `isFooter`: when `true`, the category appears in the site footer instead of the top navigation bar.
+- Categories without any published page are hidden from both the navigation and the footer.
 
 ### Relations
 

--- a/migrations/Version20260401153732.php
+++ b/migrations/Version20260401153732.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260401153732 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_footer flag to menu_category table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE menu_category ADD is_footer TINYINT NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE menu_category DROP is_footer');
+    }
+}

--- a/src/Controller/AdminMenuCategoryController.php
+++ b/src/Controller/AdminMenuCategoryController.php
@@ -19,10 +19,12 @@ use App\Form\MenuCategoryFormType;
 use App\Form\MenuCategoryTranslationFormType;
 use App\Repository\MenuCategoryRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -42,21 +44,53 @@ class AdminMenuCategoryController extends AbstractAppController
     }
 
     #[Route('', name: 'app_admin_menu_category_list', methods: ['GET'])]
-    public function list(MenuCategoryRepository $repository): Response
+    public function list(Request $request, MenuCategoryRepository $repository): Response
     {
+        $view = $request->query->getString('view', 'menu');
+        if (!\in_array($view, ['menu', 'footer'], true)) {
+            $view = 'menu';
+        }
+
+        $categories = 'footer' === $view
+            ? $repository->findFooterOrdered()
+            : $repository->findMenuOrdered();
+
         return $this->render('admin/menu_category/list.html.twig', [
-            'categories' => $repository->findAllOrdered(),
+            'categories' => $categories,
+            'currentView' => $view,
         ]);
     }
 
-    #[Route('/new', name: 'app_admin_menu_category_new', methods: ['GET', 'POST'])]
-    public function new(Request $request): Response
+    #[Route('/reorder', name: 'app_admin_menu_category_reorder', methods: ['POST'])]
+    public function reorder(Request $request, MenuCategoryRepository $repository, CacheInterface $menuCategoriesCache): JsonResponse
     {
+        /** @var list<int> $categoryIds */
+        $categoryIds = json_decode((string) $request->getContent(), true);
+        $repository->reorderCategories($categoryIds);
+
+        $menuCategoriesCache->delete('menu_categories');
+        $menuCategoriesCache->delete('footer_categories');
+
+        return new JsonResponse(['ok' => true]);
+    }
+
+    #[Route('/new', name: 'app_admin_menu_category_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, MenuCategoryRepository $repository): Response
+    {
+        $isFooter = 'footer' === $request->query->getString('view');
+
         $category = new MenuCategory();
+        $category->setIsFooter($isFooter);
+
         $form = $this->createForm(MenuCategoryFormType::class, $category);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $existingCategories = $isFooter
+                ? $repository->findFooterOrdered()
+                : $repository->findMenuOrdered();
+            $category->setPosition(\count($existingCategories));
+
             $this->em->persist($category);
             $this->em->flush();
 
@@ -67,23 +101,13 @@ class AdminMenuCategoryController extends AbstractAppController
 
         return $this->render('admin/menu_category/new.html.twig', [
             'form' => $form,
+            'isFooter' => $isFooter,
         ]);
     }
 
     #[Route('/{id}', name: 'app_admin_menu_category_edit', methods: ['GET', 'POST'], requirements: ['id' => '\d+'])]
     public function edit(Request $request, MenuCategory $category): Response
     {
-        $form = $this->createForm(MenuCategoryFormType::class, $category);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $this->em->flush();
-
-            $this->addFlash('success', 'app.cms.category_updated');
-
-            return $this->redirectToRoute('app_admin_menu_category_edit', ['id' => $category->getId()]);
-        }
-
         $translationForms = [];
         foreach (self::SUPPORTED_LOCALES as $locale) {
             $translation = $category->getTranslation($locale);
@@ -105,7 +129,6 @@ class AdminMenuCategoryController extends AbstractAppController
 
         return $this->render('admin/menu_category/edit.html.twig', [
             'category' => $category,
-            'form' => $form,
             'translationForms' => $translationForms,
             'supportedLocales' => self::SUPPORTED_LOCALES,
         ]);

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -1750,6 +1750,161 @@ Stay tuned!
 MD);
         $draftPage->addTranslation($draftEn);
         $manager->persist($draftEn);
+
+        // --- Footer categories ---
+
+        $projectCategory = new MenuCategory();
+        $projectCategory->setPosition(1);
+        $projectCategory->setIsFooter(true);
+        $manager->persist($projectCategory);
+
+        $projectEn = new MenuCategoryTranslation();
+        $projectEn->setMenuCategory($projectCategory);
+        $projectEn->setLocale('en');
+        $projectEn->setName('The Project');
+        $projectCategory->addTranslation($projectEn);
+        $manager->persist($projectEn);
+
+        $projectFr = new MenuCategoryTranslation();
+        $projectFr->setMenuCategory($projectCategory);
+        $projectFr->setLocale('fr');
+        $projectFr->setName('Le Projet');
+        $projectCategory->addTranslation($projectFr);
+        $manager->persist($projectFr);
+
+        $philosophyPage = new Page();
+        $philosophyPage->setSlug('the-philosophy');
+        $philosophyPage->setMenuCategory($projectCategory);
+        $philosophyPage->setIsPublished(true);
+        $philosophyPage->setPosition(1);
+        $manager->persist($philosophyPage);
+
+        $philosophyEn = new PageTranslation();
+        $philosophyEn->setPage($philosophyPage);
+        $philosophyEn->setLocale('en');
+        $philosophyEn->setTitle('The Philosophy');
+        $philosophyEn->setSlug('the-philosophy');
+        $philosophyEn->setContent(<<<'MD'
+        ## Our Philosophy
+
+        Expanded Decks was born from a simple idea: **making the Expanded format accessible to everyone**.
+
+        We believe that sharing physical decks within a community is the best way to grow the format and let players discover new strategies without the barrier of building a full collection.
+        MD);
+        $philosophyPage->addTranslation($philosophyEn);
+        $manager->persist($philosophyEn);
+
+        $philosophyFr = new PageTranslation();
+        $philosophyFr->setPage($philosophyPage);
+        $philosophyFr->setLocale('fr');
+        $philosophyFr->setTitle('La Philosophie');
+        $philosophyFr->setSlug('la-philosophie');
+        $philosophyFr->setContent(<<<'MD'
+        ## Notre Philosophie
+
+        Expanded Decks est né d'une idée simple : **rendre le format Expanded accessible à tous**.
+
+        Nous croyons que le partage de decks physiques au sein d'une communauté est le meilleur moyen de faire grandir le format et de permettre aux joueurs de découvrir de nouvelles stratégies sans la contrainte de constituer une collection complète.
+        MD);
+        $philosophyPage->addTranslation($philosophyFr);
+        $manager->persist($philosophyFr);
+
+        $teamPage = new Page();
+        $teamPage->setSlug('the-team');
+        $teamPage->setMenuCategory($projectCategory);
+        $teamPage->setIsPublished(true);
+        $teamPage->setPosition(2);
+        $manager->persist($teamPage);
+
+        $teamEn = new PageTranslation();
+        $teamEn->setPage($teamPage);
+        $teamEn->setLocale('en');
+        $teamEn->setTitle('The Team');
+        $teamEn->setSlug('the-team');
+        $teamEn->setContent(<<<'MD'
+        ## The Team
+
+        Expanded Decks is maintained by a small group of passionate Pokémon TCG players who love the Expanded format.
+
+        Want to contribute? Check out our [GitHub repository](https://github.com/jbourdin/expandedDecks).
+        MD);
+        $teamPage->addTranslation($teamEn);
+        $manager->persist($teamEn);
+
+        $teamFr = new PageTranslation();
+        $teamFr->setPage($teamPage);
+        $teamFr->setLocale('fr');
+        $teamFr->setTitle("L'Équipe");
+        $teamFr->setSlug('l-equipe');
+        $teamFr->setContent(<<<'MD'
+        ## L'Équipe
+
+        Expanded Decks est maintenu par un petit groupe de joueurs passionnés du JCC Pokémon qui adorent le format Expanded.
+
+        Envie de contribuer ? Consultez notre [dépôt GitHub](https://github.com/jbourdin/expandedDecks).
+        MD);
+        $teamPage->addTranslation($teamFr);
+        $manager->persist($teamFr);
+
+        $legalCategory = new MenuCategory();
+        $legalCategory->setPosition(2);
+        $legalCategory->setIsFooter(true);
+        $manager->persist($legalCategory);
+
+        $legalEn = new MenuCategoryTranslation();
+        $legalEn->setMenuCategory($legalCategory);
+        $legalEn->setLocale('en');
+        $legalEn->setName('Legal');
+        $legalCategory->addTranslation($legalEn);
+        $manager->persist($legalEn);
+
+        $legalFr = new MenuCategoryTranslation();
+        $legalFr->setMenuCategory($legalCategory);
+        $legalFr->setLocale('fr');
+        $legalFr->setName('Légal');
+        $legalCategory->addTranslation($legalFr);
+        $manager->persist($legalFr);
+
+        $legalNoticePage = new Page();
+        $legalNoticePage->setSlug('legal-notice');
+        $legalNoticePage->setMenuCategory($legalCategory);
+        $legalNoticePage->setIsPublished(true);
+        $legalNoticePage->setPosition(1);
+        $manager->persist($legalNoticePage);
+
+        $legalNoticeEn = new PageTranslation();
+        $legalNoticeEn->setPage($legalNoticePage);
+        $legalNoticeEn->setLocale('en');
+        $legalNoticeEn->setTitle('Legal Notice');
+        $legalNoticeEn->setSlug('legal-notice');
+        $legalNoticeEn->setContent(<<<'MD'
+        ## Legal Notice
+
+        **Expanded Decks** is a non-commercial, community-driven project.
+
+        Pokémon and Pokémon TCG are trademarks of Nintendo, Creatures Inc., and GAME FREAK Inc. This project is not affiliated with, endorsed, or sponsored by any of these companies.
+
+        All card data is sourced from the [TCGdex API](https://tcgdex.dev/).
+        MD);
+        $legalNoticePage->addTranslation($legalNoticeEn);
+        $manager->persist($legalNoticeEn);
+
+        $legalNoticeFr = new PageTranslation();
+        $legalNoticeFr->setPage($legalNoticePage);
+        $legalNoticeFr->setLocale('fr');
+        $legalNoticeFr->setTitle('Mentions Légales');
+        $legalNoticeFr->setSlug('mentions-legales');
+        $legalNoticeFr->setContent(<<<'MD'
+        ## Mentions Légales
+
+        **Expanded Decks** est un projet communautaire à but non lucratif.
+
+        Pokémon et Pokémon JCC sont des marques déposées de Nintendo, Creatures Inc. et GAME FREAK Inc. Ce projet n'est ni affilié, ni approuvé, ni sponsorisé par aucune de ces sociétés.
+
+        Les données de cartes proviennent de l'[API TCGdex](https://tcgdex.dev/).
+        MD);
+        $legalNoticePage->addTranslation($legalNoticeFr);
+        $manager->persist($legalNoticeFr);
     }
 
     private function createCharizardFlareonDeckVersion(ObjectManager $manager, Deck $deck): void

--- a/src/Entity/MenuCategory.php
+++ b/src/Entity/MenuCategory.php
@@ -34,6 +34,9 @@ class MenuCategory
     private int $position = 0;
 
     #[ORM\Column]
+    private bool $isFooter = false;
+
+    #[ORM\Column]
     private \DateTimeImmutable $createdAt;
 
     #[ORM\Column(nullable: true)]
@@ -67,6 +70,18 @@ class MenuCategory
     public function setPosition(int $position): static
     {
         $this->position = $position;
+
+        return $this;
+    }
+
+    public function isFooter(): bool
+    {
+        return $this->isFooter;
+    }
+
+    public function setIsFooter(bool $isFooter): static
+    {
+        $this->isFooter = $isFooter;
 
         return $this;
     }

--- a/src/EventListener/MenuCacheInvalidationListener.php
+++ b/src/EventListener/MenuCacheInvalidationListener.php
@@ -80,6 +80,7 @@ class MenuCacheInvalidationListener
         if ($this->shouldInvalidate) {
             $this->shouldInvalidate = false;
             $this->menuCategoriesCache->delete('menu_categories');
+            $this->menuCategoriesCache->delete('footer_categories');
         }
     }
 

--- a/src/Form/MenuCategoryFormType.php
+++ b/src/Form/MenuCategoryFormType.php
@@ -15,7 +15,6 @@ namespace App\Form;
 
 use App\Entity\MenuCategory;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -28,10 +27,6 @@ class MenuCategoryFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder
-            ->add('position', IntegerType::class, [
-                'label' => 'app.cms.form.position',
-            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Repository/MenuCategoryRepository.php
+++ b/src/Repository/MenuCategoryRepository.php
@@ -49,8 +49,67 @@ class MenuCategoryRepository extends ServiceEntityRepository
     }
 
     /**
-     * Find categories that have at least one published page, ordered by position.
-     * Eagerly loads published pages and their translations for menu rendering.
+     * Find menu (non-footer) categories ordered by position, with translations eagerly loaded.
+     *
+     * @return list<MenuCategory>
+     */
+    public function findMenuOrdered(): array
+    {
+        /** @var list<MenuCategory> $categories */
+        $categories = $this->createQueryBuilder('c')
+            ->leftJoin('c.translations', 't')
+            ->addSelect('t')
+            ->where('c.isFooter = false')
+            ->orderBy('c.position', 'ASC')
+            ->addOrderBy('c.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $categories;
+    }
+
+    /**
+     * Find footer categories ordered by position, with translations eagerly loaded.
+     *
+     * @return list<MenuCategory>
+     */
+    public function findFooterOrdered(): array
+    {
+        /** @var list<MenuCategory> $categories */
+        $categories = $this->createQueryBuilder('c')
+            ->leftJoin('c.translations', 't')
+            ->addSelect('t')
+            ->where('c.isFooter = true')
+            ->orderBy('c.position', 'ASC')
+            ->addOrderBy('c.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $categories;
+    }
+
+    /**
+     * Update positions for categories.
+     *
+     * @param list<int> $categoryIds ordered list of category IDs (index = new position)
+     */
+    public function reorderCategories(array $categoryIds): void
+    {
+        foreach ($categoryIds as $position => $categoryId) {
+            $this->createQueryBuilder('c')
+                ->update()
+                ->set('c.position', ':position')
+                ->where('c.id = :id')
+                ->setParameter('position', $position)
+                ->setParameter('id', $categoryId)
+                ->getQuery()
+                ->execute();
+        }
+    }
+
+    /**
+     * Find non-footer categories that have at least one published page, ordered by position.
+     * Eagerly loads published pages and their translations for navigation menu rendering.
      *
      * @return list<MenuCategory>
      */
@@ -65,6 +124,33 @@ class MenuCategoryRepository extends ServiceEntityRepository
             ->leftJoin('p.translations', 'pt')
             ->addSelect('pt')
             ->where('p.isPublished = true')
+            ->andWhere('c.isFooter = false')
+            ->orderBy('c.position', 'ASC')
+            ->addOrderBy('c.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $categories;
+    }
+
+    /**
+     * Find footer categories that have at least one published page, ordered by position.
+     * Eagerly loads published pages and their translations for footer rendering.
+     *
+     * @return list<MenuCategory>
+     */
+    public function findFooterWithPublishedPages(): array
+    {
+        /** @var list<MenuCategory> $categories */
+        $categories = $this->createQueryBuilder('c')
+            ->leftJoin('c.translations', 't')
+            ->addSelect('t')
+            ->innerJoin('c.pages', 'p')
+            ->addSelect('p')
+            ->leftJoin('p.translations', 'pt')
+            ->addSelect('pt')
+            ->where('p.isPublished = true')
+            ->andWhere('c.isFooter = true')
             ->orderBy('c.position', 'ASC')
             ->addOrderBy('c.id', 'ASC')
             ->getQuery()

--- a/src/Twig/Extension/MenuExtension.php
+++ b/src/Twig/Extension/MenuExtension.php
@@ -29,6 +29,7 @@ class MenuExtension extends AbstractExtension
     {
         return [
             new TwigFunction('menu_categories', [MenuRuntime::class, 'getCategories']),
+            new TwigFunction('footer_categories', [MenuRuntime::class, 'getFooterCategories']),
         ];
     }
 }

--- a/src/Twig/Runtime/MenuRuntime.php
+++ b/src/Twig/Runtime/MenuRuntime.php
@@ -47,8 +47,24 @@ class MenuRuntime implements RuntimeExtensionInterface
         return $categories;
     }
 
+    /**
+     * @return list<MenuCategory>
+     */
+    public function getFooterCategories(): array
+    {
+        /** @var list<MenuCategory> $categories */
+        $categories = $this->menuCategoriesCache->get('footer_categories', function (ItemInterface $item): array {
+            $item->expiresAfter(3600);
+
+            return $this->menuCategoryRepository->findFooterWithPublishedPages();
+        });
+
+        return $categories;
+    }
+
     public function invalidateCache(): void
     {
         $this->menuCategoriesCache->delete('menu_categories');
+        $this->menuCategoriesCache->delete('footer_categories');
     }
 }

--- a/templates/admin/menu_category/edit.html.twig
+++ b/templates/admin/menu_category/edit.html.twig
@@ -13,20 +13,7 @@
 {% block body %}
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h1 class="mb-0">{{ 'app.cms.admin.edit_category'|trans }}: {{ category.getName(app.request.locale) }}</h1>
-        <a href="{{ path('app_admin_menu_category_list') }}" class="btn btn-outline-secondary">{{ 'app.common.back'|trans }}</a>
-    </div>
-
-    {# Category settings #}
-    <div class="card shadow-sm mb-4">
-        <div class="card-header card-header-themed">
-            <h5 class="mb-0">{{ 'app.cms.admin.category_settings'|trans }}</h5>
-        </div>
-        <div class="card-body">
-            {{ form_start(form) }}
-                {{ form_widget(form) }}
-                <button type="submit" class="btn btn-gold mt-3">{{ 'app.common.save'|trans }}</button>
-            {{ form_end(form) }}
-        </div>
+        <a href="{{ path('app_admin_menu_category_list', {view: category.footer ? 'footer' : 'menu'}) }}" class="btn btn-outline-secondary">{{ 'app.common.back'|trans }}</a>
     </div>
 
     {# Translations — tabbed card #}

--- a/templates/admin/menu_category/list.html.twig
+++ b/templates/admin/menu_category/list.html.twig
@@ -5,7 +5,16 @@
 {% block body %}
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h1 class="mb-0">{{ 'app.cms.admin.categories_title'|trans }}</h1>
-        <a href="{{ path('app_admin_menu_category_new') }}" class="btn btn-gold">{{ 'app.cms.admin.new_category'|trans }}</a>
+        <a href="{{ path('app_admin_menu_category_new', {view: currentView}) }}" class="btn btn-gold">{{ 'app.cms.admin.new_category'|trans }}</a>
+    </div>
+
+    <div class="btn-group mb-4" role="group" aria-label="{{ 'app.cms.admin.category_view'|trans }}">
+        <a href="{{ path('app_admin_menu_category_list', {view: 'menu'}) }}" class="btn {{ currentView == 'menu' ? 'btn-gold' : 'btn-outline-secondary' }}">
+            {{ 'app.cms.admin.view_menu'|trans }}
+        </a>
+        <a href="{{ path('app_admin_menu_category_list', {view: 'footer'}) }}" class="btn {{ currentView == 'footer' ? 'btn-gold' : 'btn-outline-secondary' }}">
+            {{ 'app.cms.admin.view_footer'|trans }}
+        </a>
     </div>
 
     {% if categories is not empty %}
@@ -14,16 +23,22 @@
                 <table class="table table-striped table-themed mb-0">
                     <thead>
                         <tr>
-                            <th style="width: 80px">{{ 'app.cms.admin.table.position'|trans }}</th>
+                            <th style="width: 50px"></th>
                             <th>{{ 'app.common.name'|trans }}</th>
                             <th style="width: 100px">{{ 'app.cms.admin.table.pages_count'|trans }}</th>
                             <th></th>
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody id="sortable-categories" data-reorder-url="{{ path('app_admin_menu_category_reorder') }}">
                         {% for category in categories %}
-                            <tr>
-                                <td>{{ category.position }}</td>
+                            <tr data-category-id="{{ category.id }}">
+                                <td class="text-center align-middle">
+                                    <span class="sortable-handle d-none d-md-inline" style="cursor: grab" aria-label="{{ 'app.cms.admin.drag_to_reorder'|trans }}"><i class="bi bi-grip-vertical"></i></span>
+                                    <span class="d-inline d-md-none">
+                                        <button type="button" class="btn btn-sm btn-link p-0 move-up-btn" aria-label="{{ 'app.cms.admin.move_up'|trans }}"><i class="bi bi-chevron-up"></i></button>
+                                        <button type="button" class="btn btn-sm btn-link p-0 move-down-btn" aria-label="{{ 'app.cms.admin.move_down'|trans }}"><i class="bi bi-chevron-down"></i></button>
+                                    </span>
+                                </td>
                                 <td>{{ category.getName(app.request.locale) }}</td>
                                 <td>{{ category.pages|length }}</td>
                                 <td>
@@ -40,4 +55,9 @@
     {% else %}
         <div class="alert alert-info">{{ 'app.cms.admin.no_categories'|trans }}</div>
     {% endif %}
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {{ encore_entry_script_tags('admin_menu_category_list') }}
 {% endblock %}

--- a/templates/admin/menu_category/new.html.twig
+++ b/templates/admin/menu_category/new.html.twig
@@ -5,7 +5,7 @@
 {% block body %}
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h1 class="mb-0">{{ 'app.cms.admin.new_category'|trans }}</h1>
-        <a href="{{ path('app_admin_menu_category_list') }}" class="btn btn-outline-secondary">{{ 'app.common.back'|trans }}</a>
+        <a href="{{ path('app_admin_menu_category_list', {view: isFooter ? 'footer' : 'menu'}) }}" class="btn btn-outline-secondary">{{ 'app.common.back'|trans }}</a>
     </div>
 
     <div class="card shadow-sm">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -41,7 +41,7 @@
                                 <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
                             </li>
                             {% for category in menu_categories() %}
-                                {% set pages = category.pages|filter(p => p.published)|sort((a, b) => b.createdAt <=> a.createdAt) %}
+                                {% set pages = category.pages|filter(p => p.published)|sort((a, b) => a.position <=> b.position) %}
                                 {% if pages|length == 1 %}
                                     <li class="nav-item">
                                         <a class="nav-link" href="{{ path('app_page_show', {slug: pages|first.slug}) }}">{{ category.getName(app.request.locale) }}</a>
@@ -121,7 +121,7 @@
                                 <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
                             </li>
                             {% for category in menu_categories() %}
-                                {% set pages = category.pages|filter(p => p.published)|sort((a, b) => b.createdAt <=> a.createdAt) %}
+                                {% set pages = category.pages|filter(p => p.published)|sort((a, b) => a.position <=> b.position) %}
                                 {% if pages|length == 1 %}
                                     <li class="nav-item">
                                         <a class="nav-link" href="{{ path('app_page_show', {slug: pages|first.slug}) }}">{{ category.getName(app.request.locale) }}</a>
@@ -166,12 +166,33 @@
             {% block body %}{% endblock %}
         </main>
 
-        <footer class="footer-pokemon py-3 mt-auto">
-            <div class="container text-center">
-                &copy; {{ "now"|date("Y") }} {{ 'app.footer.copyright'|trans }}
-                <span class="ms-2" style="font-size: 0.75rem;">{{ app_version }}</span>
-                <span class="ms-2">·</span>
-                <a href="https://github.com/jbourdin/expandedDecks" class="ms-1" target="_blank" rel="noopener">GitHub</a>
+        <footer class="footer-pokemon py-4 mt-auto">
+            <div class="container">
+                {% set footerCategories = footer_categories() %}
+                {% if footerCategories is not empty %}
+                    <div class="row mb-3">
+                        {% for category in footerCategories %}
+                            {% set pages = category.pages|filter(p => p.published)|sort((a, b) => a.position <=> b.position) %}
+                            {% if pages is not empty %}
+                                <div class="col-sm-4 col-md-3">
+                                    <h6 class="text-uppercase mb-2">{{ category.getName(app.request.locale) }}</h6>
+                                    <ul class="list-unstyled">
+                                        {% for page in pages %}
+                                            <li class="mb-1"><a href="{{ path('app_page_show', {slug: page.slug}) }}">{{ page.getTitle(app.request.locale) }}</a></li>
+                                        {% endfor %}
+                                    </ul>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                    <hr class="my-2">
+                {% endif %}
+                <div class="text-center">
+                    &copy; {{ "now"|date("Y") }} {{ 'app.footer.copyright'|trans }}
+                    <span class="ms-2" style="font-size: 0.75rem;">{{ app_version }}</span>
+                    <span class="ms-2">·</span>
+                    <a href="https://github.com/jbourdin/expandedDecks" class="ms-1" target="_blank" rel="noopener">GitHub</a>
+                </div>
             </div>
         </footer>
 

--- a/tests/EventListener/MenuCacheInvalidationListenerTest.php
+++ b/tests/EventListener/MenuCacheInvalidationListenerTest.php
@@ -54,7 +54,7 @@ class MenuCacheInvalidationListenerTest extends TestCase
         $this->listener->onFlush($onFlushArgs);
 
         // Trigger postFlush to verify the flag was set
-        $this->cache->expects(self::once())->method('delete')->with('menu_categories');
+        $this->cache->expects(self::exactly(2))->method('delete');
         $this->listener->postFlush($this->createPostFlushArgs());
     }
 
@@ -66,7 +66,7 @@ class MenuCacheInvalidationListenerTest extends TestCase
 
         $this->listener->onFlush($onFlushArgs);
 
-        $this->cache->expects(self::once())->method('delete')->with('menu_categories');
+        $this->cache->expects(self::exactly(2))->method('delete');
         $this->listener->postFlush($this->createPostFlushArgs());
     }
 
@@ -78,7 +78,7 @@ class MenuCacheInvalidationListenerTest extends TestCase
 
         $this->listener->onFlush($onFlushArgs);
 
-        $this->cache->expects(self::once())->method('delete')->with('menu_categories');
+        $this->cache->expects(self::exactly(2))->method('delete');
         $this->listener->postFlush($this->createPostFlushArgs());
     }
 
@@ -90,7 +90,7 @@ class MenuCacheInvalidationListenerTest extends TestCase
 
         $this->listener->onFlush($onFlushArgs);
 
-        $this->cache->expects(self::once())->method('delete')->with('menu_categories');
+        $this->cache->expects(self::exactly(2))->method('delete');
         $this->listener->postFlush($this->createPostFlushArgs());
     }
 
@@ -106,7 +106,7 @@ class MenuCacheInvalidationListenerTest extends TestCase
 
         $this->listener->onFlush($onFlushArgs);
 
-        $this->cache->expects(self::once())->method('delete')->with('menu_categories');
+        $this->cache->expects(self::exactly(2))->method('delete');
         $this->listener->postFlush($this->createPostFlushArgs());
     }
 
@@ -118,7 +118,7 @@ class MenuCacheInvalidationListenerTest extends TestCase
 
         $this->listener->onFlush($onFlushArgs);
 
-        $this->cache->expects(self::once())->method('delete')->with('menu_categories');
+        $this->cache->expects(self::exactly(2))->method('delete');
         $this->listener->postFlush($this->createPostFlushArgs());
     }
 
@@ -134,7 +134,7 @@ class MenuCacheInvalidationListenerTest extends TestCase
 
         $this->listener->onFlush($onFlushArgs);
 
-        $this->cache->expects(self::once())->method('delete')->with('menu_categories');
+        $this->cache->expects(self::exactly(2))->method('delete');
         $this->listener->postFlush($this->createPostFlushArgs());
     }
 
@@ -146,7 +146,7 @@ class MenuCacheInvalidationListenerTest extends TestCase
 
         $this->listener->onFlush($onFlushArgs);
 
-        $this->cache->expects(self::once())->method('delete')->with('menu_categories');
+        $this->cache->expects(self::exactly(2))->method('delete');
         $this->listener->postFlush($this->createPostFlushArgs());
     }
 
@@ -192,7 +192,7 @@ class MenuCacheInvalidationListenerTest extends TestCase
         $this->listener->onFlush($onFlushArgs);
 
         // First postFlush triggers invalidation
-        $this->cache->expects(self::once())->method('delete')->with('menu_categories');
+        $this->cache->expects(self::exactly(2))->method('delete');
         $this->listener->postFlush($this->createPostFlushArgs());
 
         // Second postFlush without a new onFlush should NOT invalidate

--- a/tests/Twig/MenuRuntimeTest.php
+++ b/tests/Twig/MenuRuntimeTest.php
@@ -85,13 +85,65 @@ class MenuRuntimeTest extends TestCase
         self::assertSame([], $result);
     }
 
-    public function testInvalidateCacheDeletesCacheKey(): void
+    public function testGetFooterCategoriesReturnsCachedResult(): void
     {
+        $category = new MenuCategory();
+        $category->setPosition(1);
+        $category->setIsFooter(true);
+
         $repository = $this->createStub(MenuCategoryRepository::class);
         $cache = $this->createMock(CacheInterface::class);
         $cache->expects(self::once())
+            ->method('get')
+            ->with('footer_categories', self::callback(static fn (mixed $value): bool => \is_callable($value)))
+            ->willReturn([$category]);
+
+        $runtime = new MenuRuntime($repository, $cache);
+        $result = $runtime->getFooterCategories();
+
+        self::assertCount(1, $result);
+        self::assertSame($category, $result[0]);
+    }
+
+    public function testGetFooterCategoriesCallsRepositoryOnCacheMiss(): void
+    {
+        $category = new MenuCategory();
+        $category->setPosition(1);
+        $category->setIsFooter(true);
+
+        $repository = $this->createMock(MenuCategoryRepository::class);
+        $repository->expects(self::once())
+            ->method('findFooterWithPublishedPages')
+            ->willReturn([$category]);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())
+            ->method('get')
+            ->with('footer_categories', self::callback(static fn (mixed $value): bool => \is_callable($value)))
+            ->willReturnCallback(function (string $key, callable $callback) {
+                $item = $this->createStub(ItemInterface::class);
+
+                return $callback($item);
+            });
+
+        $runtime = new MenuRuntime($repository, $cache);
+        $result = $runtime->getFooterCategories();
+
+        self::assertCount(1, $result);
+        self::assertSame($category, $result[0]);
+    }
+
+    public function testInvalidateCacheDeletesBothCacheKeys(): void
+    {
+        $repository = $this->createStub(MenuCategoryRepository::class);
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::exactly(2))
             ->method('delete')
-            ->with('menu_categories');
+            ->willReturnCallback(static function (string $key): bool {
+                self::assertContains($key, ['menu_categories', 'footer_categories']);
+
+                return true;
+            });
 
         $runtime = new MenuRuntime($repository, $cache);
         $runtime->invalidateCache();

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -3627,6 +3627,18 @@
                 <source>app.cms.admin.no_categories</source>
                 <target>No categories found.</target>
             </trans-unit>
+            <trans-unit id="app.cms.admin.category_view">
+                <source>app.cms.admin.category_view</source>
+                <target>Category view</target>
+            </trans-unit>
+            <trans-unit id="app.cms.admin.view_menu">
+                <source>app.cms.admin.view_menu</source>
+                <target>Menu</target>
+            </trans-unit>
+            <trans-unit id="app.cms.admin.view_footer">
+                <source>app.cms.admin.view_footer</source>
+                <target>Footer</target>
+            </trans-unit>
             <trans-unit id="app.cms.admin.table.title">
                 <source>app.cms.admin.table.title</source>
                 <target>Title</target>
@@ -3646,6 +3658,10 @@
             <trans-unit id="app.cms.admin.table.pages_count">
                 <source>app.cms.admin.table.pages_count</source>
                 <target>Pages</target>
+            </trans-unit>
+            <trans-unit id="app.cms.admin.table.footer">
+                <source>app.cms.admin.table.footer</source>
+                <target>Footer</target>
             </trans-unit>
 
             <!-- CMS: Form labels -->
@@ -3708,6 +3724,10 @@
             <trans-unit id="app.cms.form.position">
                 <source>app.cms.form.position</source>
                 <target>Position</target>
+            </trans-unit>
+            <trans-unit id="app.cms.form.is_footer">
+                <source>app.cms.form.is_footer</source>
+                <target>Display in footer</target>
             </trans-unit>
 
             <!-- CMS: Status badges -->

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -3627,6 +3627,18 @@
                 <source>app.cms.admin.no_categories</source>
                 <target>Aucune catégorie trouvée.</target>
             </trans-unit>
+            <trans-unit id="app.cms.admin.category_view">
+                <source>app.cms.admin.category_view</source>
+                <target>Vue des catégories</target>
+            </trans-unit>
+            <trans-unit id="app.cms.admin.view_menu">
+                <source>app.cms.admin.view_menu</source>
+                <target>Menu</target>
+            </trans-unit>
+            <trans-unit id="app.cms.admin.view_footer">
+                <source>app.cms.admin.view_footer</source>
+                <target>Pied de page</target>
+            </trans-unit>
             <trans-unit id="app.cms.admin.table.title">
                 <source>app.cms.admin.table.title</source>
                 <target>Titre</target>
@@ -3646,6 +3658,10 @@
             <trans-unit id="app.cms.admin.table.pages_count">
                 <source>app.cms.admin.table.pages_count</source>
                 <target>Pages</target>
+            </trans-unit>
+            <trans-unit id="app.cms.admin.table.footer">
+                <source>app.cms.admin.table.footer</source>
+                <target>Pied de page</target>
             </trans-unit>
 
             <!-- CMS: Form labels -->
@@ -3708,6 +3724,10 @@
             <trans-unit id="app.cms.form.position">
                 <source>app.cms.form.position</source>
                 <target>Position</target>
+            </trans-unit>
+            <trans-unit id="app.cms.form.is_footer">
+                <source>app.cms.form.is_footer</source>
+                <target>Afficher dans le pied de page</target>
             </trans-unit>
 
             <!-- CMS: Status badges -->

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ Encore
     .addEntry('archetype_form', './assets/archetype-form.tsx')
     .addEntry('page_form', './assets/page-form.tsx')
     .addEntry('admin_page_list', './assets/admin-page-list.ts')
+    .addEntry('admin_menu_category_list', './assets/admin-menu-category-list.ts')
     .addEntry('toggle_private_decks', './assets/toggle-private-decks.ts')
     .addEntry('friendly_captcha', './assets/friendly-captcha.ts')
     .addEntry('deck_found', './assets/deck-found.tsx')


### PR DESCRIPTION
## Summary

- Add `isFooter` boolean flag to `MenuCategory` entity with migration
- Footer categories render in the site footer with pages ordered by position
- Admin category list uses a **Menu / Footer toggle** (mutually exclusive views)
- **Drag-and-drop reordering** (SortableJS) with mobile up/down fallback buttons
- New categories inherit their type (menu/footer) from the active view; position auto-assigned at end
- Position and isFooter removed from the category form — ordering is visual, type is implicit
- Navigation menu pages now sorted by position instead of createdAt
- Reorder endpoint flushes both `menu_categories` and `footer_categories` caches
- Fixtures: "The Project" (The Philosophy, The Team) and "Legal" (Legal Notice / Mentions Légales)
- Footer styling: no underline on links, brighter category headings
- Updated docs, translations (EN/FR), and tests

Closes #300

## Test plan
- [ ] Run migration (`make migrations`)
- [ ] Load fixtures (`make fixtures`) — verify two footer categories created
- [ ] Visit the site footer — confirm "The Project" and "Legal" sections appear with correct pages
- [ ] Admin > Menu Categories — verify Menu/Footer toggle switches views
- [ ] Drag-and-drop reorder in both views — verify order persists after page reload
- [ ] Create a new category from Footer view — confirm it is a footer category
- [ ] Create a new category from Menu view — confirm it is a menu category
- [ ] Verify navigation menu still shows only non-footer categories in correct order
- [ ] Test in FR locale — verify translated category names and page titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)