### PR TITLE
:wrench: Chore: move CMS content pages before app links in navbar

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -31,15 +31,6 @@
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('app_dashboard') }}">{{ 'app.nav.dashboard'|trans }}</a>
                             </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_archetype_list') }}">{{ 'app.nav.archetypes'|trans }}</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_deck_list') }}">{{ 'app.nav.decks'|trans }}</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
-                            </li>
                             {% for category in menu_categories() %}
                                 {% set pages = category.pages|filter(p => p.published)|sort((a, b) => a.position <=> b.position) %}
                                 {% if pages|length == 1 %}
@@ -61,6 +52,15 @@
                                     </li>
                                 {% endif %}
                             {% endfor %}
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_archetype_list') }}">{{ 'app.nav.archetypes'|trans }}</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_deck_list') }}">{{ 'app.nav.decks'|trans }}</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
+                            </li>
                             <li class="nav-item d-flex align-items-center me-2">
                                 <div id="notification-bell-root"
                                      data-api-url="{{ path('app_notification_api_list') }}"
@@ -112,15 +112,6 @@
                                 </ul>
                             </li>
                         {% else %}
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_archetype_list') }}">{{ 'app.nav.archetypes'|trans }}</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_deck_list') }}">{{ 'app.nav.decks'|trans }}</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
-                            </li>
                             {% for category in menu_categories() %}
                                 {% set pages = category.pages|filter(p => p.published)|sort((a, b) => a.position <=> b.position) %}
                                 {% if pages|length == 1 %}
@@ -142,6 +133,15 @@
                                     </li>
                                 {% endif %}
                             {% endfor %}
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_archetype_list') }}">{{ 'app.nav.archetypes'|trans }}</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_deck_list') }}">{{ 'app.nav.decks'|trans }}</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
+                            </li>
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('app_login', {'_target_path': app.request.pathInfo}) }}">{{ 'app.nav.login'|trans }}</a>
                             </li>


### PR DESCRIPTION
## Summary
- Reorder navigation menu so CMS content pages (dynamic menu categories) appear before the static app links (Archetypes, Decks, Events)
- Applied to both authenticated and anonymous nav sections

## Test plan
- [ ] Verify navbar order shows CMS pages first, then Archetypes/Decks/Events (logged in)
- [ ] Verify navbar order shows CMS pages first, then Archetypes/Decks/Events (logged out)