### PR TITLE
:sparkles: Feature: archetype variant decks (nullable owner + canonical)

### DIFF
--- a/migrations/Version20260410073311.php
+++ b/migrations/Version20260410073311.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Make Deck.owner nullable and add Deck.canonical boolean for archetype variant decks.
+ *
+ * @see docs/features.md F18.13 — Archetype variant decks
+ */
+final class Version20260410073311 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make Deck.owner nullable and add canonical boolean for archetype variant decks';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE deck ADD canonical TINYINT DEFAULT 0 NOT NULL, CHANGE owner_id owner_id INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE deck DROP canonical, CHANGE owner_id owner_id INT NOT NULL');
+    }
+}

--- a/src/Controller/BorrowController.php
+++ b/src/Controller/BorrowController.php
@@ -46,7 +46,7 @@ class BorrowController extends AbstractAppController
     {
         /** @var User $user */
         $user = $this->getUser();
-        $isOwner = $borrow->getDeck()->getOwner()->getId() === $user->getId();
+        $isOwner = $borrow->getDeck()->getOwnerOrFail()->getId() === $user->getId();
         $isBorrower = $borrow->getBorrower()->getId() === $user->getId();
         $isDelegatedStaff = $borrow->isDelegatedToStaff() && $borrow->getEvent()->isOrganizerOrStaff($user);
 

--- a/src/Controller/DeckBorrowHistoryController.php
+++ b/src/Controller/DeckBorrowHistoryController.php
@@ -68,7 +68,7 @@ class DeckBorrowHistoryController extends AbstractController
             return;
         }
 
-        if ($deck->getOwner()->getId() === $user->getId() || $this->isGranted('ROLE_ADMIN')) {
+        if ($deck->getOwner()?->getId() === $user->getId() || $this->isGranted('ROLE_ADMIN')) {
             return;
         }
 

--- a/src/Controller/DeckController.php
+++ b/src/Controller/DeckController.php
@@ -406,7 +406,7 @@ class DeckController extends AbstractAppController
         /** @var User $user */
         $user = $this->getUser();
 
-        if ($deck->getOwner()->getId() !== $user->getId()) {
+        if ($deck->getOwnerOrFail()->getId() !== $user->getId()) {
             throw $this->createAccessDeniedException('You are not the owner of this deck.');
         }
     }

--- a/src/Controller/DeckFoundController.php
+++ b/src/Controller/DeckFoundController.php
@@ -40,7 +40,7 @@ class DeckFoundController extends AbstractController
         $user = $this->getUser();
 
         // Owner cannot report their own deck
-        if ($user instanceof User && $deck->getOwner()->getId() === $user->getId()) {
+        if ($user instanceof User && $deck->getOwnerOrFail()->getId() === $user->getId()) {
             return new JsonResponse(['error' => 'Cannot report your own deck.'], Response::HTTP_FORBIDDEN);
         }
 

--- a/src/Controller/DeckSearchController.php
+++ b/src/Controller/DeckSearchController.php
@@ -64,7 +64,7 @@ class DeckSearchController extends AbstractController
             'id' => $deck->getId(),
             'name' => $deck->getName(),
             'shortTag' => $deck->getShortTag(),
-            'ownerName' => $deck->getOwner()->getScreenName(),
+            'ownerName' => $deck->getOwner()?->getScreenName() ?? '',
             'status' => $deck->getStatus()->value,
         ], $decks);
 

--- a/src/Controller/DeckShowController.php
+++ b/src/Controller/DeckShowController.php
@@ -68,7 +68,7 @@ class DeckShowController extends AbstractAppController
         // Access control: public decks are visible to everyone
         if (!$deck->isPublic()) {
             $isOwnerOrAdmin = null !== $user
-                && ($deck->getOwner()->getId() === $user->getId()
+                && ($deck->getOwner()?->getId() === $user->getId()
                     || $this->isGranted('ROLE_ADMIN'));
 
             $hasStaffAccess = false;
@@ -137,7 +137,7 @@ class DeckShowController extends AbstractAppController
             }
         }
 
-        $isOwner = null !== $user && $deck->getOwner()->getId() === $user->getId();
+        $isOwner = null !== $user && $deck->getOwner()?->getId() === $user->getId();
 
         // Anonymous users get empty borrow data
         $deckBorrows = [];
@@ -237,7 +237,7 @@ class DeckShowController extends AbstractAppController
         /** @var User $user */
         $user = $this->getUser();
 
-        if ($deck->getOwner()->getId() !== $user->getId()) {
+        if ($deck->getOwner()?->getId() !== $user->getId()) {
             throw $this->createAccessDeniedException();
         }
 
@@ -261,7 +261,7 @@ class DeckShowController extends AbstractAppController
         /** @var User $user */
         $user = $this->getUser();
 
-        if ($deck->getOwner()->getId() !== $user->getId()) {
+        if ($deck->getOwner()?->getId() !== $user->getId()) {
             throw $this->createAccessDeniedException();
         }
 

--- a/src/Controller/DeckVersionHistoryController.php
+++ b/src/Controller/DeckVersionHistoryController.php
@@ -42,7 +42,7 @@ class DeckVersionHistoryController extends AbstractAppController
 
         /** @var User|null $user */
         $user = $this->getUser();
-        $isOwner = null !== $user && $deck->getOwner()->getId() === $user->getId();
+        $isOwner = null !== $user && $deck->getOwnerOrFail()->getId() === $user->getId();
 
         return $this->render('deck/versions.html.twig', [
             'deck' => $deck,
@@ -153,7 +153,7 @@ class DeckVersionHistoryController extends AbstractAppController
         /** @var User|null $user */
         $user = $this->getUser();
 
-        if (null === $user || $deck->getOwner()->getId() !== $user->getId()) {
+        if (null === $user || $deck->getOwnerOrFail()->getId() !== $user->getId()) {
             throw $this->createAccessDeniedException();
         }
     }
@@ -171,7 +171,7 @@ class DeckVersionHistoryController extends AbstractAppController
             throw $this->createAccessDeniedException();
         }
 
-        if ($deck->getOwner()->getId() === $user->getId() || $this->isGranted('ROLE_ADMIN')) {
+        if ($deck->getOwnerOrFail()->getId() === $user->getId() || $this->isGranted('ROLE_ADMIN')) {
             return;
         }
 

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -209,13 +209,13 @@ class EventController extends AbstractAppController
             // Owner stats: decks in custody vs still out
             $userId = $user->getId();
             foreach ($lentBorrows as $borrow) {
-                if ($borrow->getDeck()->getOwner()->getId() === $userId) {
+                if ($borrow->getDeck()->getOwnerOrFail()->getId() === $userId) {
                     ++$endingPhaseOwnerStats['stillOut'];
                 }
             }
             $custodyBorrows = $borrowRepository->findInCustodyBorrowsByEvent($event);
             foreach ($custodyBorrows as $borrow) {
-                if ($borrow->getDeck()->getOwner()->getId() === $userId) {
+                if ($borrow->getDeck()->getOwnerOrFail()->getId() === $userId) {
                     ++$endingPhaseOwnerStats['inCustody'];
                 }
             }
@@ -353,7 +353,7 @@ class EventController extends AbstractAppController
         }
 
         // Cancel pending borrows for own deck when owner selects it for themselves
-        if ($deck->getOwner()->getId() === $user->getId()) {
+        if ($deck->getOwnerOrFail()->getId() === $user->getId()) {
             $pendingBorrows = $borrowRepository->findAllPendingBorrowsForDeckAtEvent($deck, $event);
 
             if ([] !== $pendingBorrows && '1' !== $request->getPayload()->getString('confirm_cancel_borrows')) {
@@ -908,7 +908,7 @@ class EventController extends AbstractAppController
             return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
         }
 
-        if ($deck->getOwner()->getId() !== $user->getId()) {
+        if ($deck->getOwnerOrFail()->getId() !== $user->getId()) {
             $this->addFlash('danger', 'app.flash.event.own_decks_only_registration');
 
             return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
@@ -983,7 +983,7 @@ class EventController extends AbstractAppController
             return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
         }
 
-        if ($deck->getOwner()->getId() !== $user->getId()) {
+        if ($deck->getOwnerOrFail()->getId() !== $user->getId()) {
             $this->addFlash('danger', 'app.flash.event.own_decks_only_delegation');
 
             return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
@@ -1218,7 +1218,7 @@ class EventController extends AbstractAppController
         BorrowRepository $borrowRepository,
     ): ?DeckVersion {
         // Own deck: must not be lent, retired, or committed to a borrower at this event
-        if ($deck->getOwner()->getId() === $user->getId()) {
+        if ($deck->getOwnerOrFail()->getId() === $user->getId()) {
             if (DeckStatus::Lent === $deck->getStatus() || DeckStatus::Retired === $deck->getStatus()) {
                 return null;
             }

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -44,9 +44,14 @@ class Deck
     #[Assert\Length(min: 2, max: 100)]
     private string $name = '';
 
+    /**
+     * Null for archetype variant decks (editorial decklists with no user owner).
+     *
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'ownedDecks')]
-    #[ORM\JoinColumn(nullable: false)]
-    private User $owner;
+    #[ORM\JoinColumn(nullable: true)]
+    private ?User $owner = null;
 
     #[ORM\Column(length: 30)]
     #[Assert\NotBlank]
@@ -59,6 +64,15 @@ class Deck
     #[ORM\ManyToOne(targetEntity: Archetype::class)]
     #[ORM\JoinColumn(nullable: true)]
     private ?Archetype $archetype = null;
+
+    /**
+     * Marks the primary/reference variant for an archetype.
+     * Only meaningful for archetype variant decks (owner = null).
+     *
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    #[ORM\Column(options: ['default' => false])]
+    private bool $canonical = false;
 
     /** @var list<string> */
     #[ORM\Column(type: Types::JSON)]
@@ -136,16 +150,55 @@ class Deck
         return $this;
     }
 
-    public function getOwner(): User
+    public function getOwner(): ?User
     {
         return $this->owner;
     }
 
-    public function setOwner(User $owner): static
+    /**
+     * Return the owner, throwing if this is an archetype variant deck.
+     * Use in contexts where an owner is guaranteed (borrow, event, notification).
+     *
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function getOwnerOrFail(): User
+    {
+        return $this->owner ?? throw new \LogicException(\sprintf('Deck #%d has no owner (archetype variant).', $this->id ?? 0));
+    }
+
+    public function setOwner(?User $owner): static
     {
         $this->owner = $owner;
 
         return $this;
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function isCanonical(): bool
+    {
+        return $this->canonical;
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function setCanonical(bool $canonical): static
+    {
+        $this->canonical = $canonical;
+
+        return $this;
+    }
+
+    /**
+     * Whether this deck is an archetype variant (no user owner).
+     *
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function isArchetypeVariant(): bool
+    {
+        return null === $this->owner && null !== $this->archetype;
     }
 
     public function getFormat(): string

--- a/src/MessageHandler/DeclineCompetingBorrowsHandler.php
+++ b/src/MessageHandler/DeclineCompetingBorrowsHandler.php
@@ -44,7 +44,7 @@ class DeclineCompetingBorrowsHandler
             return;
         }
 
-        $owner = $approvedBorrow->getDeck()->getOwner();
+        $owner = $approvedBorrow->getDeck()->getOwnerOrFail();
 
         $competitors = $this->borrowRepository->findPendingBorrowsForDeckAtEvent(
             $approvedBorrow->getDeck(),

--- a/src/Service/BorrowNotificationEmailService.php
+++ b/src/Service/BorrowNotificationEmailService.php
@@ -38,7 +38,7 @@ class BorrowNotificationEmailService
 
     public function sendBorrowRequested(Borrow $borrow): void
     {
-        $recipient = $borrow->getDeck()->getOwner();
+        $recipient = $borrow->getDeck()->getOwnerOrFail();
 
         if (!$recipient->isNotificationEnabled(NotificationType::BorrowRequested, 'email')) {
             return;
@@ -95,7 +95,7 @@ class BorrowNotificationEmailService
         $deckName = $borrow->getDeck()->getName();
 
         // Notify both owner and borrower
-        $owner = $borrow->getDeck()->getOwner();
+        $owner = $borrow->getDeck()->getOwnerOrFail();
         if ($owner->isNotificationEnabled(NotificationType::BorrowOverdue, 'email')) {
             $this->sendEmail(
                 $owner,
@@ -119,7 +119,7 @@ class BorrowNotificationEmailService
     public function sendBorrowCancelled(Borrow $borrow, User $actor): void
     {
         $recipient = $actor->getId() === $borrow->getBorrower()->getId()
-            ? $borrow->getDeck()->getOwner()
+            ? $borrow->getDeck()->getOwnerOrFail()
             : $borrow->getBorrower();
 
         if (!$recipient->isNotificationEnabled(NotificationType::BorrowCancelled, 'email')) {

--- a/src/Service/BorrowService.php
+++ b/src/Service/BorrowService.php
@@ -67,7 +67,7 @@ class BorrowService
             throw new \DomainException('Cannot borrow decks during the ending phase.');
         }
 
-        if ($deck->getOwner()->getId() === $borrower->getId()) {
+        if ($deck->getOwnerOrFail()->getId() === $borrower->getId()) {
             throw new \DomainException('You cannot borrow your own deck.');
         }
 
@@ -109,7 +109,7 @@ class BorrowService
         $this->em->flush();
 
         $this->createNotification(
-            $deck->getOwner(),
+            $deck->getOwnerOrFail(),
             NotificationType::BorrowRequested,
             'New borrow request',
             \sprintf('%s wants to borrow "%s" for %s.', $borrower->getScreenName(), $deck->getName(), $event->getName()),
@@ -230,7 +230,7 @@ class BorrowService
         $this->em->flush();
 
         $this->createNotification(
-            $borrow->getDeck()->getOwner(),
+            $borrow->getDeck()->getOwnerOrFail(),
             NotificationType::BorrowReturned,
             'Deck returned',
             \sprintf('"%s" has been returned by %s.', $borrow->getDeck()->getName(), $borrow->getBorrower()->getScreenName()),
@@ -254,7 +254,7 @@ class BorrowService
         $this->em->flush();
 
         $notifyUser = $actor->getId() === $borrow->getBorrower()->getId()
-            ? $borrow->getDeck()->getOwner()
+            ? $borrow->getDeck()->getOwnerOrFail()
             : $borrow->getBorrower();
 
         $this->createNotification(
@@ -274,7 +274,7 @@ class BorrowService
      */
     public function createWalkUpBorrow(Deck $deck, User $borrower, Event $event, User $initiator): Borrow
     {
-        if ($deck->getOwner()->getId() === $borrower->getId()) {
+        if ($deck->getOwnerOrFail()->getId() === $borrower->getId()) {
             throw new \DomainException('The borrower cannot be the deck owner.');
         }
 
@@ -307,7 +307,7 @@ class BorrowService
             throw new \DomainException('This deck has no version and cannot be lent.');
         }
 
-        $isOwner = $deck->getOwner()->getId() === $initiator->getId();
+        $isOwner = $deck->getOwnerOrFail()->getId() === $initiator->getId();
         if (!$isOwner && !$event->isOrganizerOrStaff($initiator)) {
             throw new AccessDeniedHttpException('Only the deck owner or event staff can initiate a walk-up lend.');
         }
@@ -357,7 +357,7 @@ class BorrowService
         // Notify owner if initiator is staff (not the owner)
         if (!$isOwner) {
             $this->createNotification(
-                $deck->getOwner(),
+                $deck->getOwnerOrFail(),
                 NotificationType::BorrowHandedOff,
                 'Walk-up lend initiated',
                 \sprintf('"%s" was lent to %s by event staff at %s.', $deck->getName(), $borrower->getScreenName(), $event->getName()),
@@ -392,7 +392,7 @@ class BorrowService
         $this->em->flush();
 
         $this->createNotification(
-            $borrow->getDeck()->getOwner(),
+            $borrow->getDeck()->getOwnerOrFail(),
             NotificationType::BorrowReturned,
             'Deck returned to owner',
             \sprintf('"%s" has been returned to your custody by %s.', $borrow->getDeck()->getName(), $actor->getScreenName()),
@@ -499,7 +499,7 @@ class BorrowService
             );
 
             $this->createNotification(
-                $borrow->getDeck()->getOwner(),
+                $borrow->getDeck()->getOwnerOrFail(),
                 NotificationType::BorrowOverdue,
                 'Deck overdue',
                 \sprintf('Your deck "%s" is overdue for return from %s.', $borrow->getDeck()->getName(), $borrow->getBorrower()->getScreenName()),
@@ -523,7 +523,7 @@ class BorrowService
      */
     private function assertOwnerOrDelegatedStaff(Borrow $borrow, User $actor): void
     {
-        $isOwner = $borrow->getDeck()->getOwner()->getId() === $actor->getId();
+        $isOwner = $borrow->getDeck()->getOwnerOrFail()->getId() === $actor->getId();
         $isDelegatedStaff = $borrow->isDelegatedToStaff() && $borrow->getEvent()->isOrganizerOrStaff($actor);
 
         if (!$isOwner && !$isDelegatedStaff) {
@@ -535,7 +535,7 @@ class BorrowService
     {
         $actorId = $actor->getId();
         $isBorrower = $borrow->getBorrower()->getId() === $actorId;
-        $isOwner = $borrow->getDeck()->getOwner()->getId() === $actorId;
+        $isOwner = $borrow->getDeck()->getOwnerOrFail()->getId() === $actorId;
         $isDelegatedStaff = $borrow->isDelegatedToStaff() && $borrow->getEvent()->isOrganizerOrStaff($actor);
 
         if (!$isBorrower && !$isOwner && !$isDelegatedStaff) {
@@ -555,7 +555,7 @@ class BorrowService
             return;
         }
 
-        $isOwner = $borrow->getDeck()->getOwner()->getId() === $actor->getId();
+        $isOwner = $borrow->getDeck()->getOwnerOrFail()->getId() === $actor->getId();
         if ($isOwner) {
             return;
         }

--- a/src/Service/DeckFoundNotificationService.php
+++ b/src/Service/DeckFoundNotificationService.php
@@ -46,7 +46,7 @@ class DeckFoundNotificationService
      */
     public function notify(Deck $deck, ?User $reporter, ?string $message): void
     {
-        $owner = $deck->getOwner();
+        $owner = $deck->getOwnerOrFail();
         $locale = $owner->getPreferredLocale();
         $deckName = $deck->getName();
         $reporterName = $reporter?->getScreenName();

--- a/src/Service/EventNotificationService.php
+++ b/src/Service/EventNotificationService.php
@@ -153,9 +153,9 @@ class EventNotificationService
             $byBorrower[$borrowerId][] = $borrow;
             $borrowerMap[$borrowerId] = $borrow->getBorrower();
 
-            $ownerId = (int) $borrow->getDeck()->getOwner()->getId();
+            $ownerId = (int) $borrow->getDeck()->getOwnerOrFail()->getId();
             $byOwner[$ownerId][] = $borrow;
-            $ownerMap[$ownerId] = $borrow->getDeck()->getOwner();
+            $ownerMap[$ownerId] = $borrow->getDeck()->getOwnerOrFail();
         }
 
         foreach ($byBorrower as $borrowerId => $borrows) {
@@ -227,9 +227,9 @@ class EventNotificationService
         $ownerMap = [];
 
         foreach ($custodyBorrows as $borrow) {
-            $ownerId = (int) $borrow->getDeck()->getOwner()->getId();
+            $ownerId = (int) $borrow->getDeck()->getOwnerOrFail()->getId();
             $byOwner[$ownerId][] = $borrow;
-            $ownerMap[$ownerId] = $borrow->getDeck()->getOwner();
+            $ownerMap[$ownerId] = $borrow->getDeck()->getOwnerOrFail();
         }
 
         foreach ($byOwner as $ownerId => $borrows) {

--- a/src/Service/StaffCustodyService.php
+++ b/src/Service/StaffCustodyService.php
@@ -54,7 +54,7 @@ class StaffCustodyService
             throw new \DomainException('This deck has already been handed over to staff.');
         }
 
-        $deckOwner = $registration->getDeck()->getOwner();
+        $deckOwner = $registration->getDeck()->getOwnerOrFail();
         if ($deckOwner->getId() !== $actor->getId()) {
             throw new AccessDeniedHttpException('Only the deck owner can confirm the handover to staff.');
         }
@@ -118,7 +118,7 @@ class StaffCustodyService
      */
     public function ownerReclaimDeck(EventDeckRegistration $registration, User $actor): void
     {
-        $deckOwner = $registration->getDeck()->getOwner();
+        $deckOwner = $registration->getDeck()->getOwnerOrFail();
         if ($deckOwner->getId() !== $actor->getId()) {
             throw new AccessDeniedHttpException('Only the deck owner can reclaim this deck.');
         }

--- a/tests/Entity/DeckTest.php
+++ b/tests/Entity/DeckTest.php
@@ -235,4 +235,92 @@ class DeckTest extends TestCase
 
         self::assertNull($deck->getCurrentVersion());
     }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testOwnerIsNullableForArchetypeVariants(): void
+    {
+        $deck = new Deck();
+
+        self::assertNull($deck->getOwner());
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testCanonicalDefaultsToFalse(): void
+    {
+        $deck = new Deck();
+
+        self::assertFalse($deck->isCanonical());
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testSetCanonical(): void
+    {
+        $deck = new Deck();
+        $deck->setCanonical(true);
+
+        self::assertTrue($deck->isCanonical());
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testIsArchetypeVariantWhenOwnerlessWithArchetype(): void
+    {
+        $deck = new Deck();
+        $archetype = new Archetype();
+        $deck->setArchetype($archetype);
+
+        self::assertTrue($deck->isArchetypeVariant());
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testIsNotArchetypeVariantWhenOwned(): void
+    {
+        $deck = new Deck();
+        $deck->setOwner(new User());
+        $deck->setArchetype(new Archetype());
+
+        self::assertFalse($deck->isArchetypeVariant());
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testIsNotArchetypeVariantWithoutArchetype(): void
+    {
+        $deck = new Deck();
+
+        self::assertFalse($deck->isArchetypeVariant());
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testGetOwnerOrFailReturnsOwner(): void
+    {
+        $deck = new Deck();
+        $user = new User();
+        $deck->setOwner($user);
+
+        self::assertSame($user, $deck->getOwnerOrFail());
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testGetOwnerOrFailThrowsForVariant(): void
+    {
+        $deck = new Deck();
+
+        $this->expectException(\LogicException::class);
+        $deck->getOwnerOrFail();
+    }
 }


### PR DESCRIPTION
## Summary

- **Deck.owner nullable** — `?User` with `JoinColumn(nullable: true)` allows decks without a user owner, serving as archetype variant decklists
- **Deck.canonical** — new `bool` column (default `false`) marks the primary/reference variant per archetype
- **`getOwnerOrFail(): User`** — throws `LogicException` for variant decks; used in borrow/event/notification contexts where an owner is guaranteed
- **`isArchetypeVariant(): bool`** — convenience method (`owner === null && archetype !== null`)
- **Null safety** — 59 PHPStan errors fixed across 14 files: `getOwnerOrFail()` in borrow/event contexts, null-safe `?->` in display/search contexts
- **Migration** — makes `owner_id` nullable, adds `canonical` column
- **8 new unit tests** — canonical, variant detection, `getOwnerOrFail()` success and failure

Closes #347

## Test plan

- [ ] Run migration on dev database
- [ ] Verify existing decks still work (all have owners, unaffected)
- [ ] Verify deck catalog (`/deck`) doesn't show ownerless decks (inner join excludes them)
- [ ] Verify borrow workflows still function correctly
- [ ] PHPStan level 10 passes (0 errors)
- [ ] 830 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)