### PR TITLE
:wrench: Config: extend session and remember-me duration

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -10,6 +10,8 @@ framework:
     # Both dev and prod use database-backed sessions (via DATABASE_URL).
     session:
         handler_id: '%env(DATABASE_URL)%'
+        cookie_lifetime: 86400
+        gc_maxlifetime: 86400
 
     http_client:
         scoped_clients:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -36,7 +36,7 @@ security:
                 target: app_home
             remember_me:
                 secret: '%kernel.secret%'
-                lifetime: 604800
+                lifetime: 2592000
 
     access_control:
         - { path: ^/login$, roles: PUBLIC_ACCESS }


### PR DESCRIPTION
## Summary
- Set session `cookie_lifetime` and `gc_maxlifetime` to **86400s (1 day)** — regular sessions now survive browser restarts and up to 24h of inactivity (was PHP default: ~24 min / browser close)
- Bump `remember_me` lifetime from **7 days to 30 days** (2592000s)

## Test plan
- [ ] Log in **without** "Remember me" → session should persist after closing and reopening the browser, and survive ~24h of inactivity
- [ ] Log in **with** "Remember me" → session should persist for ~30 days