### PR TITLE
:recycle: Refactor: split richText into richText and pageEmbed blocks

### DIFF
--- a/assets/components/BlockEditModal.tsx
+++ b/assets/components/BlockEditModal.tsx
@@ -168,7 +168,7 @@ export default function BlockEditModal({
                 />
 
                 {/* Type-specific non-translatable settings */}
-                {blockType === 'richText' && (
+                {blockType === 'pageEmbed' && (
                     <TextInput
                         label={label('pageSlug')}
                         value={(editedBlock.pageSlug as string) ?? ''}

--- a/docs/models/homepage.md
+++ b/docs/models/homepage.md
@@ -60,7 +60,8 @@ String-backed PHP enum defining the available block types.
 | Case            | Value            | Description |
 |-----------------|------------------|-------------|
 | `Hero`          | `hero`           | Full-width hero banner with title, subtitle, and CTA buttons. |
-| `RichText`      | `richText`       | Markdown content block (optionally sourced from a CMS page). |
+| `RichText`      | `richText`       | Inline Markdown content block with per-locale translatable content. |
+| `PageEmbed`     | `pageEmbed`      | Embeds a CMS page by slug, rendering its Markdown content. |
 | `Carousel`      | `carousel`       | Swipeable image slideshow with per-item links and scheduling. |
 | `LatestPages`   | `latestPages`    | Auto-populated list of recent published pages from a category. |
 | `FeaturedDeck`  | `featuredDeck`   | Highlighted deck card with description and image. |
@@ -92,7 +93,9 @@ Each entry in `HomepageLayout.blocks` is an object with common and type-specific
 
 **hero** — Translatable: `title`, `subtitle`, `ctaButtons[]` (each with `label`, `route`, `style`).
 
-**richText** — `pageSlug` (optional, source content from a CMS page). Translatable: `content` (Markdown, used when no `pageSlug`).
+**richText** — Translatable: `content` (Markdown, rendered to HTML). Inline content stored in `HomepageLayoutTranslation`.
+
+**pageEmbed** — `pageSlug` (CMS page slug to embed). Content comes from the referenced page's translation, not from `HomepageLayoutTranslation`.
 
 **carousel** — `items[]` (each with `image`, `alt`, `link`, `startAt`, `endAt`). Translatable: per-item `alt` text.
 

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -2248,7 +2248,7 @@ PTCG;
                 'endAt' => null,
             ],
             [
-                'type' => 'richText',
+                'type' => 'pageEmbed',
                 'columnWidth' => 6,
                 'cssClasses' => null,
                 'startAt' => null,

--- a/src/Enum/HomepageBlockType.php
+++ b/src/Enum/HomepageBlockType.php
@@ -22,6 +22,7 @@ enum HomepageBlockType: string
 {
     case Hero = 'hero';
     case RichText = 'richText';
+    case PageEmbed = 'pageEmbed';
     case Carousel = 'carousel';
     case LatestPages = 'latestPages';
     case FeaturedDeck = 'featuredDeck';
@@ -35,6 +36,7 @@ enum HomepageBlockType: string
         return match ($this) {
             self::Hero => 'app.homepage.block_type.hero',
             self::RichText => 'app.homepage.block_type.rich_text',
+            self::PageEmbed => 'app.homepage.block_type.page_embed',
             self::Carousel => 'app.homepage.block_type.carousel',
             self::LatestPages => 'app.homepage.block_type.latest_pages',
             self::FeaturedDeck => 'app.homepage.block_type.featured_deck',
@@ -50,6 +52,7 @@ enum HomepageBlockType: string
         return match ($this) {
             self::Hero => 'bi-megaphone',
             self::RichText => 'bi-file-richtext',
+            self::PageEmbed => 'bi-box-arrow-in-right',
             self::Carousel => 'bi-images',
             self::LatestPages => 'bi-newspaper',
             self::FeaturedDeck => 'bi-collection',
@@ -64,7 +67,7 @@ enum HomepageBlockType: string
     {
         return match ($this) {
             self::Hero, self::RichText, self::FeaturedDeck, self::FeaturedEvent => true,
-            self::Carousel, self::LatestPages => false,
+            self::Carousel, self::LatestPages, self::PageEmbed => false,
         };
     }
 }

--- a/src/Service/HomepageRenderer.php
+++ b/src/Service/HomepageRenderer.php
@@ -62,7 +62,7 @@ class HomepageRenderer
             }
 
             $translated = $blockTranslations[$index] ?? $blockTranslations[(string) $index] ?? [];
-            $resolvedData = $this->resolveBlockData($type, $block, $locale);
+            $resolvedData = $this->resolveBlockData($type, $block, $locale, $translated);
 
             $columnWidth = $block['columnWidth'] ?? null;
             $cssClasses = $block['cssClasses'] ?? null;
@@ -106,13 +106,15 @@ class HomepageRenderer
      * Resolve dynamic runtime data for a block.
      *
      * @param array<string, mixed> $block
+     * @param array<string, mixed> $translated
      *
      * @return array<string, mixed>
      */
-    private function resolveBlockData(HomepageBlockType $type, array $block, string $locale): array
+    private function resolveBlockData(HomepageBlockType $type, array $block, string $locale, array $translated = []): array
     {
         return match ($type) {
-            HomepageBlockType::RichText => $this->resolveRichText($block, $locale),
+            HomepageBlockType::RichText => $this->resolveRichText($block, $locale, $translated),
+            HomepageBlockType::PageEmbed => $this->resolvePageEmbed($block, $locale),
             HomepageBlockType::LatestPages => $this->resolveLatestPages($block, $locale),
             HomepageBlockType::FeaturedEvent => $this->resolveFeaturedEvent(),
             HomepageBlockType::FeaturedDeck => $this->resolveFeaturedDeck(),
@@ -122,11 +124,34 @@ class HomepageRenderer
     }
 
     /**
+     * Resolve inline rich text block — renders translatable Markdown content to HTML.
+     * The Markdown content comes from HomepageLayoutTranslation, not from a CMS page.
+     *
+     * @param array<string, mixed> $block
+     * @param array<string, mixed> $translated
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveRichText(array $block, string $locale, array $translated = []): array
+    {
+        $content = $translated['content'] ?? null;
+        if (!\is_string($content) || '' === $content) {
+            return [];
+        }
+
+        return [
+            'html' => $this->markdownRenderer->render($content),
+        ];
+    }
+
+    /**
+     * Resolve page embed block — fetches a CMS page by slug and renders its Markdown content.
+     *
      * @param array<string, mixed> $block
      *
      * @return array<string, mixed>
      */
-    private function resolveRichText(array $block, string $locale): array
+    private function resolvePageEmbed(array $block, string $locale): array
     {
         $pageSlug = $block['pageSlug'] ?? null;
         if (!\is_string($pageSlug) || '' === $pageSlug) {

--- a/templates/admin/homepage/editor.html.twig
+++ b/templates/admin/homepage/editor.html.twig
@@ -29,6 +29,7 @@
          data-block-types="{{ [
              {value: 'hero', label: 'app.homepage.block_type.hero'|trans, icon: 'bi-megaphone'},
              {value: 'richText', label: 'app.homepage.block_type.rich_text'|trans, icon: 'bi-file-richtext'},
+             {value: 'pageEmbed', label: 'app.homepage.block_type.page_embed'|trans, icon: 'bi-box-arrow-in-right'},
              {value: 'carousel', label: 'app.homepage.block_type.carousel'|trans, icon: 'bi-images'},
              {value: 'latestPages', label: 'app.homepage.block_type.latest_pages'|trans, icon: 'bi-newspaper'},
              {value: 'featuredDeck', label: 'app.homepage.block_type.featured_deck'|trans, icon: 'bi-collection'},

--- a/templates/home/blocks.html.twig
+++ b/templates/home/blocks.html.twig
@@ -21,6 +21,7 @@
         {% set templateMap = {
             'hero': '_hero',
             'richText': '_rich_text',
+            'pageEmbed': '_page_embed',
             'carousel': '_carousel',
             'latestPages': '_latest_pages',
             'featuredDeck': '_featured_deck',

--- a/templates/home/blocks/_page_embed.html.twig
+++ b/templates/home/blocks/_page_embed.html.twig
@@ -1,0 +1,16 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{# @see docs/features.md F10.4 — Homepage rendering service and Twig block partials #}
+{% if entry.resolvedData.html is defined and entry.resolvedData.html is not empty %}
+    <div class="card shadow-sm mb-4">
+        <div class="card-body cms-content">
+            {{ entry.resolvedData.html|raw }}
+        </div>
+    </div>
+{% endif %}

--- a/tests/Enum/HomepageBlockTypeTest.php
+++ b/tests/Enum/HomepageBlockTypeTest.php
@@ -45,6 +45,11 @@ class HomepageBlockTypeTest extends TestCase
         self::assertTrue(HomepageBlockType::RichText->hasTranslatableContent());
     }
 
+    public function testPageEmbedHasNoTranslatableContent(): void
+    {
+        self::assertFalse(HomepageBlockType::PageEmbed->hasTranslatableContent());
+    }
+
     public function testCarouselHasNoTranslatableContent(): void
     {
         self::assertFalse(HomepageBlockType::Carousel->hasTranslatableContent());
@@ -69,6 +74,7 @@ class HomepageBlockTypeTest extends TestCase
     {
         self::assertSame(HomepageBlockType::Hero, HomepageBlockType::tryFrom('hero'));
         self::assertSame(HomepageBlockType::RichText, HomepageBlockType::tryFrom('richText'));
+        self::assertSame(HomepageBlockType::PageEmbed, HomepageBlockType::tryFrom('pageEmbed'));
         self::assertSame(HomepageBlockType::Carousel, HomepageBlockType::tryFrom('carousel'));
         self::assertSame(HomepageBlockType::LatestPages, HomepageBlockType::tryFrom('latestPages'));
         self::assertSame(HomepageBlockType::FeaturedDeck, HomepageBlockType::tryFrom('featuredDeck'));
@@ -84,6 +90,7 @@ class HomepageBlockTypeTest extends TestCase
     {
         self::assertSame('app.homepage.block_type.hero', HomepageBlockType::Hero->label());
         self::assertSame('app.homepage.block_type.rich_text', HomepageBlockType::RichText->label());
+        self::assertSame('app.homepage.block_type.page_embed', HomepageBlockType::PageEmbed->label());
         self::assertSame('app.homepage.block_type.carousel', HomepageBlockType::Carousel->label());
         self::assertSame('app.homepage.block_type.latest_pages', HomepageBlockType::LatestPages->label());
         self::assertSame('app.homepage.block_type.featured_deck', HomepageBlockType::FeaturedDeck->label());

--- a/tests/Service/HomepageRendererTest.php
+++ b/tests/Service/HomepageRendererTest.php
@@ -100,7 +100,41 @@ class HomepageRendererTest extends TestCase
         self::assertSame('Hello world', $result[0]->translations['subtitle']);
     }
 
-    public function testResolveRichTextWithPageSlug(): void
+    public function testResolveRichTextWithTranslatableContent(): void
+    {
+        $layout = new HomepageLayout();
+        $layout->setBlocks([
+            ['type' => 'richText', 'startAt' => null, 'endAt' => null, 'columnWidth' => null, 'cssClasses' => null],
+        ]);
+
+        $translation = new HomepageLayoutTranslation();
+        $translation->setLocale('en');
+        $translation->setBlockTranslations([
+            0 => ['content' => '## Hello World'],
+        ]);
+        $layout->addTranslation($translation);
+
+        $result = $this->renderer->resolve($layout, 'en');
+
+        self::assertCount(1, $result);
+        self::assertSame(HomepageBlockType::RichText, $result[0]->type);
+        self::assertStringContainsString('Hello World', $result[0]->resolvedData['html']);
+    }
+
+    public function testResolveRichTextWithEmptyContentReturnsEmptyData(): void
+    {
+        $layout = new HomepageLayout();
+        $layout->setBlocks([
+            ['type' => 'richText', 'startAt' => null, 'endAt' => null, 'columnWidth' => null, 'cssClasses' => null],
+        ]);
+
+        $result = $this->renderer->resolve($layout, 'en');
+
+        self::assertCount(1, $result);
+        self::assertSame([], $result[0]->resolvedData);
+    }
+
+    public function testResolvePageEmbedWithPageSlug(): void
     {
         $page = new Page();
         $page->setSlug('welcome');
@@ -116,23 +150,23 @@ class HomepageRendererTest extends TestCase
 
         $layout = new HomepageLayout();
         $layout->setBlocks([
-            ['type' => 'richText', 'startAt' => null, 'endAt' => null, 'columnWidth' => null, 'cssClasses' => null, 'pageSlug' => 'welcome'],
+            ['type' => 'pageEmbed', 'startAt' => null, 'endAt' => null, 'columnWidth' => null, 'cssClasses' => null, 'pageSlug' => 'welcome'],
         ]);
 
         $result = $this->renderer->resolve($layout, 'en');
 
         self::assertCount(1, $result);
-        self::assertSame(HomepageBlockType::RichText, $result[0]->type);
+        self::assertSame(HomepageBlockType::PageEmbed, $result[0]->type);
         self::assertStringContainsString('Hello', $result[0]->resolvedData['html']);
     }
 
-    public function testResolveRichTextWithMissingPageReturnsEmptyData(): void
+    public function testResolvePageEmbedWithMissingPageReturnsEmptyData(): void
     {
         $this->pageRepository->method('findBySlug')->willReturn(null);
 
         $layout = new HomepageLayout();
         $layout->setBlocks([
-            ['type' => 'richText', 'startAt' => null, 'endAt' => null, 'columnWidth' => null, 'cssClasses' => null, 'pageSlug' => 'nonexistent'],
+            ['type' => 'pageEmbed', 'startAt' => null, 'endAt' => null, 'columnWidth' => null, 'cssClasses' => null, 'pageSlug' => 'nonexistent'],
         ]);
 
         $result = $this->renderer->resolve($layout, 'en');

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -3826,6 +3826,10 @@
                 <source>app.homepage.block_type.rich_text</source>
                 <target>Rich Text</target>
             </trans-unit>
+            <trans-unit id="app.homepage.block_type.page_embed">
+                <source>app.homepage.block_type.page_embed</source>
+                <target>Page Embed</target>
+            </trans-unit>
             <trans-unit id="app.homepage.block_type.carousel">
                 <source>app.homepage.block_type.carousel</source>
                 <target>Carousel</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -3826,6 +3826,10 @@
                 <source>app.homepage.block_type.rich_text</source>
                 <target>Texte enrichi</target>
             </trans-unit>
+            <trans-unit id="app.homepage.block_type.page_embed">
+                <source>app.homepage.block_type.page_embed</source>
+                <target>Page intégrée</target>
+            </trans-unit>
             <trans-unit id="app.homepage.block_type.carousel">
                 <source>app.homepage.block_type.carousel</source>
                 <target>Carrousel</target>


### PR DESCRIPTION
## Summary

- **New `pageEmbed` block type** — references a CMS page by slug and renders its Markdown content. Replaces the `pageSlug` usage of the old `richText` block.
- **Updated `richText` block type** — now stores inline translatable Markdown content per locale in `HomepageLayoutTranslation`. No longer references CMS pages.
- Updated `HomepageBlockType` enum, `HomepageRenderer`, block partials, admin editor, fixture, translations (EN/FR), tests, and documentation.

Closes #309

## Test plan
- [ ] `make fixtures` — verify homepage renders with `pageEmbed` (welcome page) and no missing blocks
- [ ] Admin > Homepage editor — verify "Rich Text" and "Page Embed" appear as separate block types
- [ ] Add a Rich Text block — verify locale tabs with Markdown content textarea
- [ ] Add a Page Embed block — verify slug input field
- [ ] Save and verify homepage renders both block types correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)