### PR TITLE
:bug: Fix: allow sub-roles to access admin routes

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -59,6 +59,10 @@ security:
         - { path: ^/health, roles: PUBLIC_ACCESS }
         - { path: ^/webhook/messenger/, roles: PUBLIC_ACCESS }
         - { path: ^/admin/technical, roles: ROLE_TECHNICAL_ADMIN }
+        - { path: ^/admin/archetypes, roles: ROLE_ARCHETYPE_EDITOR }
+        - { path: ^/admin/pages, roles: ROLE_CMS_EDITOR }
+        - { path: ^/admin/homepage, roles: ROLE_CMS_EDITOR }
+        - { path: ^/admin/menu-categories, roles: ROLE_CMS_EDITOR }
         - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/dashboard, roles: ROLE_USER }
         - { path: ^/deck, roles: ROLE_USER }

--- a/src/Controller/CardImageUrlController.php
+++ b/src/Controller/CardImageUrlController.php
@@ -16,6 +16,7 @@ namespace App\Controller;
 use App\Repository\DeckCardRepository;
 use App\Service\Tcgdex\TcgdexApiClient;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -36,7 +37,7 @@ class CardImageUrlController extends AbstractController
     }
 
     #[Route('/api/card/image-url', name: 'app_card_image_url', methods: ['GET'])]
-    #[IsGranted('ROLE_CMS_EDITOR')]
+    #[IsGranted(new Expression("is_granted('ROLE_CMS_EDITOR') or is_granted('ROLE_ARCHETYPE_EDITOR')"))]
     public function __invoke(Request $request): JsonResponse
     {
         $reference = $request->query->getString('reference');

--- a/src/Controller/EditorUploadController.php
+++ b/src/Controller/EditorUploadController.php
@@ -16,6 +16,7 @@ namespace App\Controller;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,7 +50,7 @@ class EditorUploadController extends AbstractController
     }
 
     #[Route('/api/editor/upload-image', name: 'app_editor_upload_image', methods: ['POST'])]
-    #[IsGranted('ROLE_CMS_EDITOR')]
+    #[IsGranted(new Expression("is_granted('ROLE_CMS_EDITOR') or is_granted('ROLE_ARCHETYPE_EDITOR')"))]
     public function upload(Request $request): JsonResponse
     {
         $file = $request->files->get('file');


### PR DESCRIPTION
## Summary
- Add route-specific `access_control` rules in `security.yaml` for `/admin/archetypes` (`ROLE_ARCHETYPE_EDITOR`), `/admin/pages`, `/admin/homepage`, `/admin/menu-categories` (`ROLE_CMS_EDITOR`) — placed before the catch-all `/admin` rule that requires `ROLE_ADMIN`
- Widen `#[IsGranted]` on `/api/editor/upload-image` and `/api/card/image-url` to accept both `ROLE_CMS_EDITOR` and `ROLE_ARCHETYPE_EDITOR`, since the RTE (with image upload and card insertion) is shared by both editor contexts

Closes #327, Closes #328

## Test plan
- [x] Log in as `ROLE_ARCHETYPE_EDITOR` → access `/admin/archetypes` → edit archetype → upload image in RTE → insert card image
- [x] Log in as `ROLE_CMS_EDITOR` → access `/admin/pages`, `/admin/homepage`, `/admin/menu-categories`
- [x] Confirm `ROLE_CMS_EDITOR` cannot access `/admin/archetypes`
- [x] Confirm `ROLE_ARCHETYPE_EDITOR` cannot access `/admin/pages`
- [x] Confirm neither role can access `/admin/users`

🤖 Generated with [Claude Code](https://claude.com/claude-code)