### PR TITLE
:bug: Fix: expand custom RTE tags on content pages

### DIFF
--- a/assets/page-show.ts
+++ b/assets/page-show.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @see docs/features.md F11.3 — Page rendering & locale fallback
+ */
+
+import { initCardHover } from './shared/card-hover';
+
+initCardHover();

--- a/src/Controller/PageController.php
+++ b/src/Controller/PageController.php
@@ -15,7 +15,7 @@ namespace App\Controller;
 
 use App\Entity\MenuCategory;
 use App\Repository\PageRepository;
-use App\Service\MarkdownRenderer;
+use App\Service\ArchetypeDescriptionRenderer;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -73,7 +73,7 @@ class PageController extends AbstractController
         string $slug,
         Request $request,
         PageRepository $pageRepository,
-        MarkdownRenderer $markdownRenderer,
+        ArchetypeDescriptionRenderer $contentRenderer,
     ): Response {
         $page = $pageRepository->findBySlug($slug);
 
@@ -94,7 +94,7 @@ class PageController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        $htmlContent = $markdownRenderer->render($translation->getContent());
+        $htmlContent = $contentRenderer->render($translation->getContent(), $locale);
 
         return $this->render('page/show.html.twig', [
             'page' => $page,

--- a/templates/page/show.html.twig
+++ b/templates/page/show.html.twig
@@ -43,4 +43,26 @@
             {{ htmlContent|raw }}
         </div>
     </article>
+
+    {# Card image modal for mobile tap-to-show with swipe navigation #}
+    <div class="modal fade" id="cardImageModal" tabindex="-1" aria-labelledby="cardImageModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-sm">
+            <div class="modal-content">
+                <div class="modal-header py-2">
+                    <h6 class="modal-title" id="cardImageModalLabel"></h6>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body text-center p-2 position-relative">
+                    <button type="button" id="cardImageModalPrev" class="btn btn-sm btn-outline-secondary position-absolute start-0 top-50 translate-middle-y ms-1" aria-label="Previous">&lsaquo;</button>
+                    <img id="cardImageModalImg" src="" alt="" class="img-fluid rounded">
+                    <button type="button" id="cardImageModalNext" class="btn btn-sm btn-outline-secondary position-absolute end-0 top-50 translate-middle-y me-1" aria-label="Next">&rsaquo;</button>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {{ encore_entry_script_tags('page_show') }}
 {% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ Encore
     .addEntry('deck_form', './assets/deck-form.tsx')
     .addEntry('deck_card_list', './assets/deck-card-list.tsx')
     .addEntry('archetype_show', './assets/archetype-show.ts')
+    .addEntry('page_show', './assets/page-show.ts')
     .addEntry('staff_autocomplete', './assets/staff-autocomplete.tsx')
     .addEntry('walk_up_autocomplete', './assets/walk-up-autocomplete.tsx')
     .addEntry('catalog_filters', './assets/catalog-filters.tsx')


### PR DESCRIPTION
## Summary
- Use `ArchetypeDescriptionRenderer` in `PageController` instead of plain `MarkdownRenderer`, so `[[card:...]]`, `[[archetype:...]]`, and `[[deck:...]]` tags are expanded on CMS content pages
- Create `page_show` Webpack entry point that initializes card hover behavior
- Add card image modal to `page/show.html.twig` for mobile tap-to-show

Closes #329

## Test plan
- [x] Create a CMS page with `[[card:UPR-100]]`, `[[archetype:pikachu]]`, and `[[deck:A445HP]]` tags
- [x] Verify card names render with hover image preview
- [x] Verify archetype links render with sprites
- [x] Verify deck links render as badges
- [x] Verify card image modal works on mobile (tap to show)
- [x] Verify archetype pages still render correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)