### PR TITLE
:sparkles: Feature: admin archetype variants & public variant selector

### DIFF
--- a/assets/archetype-form.tsx
+++ b/assets/archetype-form.tsx
@@ -36,11 +36,13 @@ if (spriteRoot) {
         // Invalid JSON — use empty array
     }
 
+    const hiddenInputName = spriteRoot.dataset.hiddenInputName ?? 'archetype_form[pokemonSlugs]';
+
     createRoot(spriteRoot).render(
         <MantineProvider>
             <PokemonSpriteSelect
                 initialValues={initialSlugs}
-                hiddenInputName="archetype_form[pokemonSlugs]"
+                hiddenInputName={hiddenInputName}
             />
         </MantineProvider>,
     );

--- a/assets/archetype-variants.tsx
+++ b/assets/archetype-variants.tsx
@@ -14,6 +14,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { MantineProvider } from '@mantine/core';
+import '@mantine/core/styles.css';
 import ArchetypeVariantSelector from './components/ArchetypeVariantSelector';
 
 const root = document.getElementById('archetype-variant-selector-root');

--- a/assets/archetype-variants.tsx
+++ b/assets/archetype-variants.tsx
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @see docs/features.md F18.16 — Archetype detail: variant selector
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { MantineProvider } from '@mantine/core';
+import ArchetypeVariantSelector from './components/ArchetypeVariantSelector';
+
+const root = document.getElementById('archetype-variant-selector-root');
+if (root) {
+    const variants = JSON.parse(root.dataset.variants ?? '[]');
+    const labels = {
+        viewTable: root.dataset.labelViewTable ?? 'Table',
+        viewMosaic: root.dataset.labelViewMosaic ?? 'Mosaic',
+        mosaicAlt: root.dataset.labelMosaicAlt ?? 'Deck mosaic',
+        sectionPokemon: root.dataset.labelSectionPokemon ?? 'Pokemon',
+        sectionTrainer: root.dataset.labelSectionTrainer ?? 'Trainer',
+        sectionEnergy: root.dataset.labelSectionEnergy ?? 'Energy',
+        tableQty: root.dataset.labelTableQty ?? 'Qty',
+        tableCard: root.dataset.labelTableCard ?? 'Card',
+        tableSet: root.dataset.labelTableSet ?? 'Set',
+        moreVariants: root.dataset.labelMoreVariants ?? 'More variants\u2026',
+    };
+
+    createRoot(root).render(
+        <MantineProvider>
+            <ArchetypeVariantSelector variants={variants} labels={labels} />
+        </MantineProvider>,
+    );
+}

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -7,8 +7,9 @@
  * file that was distributed with this source code.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Button, Group, Select, SegmentedControl, Stack } from '@mantine/core';
+import { initCardHover } from '../shared/card-hover';
 
 /**
  * @see docs/features.md F18.16 — Archetype detail: variant selector
@@ -76,12 +77,23 @@ function CardSection({ title, cards, labels }: { title: string; cards: CardData[
                 </thead>
                 <tbody>
                     {cards.map((card, index) => (
-                        <tr key={index}
-                            data-card-hover-url={card.imageUrl ?? undefined}
-                            data-card-hover-name={card.cardName}
-                            style={{ cursor: card.imageUrl ? 'pointer' : 'default' }}>
+                        <tr key={index}>
                             <td>{card.quantity}</td>
-                            <td>{card.cardName}</td>
+                            <td>
+                                {card.imageUrl ? (
+                                    <span className="card-hover" data-quantity={card.quantity}>
+                                        {card.cardName}
+                                        <img
+                                            className="card-hover-img"
+                                            src={card.imageUrl}
+                                            alt={card.cardName}
+                                            loading="lazy"
+                                        />
+                                    </span>
+                                ) : (
+                                    card.cardName
+                                )}
+                            </td>
                             <td><span className="badge bg-secondary">{card.setCode}</span></td>
                             <td>{card.cardNumber}</td>
                         </tr>
@@ -124,6 +136,14 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
     const canonicalIndex = variants.findIndex((variant) => variant.canonical);
     const [selectedIndex, setSelectedIndex] = useState(canonicalIndex >= 0 ? canonicalIndex : 0);
     const [viewMode, setViewMode] = useState<ViewMode>('table');
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    // Re-initialize card hover after variant switch or view mode change
+    useEffect(() => {
+        if (viewMode === 'table') {
+            initCardHover();
+        }
+    }, [selectedIndex, viewMode]);
 
     if (variants.length === 0) {
         return null;
@@ -137,7 +157,7 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
     const dropdownVariants = variants.slice(MAX_BUTTONS);
 
     return (
-        <div>
+        <div ref={containerRef}>
             {/* Variant selector */}
             {variants.length > 1 && (
                 <div className="mb-3">
@@ -150,7 +170,7 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                                 onClick={() => setSelectedIndex(index)}
                             >
                                 {variant.name}
-                                {variant.canonical && ' ★'}
+                                {variant.canonical && ' \u2605'}
                             </Button>
                         ))}
                         {dropdownVariants.length > 0 && (
@@ -201,7 +221,7 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                         <div className="text-center">
                             <img
                                 src={selectedVariant.mosaicUrl}
-                                alt={`${labels.mosaicAlt} — ${selectedVariant.name}`}
+                                alt={`${labels.mosaicAlt} \u2014 ${selectedVariant.name}`}
                                 className="img-fluid rounded shadow-sm"
                             />
                         </div>

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -1,0 +1,217 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React, { useState } from 'react';
+import { Button, Group, Select, SegmentedControl, Stack } from '@mantine/core';
+
+/**
+ * @see docs/features.md F18.16 — Archetype detail: variant selector
+ */
+
+interface CardData {
+    cardName: string;
+    quantity: number;
+    setCode: string;
+    cardNumber: string;
+    cardType: string;
+    trainerSubtype: string | null;
+    imageUrl: string | null;
+}
+
+interface VariantData {
+    id: number;
+    name: string;
+    canonical: boolean;
+    description: string | null;
+    mosaicUrl: string | null;
+    groupedCards: Record<string, CardData[]>;
+}
+
+interface Labels {
+    viewTable: string;
+    viewMosaic: string;
+    mosaicAlt: string;
+    sectionPokemon: string;
+    sectionTrainer: string;
+    sectionEnergy: string;
+    tableQty: string;
+    tableCard: string;
+    tableSet: string;
+    moreVariants: string;
+}
+
+interface ArchetypeVariantSelectorProps {
+    variants: VariantData[];
+    labels: Labels;
+}
+
+type ViewMode = 'table' | 'mosaic';
+
+const SECTION_LABELS: Record<string, keyof Labels> = {
+    pokemon: 'sectionPokemon',
+    trainer: 'sectionTrainer',
+    energy: 'sectionEnergy',
+};
+
+const MAX_BUTTONS = 5;
+
+function CardSection({ title, cards, labels }: { title: string; cards: CardData[]; labels: Labels }) {
+    return (
+        <div className="mb-3">
+            <h6 className="text-muted text-uppercase small fw-bold">{title}</h6>
+            <table className="table table-sm table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th style={{ width: '40px' }}>{labels.tableQty}</th>
+                        <th>{labels.tableCard}</th>
+                        <th style={{ width: '60px' }}>{labels.tableSet}</th>
+                        <th style={{ width: '40px' }}>#</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {cards.map((card, index) => (
+                        <tr key={index}
+                            data-card-hover-url={card.imageUrl ?? undefined}
+                            data-card-hover-name={card.cardName}
+                            style={{ cursor: card.imageUrl ? 'pointer' : 'default' }}>
+                            <td>{card.quantity}</td>
+                            <td>{card.cardName}</td>
+                            <td><span className="badge bg-secondary">{card.setCode}</span></td>
+                            <td>{card.cardNumber}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+function CardTable({ groupedCards, labels }: { groupedCards: Record<string, CardData[]>; labels: Labels }) {
+    const sections = Object.entries(groupedCards);
+
+    if (sections.length === 0) {
+        return null;
+    }
+
+    // Split into two columns for wider layouts
+    const midpoint = Math.ceil(sections.length / 2);
+    const leftSections = sections.slice(0, midpoint);
+    const rightSections = sections.slice(midpoint);
+
+    return (
+        <div className="row">
+            <div className="col-md-6">
+                {leftSections.map(([type, cards]) => (
+                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} />
+                ))}
+            </div>
+            <div className="col-md-6">
+                {rightSections.map(([type, cards]) => (
+                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default function ArchetypeVariantSelector({ variants, labels }: ArchetypeVariantSelectorProps) {
+    const canonicalIndex = variants.findIndex((variant) => variant.canonical);
+    const [selectedIndex, setSelectedIndex] = useState(canonicalIndex >= 0 ? canonicalIndex : 0);
+    const [viewMode, setViewMode] = useState<ViewMode>('table');
+
+    if (variants.length === 0) {
+        return null;
+    }
+
+    const selectedVariant = variants[selectedIndex];
+    const hasCards = Object.keys(selectedVariant.groupedCards).length > 0;
+
+    // Split variants: first MAX_BUTTONS as buttons, rest in dropdown
+    const buttonVariants = variants.slice(0, MAX_BUTTONS);
+    const dropdownVariants = variants.slice(MAX_BUTTONS);
+
+    return (
+        <div>
+            {/* Variant selector */}
+            {variants.length > 1 && (
+                <div className="mb-3">
+                    <Group gap="xs" wrap="wrap">
+                        {buttonVariants.map((variant, index) => (
+                            <Button
+                                key={variant.id}
+                                variant={index === selectedIndex ? 'filled' : 'outline'}
+                                size="sm"
+                                onClick={() => setSelectedIndex(index)}
+                            >
+                                {variant.name}
+                                {variant.canonical && ' ★'}
+                            </Button>
+                        ))}
+                        {dropdownVariants.length > 0 && (
+                            <Select
+                                placeholder={labels.moreVariants}
+                                data={dropdownVariants.map((variant, index) => ({
+                                    value: String(MAX_BUTTONS + index),
+                                    label: variant.name,
+                                }))}
+                                value={selectedIndex >= MAX_BUTTONS ? String(selectedIndex) : null}
+                                onChange={(value) => {
+                                    if (value) {
+                                        setSelectedIndex(Number(value));
+                                    }
+                                }}
+                                size="sm"
+                                clearable
+                                style={{ minWidth: 200 }}
+                            />
+                        )}
+                    </Group>
+                </div>
+            )}
+
+            {/* Description */}
+            {selectedVariant.description && (
+                <div className="cms-content mb-3" dangerouslySetInnerHTML={{ __html: selectedVariant.description }} />
+            )}
+
+            {/* View mode toggle + card display */}
+            {hasCards && (
+                <Stack gap="sm">
+                    <SegmentedControl
+                        value={viewMode}
+                        onChange={(value) => setViewMode(value as ViewMode)}
+                        data={[
+                            { label: labels.viewTable, value: 'table' },
+                            { label: labels.viewMosaic, value: 'mosaic' },
+                        ]}
+                        size="xs"
+                    />
+
+                    {viewMode === 'table' && (
+                        <CardTable groupedCards={selectedVariant.groupedCards} labels={labels} />
+                    )}
+
+                    {viewMode === 'mosaic' && selectedVariant.mosaicUrl && (
+                        <div className="text-center">
+                            <img
+                                src={selectedVariant.mosaicUrl}
+                                alt={`${labels.mosaicAlt} — ${selectedVariant.name}`}
+                                className="img-fluid rounded shadow-sm"
+                            />
+                        </div>
+                    )}
+
+                    {viewMode === 'mosaic' && !selectedVariant.mosaicUrl && (
+                        <p className="text-muted text-center">Mosaic not yet generated.</p>
+                    )}
+                </Stack>
+            )}
+        </div>
+    );
+}

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -135,7 +135,7 @@ function CardTable({ groupedCards, labels }: { groupedCards: Record<string, Card
 export default function ArchetypeVariantSelector({ variants, labels }: ArchetypeVariantSelectorProps) {
     const canonicalIndex = variants.findIndex((variant) => variant.canonical);
     const [selectedIndex, setSelectedIndex] = useState(canonicalIndex >= 0 ? canonicalIndex : 0);
-    const [viewMode, setViewMode] = useState<ViewMode>('table');
+    const [viewMode, setViewMode] = useState<ViewMode>('mosaic');
     const containerRef = useRef<HTMLDivElement>(null);
 
     // Re-initialize card hover after variant switch or view mode change
@@ -161,12 +161,13 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
             {/* Variant selector */}
             {variants.length > 1 && (
                 <div className="mb-3">
-                    <Group gap="xs" wrap="wrap">
+                    <Group gap={4} wrap="wrap">
                         {buttonVariants.map((variant, index) => (
                             <Button
                                 key={variant.id}
                                 variant={index === selectedIndex ? 'filled' : 'outline'}
-                                size="sm"
+                                size="compact-sm"
+                                radius="xl"
                                 onClick={() => setSelectedIndex(index)}
                             >
                                 {variant.name}

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -9,6 +9,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Button, Group, Select, SegmentedControl, Stack } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import { initCardHover } from '../shared/card-hover';
 
 /**
@@ -29,6 +30,7 @@ interface VariantData {
     id: number;
     name: string;
     canonical: boolean;
+    sprites: string[];
     description: string | null;
     mosaicUrl: string | null;
     groupedCards: Record<string, CardData[]>;
@@ -61,6 +63,21 @@ const SECTION_LABELS: Record<string, keyof Labels> = {
 };
 
 const MAX_BUTTONS = 5;
+
+function SpriteList({ slugs, height = 20 }: { slugs: string[]; height?: number }) {
+    return (
+        <>
+            {slugs.slice(0, 3).map((slug) => (
+                <img
+                    key={slug}
+                    src={`/build/sprites/pokemon/${slug}.png`}
+                    alt={slug}
+                    style={{ height, width: 'auto', marginRight: 2, verticalAlign: 'middle', imageRendering: 'pixelated' }}
+                />
+            ))}
+        </>
+    );
+}
 
 function CardSection({ title, cards, labels }: { title: string; cards: CardData[]; labels: Labels }) {
     return (
@@ -111,7 +128,6 @@ function CardTable({ groupedCards, labels }: { groupedCards: Record<string, Card
         return null;
     }
 
-    // Split into two columns for wider layouts
     const midpoint = Math.ceil(sections.length / 2);
     const leftSections = sections.slice(0, midpoint);
     const rightSections = sections.slice(midpoint);
@@ -132,13 +148,91 @@ function CardTable({ groupedCards, labels }: { groupedCards: Record<string, Card
     );
 }
 
+/**
+ * Desktop variant selector: compact pill buttons with sprites.
+ */
+function DesktopSelector({ variants, selectedIndex, onSelect }: {
+    variants: VariantData[];
+    selectedIndex: number;
+    onSelect: (index: number) => void;
+}) {
+    const buttonVariants = variants.slice(0, MAX_BUTTONS);
+    const dropdownVariants = variants.slice(MAX_BUTTONS);
+
+    return (
+        <Group gap={4} wrap="wrap">
+            {buttonVariants.map((variant, index) => (
+                <Button
+                    key={variant.id}
+                    variant={index === selectedIndex ? 'filled' : 'outline'}
+                    size="compact-sm"
+                    radius="xl"
+                    onClick={() => onSelect(index)}
+                    leftSection={variant.sprites.length > 0 ? <SpriteList slugs={variant.sprites} height={18} /> : undefined}
+                >
+                    {variant.name}
+                </Button>
+            ))}
+            {dropdownVariants.length > 0 && (
+                <Select
+                    data={dropdownVariants.map((variant, index) => ({
+                        value: String(MAX_BUTTONS + index),
+                        label: variant.name,
+                    }))}
+                    value={selectedIndex >= MAX_BUTTONS ? String(selectedIndex) : null}
+                    onChange={(value) => {
+                        if (value) {
+                            onSelect(Number(value));
+                        }
+                    }}
+                    size="xs"
+                    clearable
+                    style={{ minWidth: 200 }}
+                />
+            )}
+        </Group>
+    );
+}
+
+/**
+ * Mobile variant selector: dropdown with sprites and name.
+ */
+function MobileSelector({ variants, selectedIndex, onSelect }: {
+    variants: VariantData[];
+    selectedIndex: number;
+    onSelect: (index: number) => void;
+}) {
+    return (
+        <Select
+            data={variants.map((variant, index) => ({
+                value: String(index),
+                label: variant.name,
+            }))}
+            value={String(selectedIndex)}
+            onChange={(value) => {
+                if (value) {
+                    onSelect(Number(value));
+                }
+            }}
+            size="sm"
+            leftSection={
+                variants[selectedIndex].sprites.length > 0
+                    ? <SpriteList slugs={variants[selectedIndex].sprites} height={20} />
+                    : undefined
+            }
+            leftSectionWidth={variants[selectedIndex].sprites.length * 22 + 8}
+            styles={{ input: { fontWeight: 600 } }}
+        />
+    );
+}
+
 export default function ArchetypeVariantSelector({ variants, labels }: ArchetypeVariantSelectorProps) {
     const canonicalIndex = variants.findIndex((variant) => variant.canonical);
     const [selectedIndex, setSelectedIndex] = useState(canonicalIndex >= 0 ? canonicalIndex : 0);
     const [viewMode, setViewMode] = useState<ViewMode>('mosaic');
     const containerRef = useRef<HTMLDivElement>(null);
+    const isMobile = useMediaQuery('(max-width: 767.98px)');
 
-    // Re-initialize card hover after variant switch or view mode change
     useEffect(() => {
         if (viewMode === 'table') {
             initCardHover();
@@ -152,47 +246,16 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
     const selectedVariant = variants[selectedIndex];
     const hasCards = Object.keys(selectedVariant.groupedCards).length > 0;
 
-    // Split variants: first MAX_BUTTONS as buttons, rest in dropdown
-    const buttonVariants = variants.slice(0, MAX_BUTTONS);
-    const dropdownVariants = variants.slice(MAX_BUTTONS);
-
     return (
         <div ref={containerRef}>
             {/* Variant selector */}
             {variants.length > 1 && (
                 <div className="mb-3">
-                    <Group gap={4} wrap="wrap">
-                        {buttonVariants.map((variant, index) => (
-                            <Button
-                                key={variant.id}
-                                variant={index === selectedIndex ? 'filled' : 'outline'}
-                                size="compact-sm"
-                                radius="xl"
-                                onClick={() => setSelectedIndex(index)}
-                            >
-                                {variant.name}
-                                {variant.canonical && ' \u2605'}
-                            </Button>
-                        ))}
-                        {dropdownVariants.length > 0 && (
-                            <Select
-                                placeholder={labels.moreVariants}
-                                data={dropdownVariants.map((variant, index) => ({
-                                    value: String(MAX_BUTTONS + index),
-                                    label: variant.name,
-                                }))}
-                                value={selectedIndex >= MAX_BUTTONS ? String(selectedIndex) : null}
-                                onChange={(value) => {
-                                    if (value) {
-                                        setSelectedIndex(Number(value));
-                                    }
-                                }}
-                                size="sm"
-                                clearable
-                                style={{ minWidth: 200 }}
-                            />
-                        )}
-                    </Group>
+                    {isMobile ? (
+                        <MobileSelector variants={variants} selectedIndex={selectedIndex} onSelect={setSelectedIndex} />
+                    ) : (
+                        <DesktopSelector variants={variants} selectedIndex={selectedIndex} onSelect={setSelectedIndex} />
+                    )}
                 </div>
             )}
 

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -195,7 +195,7 @@ function DesktopSelector({ variants, selectedIndex, onSelect }: {
 }
 
 /**
- * Mobile variant selector: dropdown with sprites and name.
+ * Mobile variant selector: dropdown with sprites in both the input and options.
  */
 function MobileSelector({ variants, selectedIndex, onSelect }: {
     variants: VariantData[];
@@ -220,8 +220,18 @@ function MobileSelector({ variants, selectedIndex, onSelect }: {
                     ? <SpriteList slugs={variants[selectedIndex].sprites} height={20} />
                     : undefined
             }
-            leftSectionWidth={variants[selectedIndex].sprites.length * 22 + 8}
+            leftSectionWidth={variants[selectedIndex].sprites.length > 0 ? variants[selectedIndex].sprites.length * 22 + 8 : undefined}
             styles={{ input: { fontWeight: 600 } }}
+            renderOption={({ option }) => {
+                const variant = variants[Number(option.value)];
+
+                return (
+                    <Group gap={6} wrap="nowrap">
+                        {variant.sprites.length > 0 && <SpriteList slugs={variant.sprites} height={20} />}
+                        <span>{variant.name}</span>
+                    </Group>
+                );
+            }}
         />
     );
 }

--- a/assets/shared/card-hover.ts
+++ b/assets/shared/card-hover.ts
@@ -29,30 +29,39 @@ interface CardEntry {
 
 const isTouchDevice = (): boolean => window.matchMedia('(max-width: 767.98px)').matches;
 
+// Module-level state shared across multiple initCardHover() calls
+const cards: CardEntry[] = [];
+let currentIndex = 0;
+let modalInitialized = false;
+
+function showCard(index: number): void {
+    const modalImg = document.getElementById('cardImageModalImg') as HTMLImageElement | null;
+    const modalLabel = document.getElementById('cardImageModalLabel');
+
+    if (!modalImg || index < 0 || index >= cards.length) return;
+
+    const card = cards[index];
+    modalImg.src = card.src;
+    modalImg.alt = card.name;
+    if (modalLabel) {
+        modalLabel.textContent = card.quantity > 1 ? `${card.quantity} x ${card.name}` : card.name;
+    }
+}
+
+function navigate(direction: number): void {
+    currentIndex = (currentIndex + direction + cards.length) % cards.length;
+    showCard(currentIndex);
+}
+
+/**
+ * Initialize card hover for all `.card-hover` elements not yet initialized.
+ * Safe to call multiple times (e.g. after React re-renders).
+ */
 export function initCardHover(): void {
-    const cards: CardEntry[] = [];
-    let currentIndex = 0;
-
-    function showCard(index: number): void {
-        const modalImg = document.getElementById('cardImageModalImg') as HTMLImageElement | null;
-        const modalLabel = document.getElementById('cardImageModalLabel');
-
-        if (!modalImg || index < 0 || index >= cards.length) return;
-
-        const card = cards[index];
-        modalImg.src = card.src;
-        modalImg.alt = card.name;
-        if (modalLabel) {
-            modalLabel.textContent = card.quantity > 1 ? `${card.quantity} x ${card.name}` : card.name;
-        }
-    }
-
-    function navigate(direction: number): void {
-        currentIndex = (currentIndex + direction + cards.length) % cards.length;
-        showCard(currentIndex);
-    }
-
     document.querySelectorAll<HTMLElement>('.card-hover').forEach((element) => {
+        if (element.dataset.cardHoverInit) return;
+        element.dataset.cardHoverInit = '1';
+
         const img = element.querySelector<HTMLImageElement>('.card-hover-img');
         if (!img) return;
 
@@ -104,6 +113,10 @@ export function initCardHover(): void {
             bsModal.show();
         });
     });
+
+    // Only set up modal navigation handlers once
+    if (modalInitialized) return;
+    modalInitialized = true;
 
     // Prev/next button handlers
     document.getElementById('cardImageModalPrev')?.addEventListener('click', () => navigate(-1));

--- a/src/Controller/AdminArchetypeController.php
+++ b/src/Controller/AdminArchetypeController.php
@@ -15,15 +15,23 @@ namespace App\Controller;
 
 use App\Entity\Archetype;
 use App\Entity\ArchetypeTranslation;
+use App\Entity\Deck;
+use App\Entity\DeckCard;
+use App\Entity\DeckVersion;
 use App\Form\ArchetypeFormType;
 use App\Form\ArchetypeTranslationFormType;
+use App\Form\ArchetypeVariantFormType;
+use App\Message\EnrichDeckVersionMessage;
 use App\Repository\ArchetypeRepository;
 use App\Repository\DeckRepository;
+use App\Repository\DeckVersionRepository;
+use App\Service\DeckListParser;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -108,6 +116,7 @@ class AdminArchetypeController extends AbstractAppController
         }
 
         $translationForms = $this->buildTranslationForms($archetype, $request);
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
 
         return $this->render('admin/archetype/edit.html.twig', [
             'archetype' => $archetype,
@@ -116,6 +125,7 @@ class AdminArchetypeController extends AbstractAppController
             'translationForms' => $translationForms,
             'supportedLocales' => self::SUPPORTED_LOCALES,
             'deckCount' => $deckRepository->countAllByArchetype($archetype),
+            'variants' => $variants,
         ]);
     }
 
@@ -187,6 +197,209 @@ class AdminArchetypeController extends AbstractAppController
         return $this->redirect(
             $this->generateUrl('app_admin_archetype_edit', ['id' => $archetype->getId()]).'#pane-'.$locale
         );
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    #[Route('/{id}/variants/new', name: 'app_admin_archetype_variant_new', methods: ['GET', 'POST'], requirements: ['id' => '\d+'])]
+    public function newVariant(
+        Request $request,
+        Archetype $archetype,
+        DeckListParser $parser,
+        DeckVersionRepository $versionRepository,
+        MessageBusInterface $messageBus,
+    ): Response {
+        $deck = new Deck();
+        $deck->setArchetype($archetype);
+        $deck->setFormat('Expanded');
+
+        $form = $this->createForm(ArchetypeVariantFormType::class, $deck, [
+            'action' => $this->generateUrl('app_admin_archetype_variant_new', ['id' => $archetype->getId()]),
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->handleVariantPokemonSlugs($form, $deck);
+            $this->handleCanonicalToggle($deck, $archetype);
+            $this->em->persist($deck);
+            $this->em->flush();
+
+            $this->handleVariantRawList($form, $deck, $parser, $versionRepository, $messageBus);
+
+            $this->addFlash('success', 'app.archetype.variant.created', ['%name%' => $deck->getName()]);
+
+            return $this->redirectToRoute('app_admin_archetype_edit', ['id' => $archetype->getId()]);
+        }
+
+        return $this->render('admin/archetype/variant_form.html.twig', [
+            'archetype' => $archetype,
+            'form' => $form,
+            'deck' => $deck,
+            'isNew' => true,
+        ]);
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    #[Route('/{id}/variants/{deckId}', name: 'app_admin_archetype_variant_edit', methods: ['GET', 'POST'], requirements: ['id' => '\d+', 'deckId' => '\d+'])]
+    public function editVariant(
+        Request $request,
+        Archetype $archetype,
+        int $deckId,
+        DeckRepository $deckRepository,
+        DeckListParser $parser,
+        DeckVersionRepository $versionRepository,
+        MessageBusInterface $messageBus,
+    ): Response {
+        $deck = $deckRepository->find($deckId);
+        if (!$deck instanceof Deck || !$deck->isArchetypeVariant() || $deck->getArchetype()?->getId() !== $archetype->getId()) {
+            throw $this->createNotFoundException();
+        }
+
+        $form = $this->createForm(ArchetypeVariantFormType::class, $deck, [
+            'action' => $this->generateUrl('app_admin_archetype_variant_edit', [
+                'id' => $archetype->getId(),
+                'deckId' => $deckId,
+            ]),
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->handleVariantPokemonSlugs($form, $deck);
+            $this->handleCanonicalToggle($deck, $archetype);
+            $this->em->flush();
+
+            $this->handleVariantRawList($form, $deck, $parser, $versionRepository, $messageBus);
+
+            $this->addFlash('success', 'app.archetype.variant.updated', ['%name%' => $deck->getName()]);
+
+            return $this->redirectToRoute('app_admin_archetype_edit', ['id' => $archetype->getId()]);
+        }
+
+        return $this->render('admin/archetype/variant_form.html.twig', [
+            'archetype' => $archetype,
+            'form' => $form,
+            'deck' => $deck,
+            'isNew' => false,
+        ]);
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    #[Route('/{id}/variants/{deckId}/delete', name: 'app_admin_archetype_variant_delete', methods: ['POST'], requirements: ['id' => '\d+', 'deckId' => '\d+'])]
+    public function deleteVariant(Request $request, Archetype $archetype, int $deckId, DeckRepository $deckRepository): Response
+    {
+        $deck = $deckRepository->find($deckId);
+        if (!$deck instanceof Deck || !$deck->isArchetypeVariant() || $deck->getArchetype()?->getId() !== $archetype->getId()) {
+            throw $this->createNotFoundException();
+        }
+
+        if (!$this->isCsrfTokenValid('variant-delete-'.$deckId, $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_archetype_edit', ['id' => $archetype->getId()]);
+        }
+
+        $deck->setDeletedAt(new \DateTimeImmutable());
+        $this->em->flush();
+
+        $this->addFlash('success', 'app.archetype.variant.deleted', ['%name%' => $deck->getName()]);
+
+        return $this->redirectToRoute('app_admin_archetype_edit', ['id' => $archetype->getId()]);
+    }
+
+    /**
+     * @param FormInterface<Deck> $form
+     */
+    private function handleVariantPokemonSlugs(FormInterface $form, Deck $deck): void
+    {
+        /** @var string|null $slugsJson */
+        $slugsJson = $form->get('pokemonSlugs')->getData();
+
+        if (null !== $slugsJson && '' !== $slugsJson) {
+            /** @var list<string> $slugs */
+            $slugs = json_decode($slugsJson, true);
+            $deck->setPokemonSlugs($slugs);
+        } else {
+            $deck->setPokemonSlugs([]);
+        }
+    }
+
+    /**
+     * If this variant is set as canonical, unset any other canonical variant for the same archetype.
+     */
+    private function handleCanonicalToggle(Deck $deck, Archetype $archetype): void
+    {
+        if (!$deck->isCanonical()) {
+            return;
+        }
+
+        $queryBuilder = $this->em->createQueryBuilder();
+        $queryBuilder
+            ->update(Deck::class, 'd')
+            ->set('d.canonical', ':false')
+            ->where('d.archetype = :archetype')
+            ->andWhere('d.owner IS NULL')
+            ->andWhere('d.canonical = :true')
+            ->setParameter('false', false)
+            ->setParameter('archetype', $archetype)
+            ->setParameter('true', true);
+
+        if (null !== $deck->getId()) {
+            $queryBuilder
+                ->andWhere('d.id != :currentId')
+                ->setParameter('currentId', $deck->getId());
+        }
+
+        $queryBuilder->getQuery()->execute();
+    }
+
+    /**
+     * Create a DeckVersion from rawList if provided, and dispatch enrichment.
+     *
+     * @param FormInterface<Deck> $form
+     */
+    private function handleVariantRawList(
+        FormInterface $form,
+        Deck $deck,
+        DeckListParser $parser,
+        DeckVersionRepository $versionRepository,
+        MessageBusInterface $messageBus,
+    ): void {
+        /** @var string|null $rawList */
+        $rawList = $form->get('rawList')->getData();
+        if (null === $rawList || '' === trim($rawList)) {
+            return;
+        }
+
+        $nextVersion = $versionRepository->findMaxVersionNumber($deck) + 1;
+        $result = $parser->parse($rawList);
+
+        $version = new DeckVersion();
+        $version->setDeck($deck);
+        $version->setVersionNumber($nextVersion);
+        $version->setRawList($rawList);
+
+        foreach ($result->cards as $parsedCard) {
+            $card = new DeckCard();
+            $card->setCardName($parsedCard->cardName);
+            $card->setSetCode($parsedCard->setCode);
+            $card->setCardNumber($parsedCard->cardNumber);
+            $card->setQuantity($parsedCard->quantity);
+            $card->setCardType($parsedCard->cardType);
+            $version->addCard($card);
+        }
+
+        $this->em->persist($version);
+        $deck->setCurrentVersion($version);
+        $this->em->flush();
+
+        /** @var int $versionId */
+        $versionId = $version->getId();
+        $messageBus->dispatch(new EnrichDeckVersionMessage($versionId));
     }
 
     /**

--- a/src/Controller/ArchetypeDetailController.php
+++ b/src/Controller/ArchetypeDetailController.php
@@ -153,7 +153,7 @@ class ArchetypeDetailController extends AbstractController
                 'id' => $variantId,
                 'name' => $variant->getName(),
                 'canonical' => $variant->isCanonical(),
-                'sprites' => $variant->getEffectivePokemonSlugs(),
+                'sprites' => $variant->getPokemonSlugs(),
                 'description' => $htmlDescription,
                 'mosaicUrl' => $mosaicUrl,
                 'groupedCards' => $orderedGroups,

--- a/src/Controller/ArchetypeDetailController.php
+++ b/src/Controller/ArchetypeDetailController.php
@@ -153,6 +153,7 @@ class ArchetypeDetailController extends AbstractController
                 'id' => $variantId,
                 'name' => $variant->getName(),
                 'canonical' => $variant->isCanonical(),
+                'sprites' => $variant->getEffectivePokemonSlugs(),
                 'description' => $htmlDescription,
                 'mosaicUrl' => $mosaicUrl,
                 'groupedCards' => $orderedGroups,

--- a/src/Controller/ArchetypeDetailController.php
+++ b/src/Controller/ArchetypeDetailController.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\Deck;
+use App\Entity\DeckCard;
 use App\Repository\ArchetypeRepository;
 use App\Repository\DeckRepository;
 use App\Service\ArchetypeDescriptionRenderer;
@@ -60,11 +62,103 @@ class ArchetypeDetailController extends AbstractController
         $latestDecks = $deckRepository->findLatestPublicByArchetype($archetype);
         $totalDeckCount = $deckRepository->countPublicByArchetype($archetype);
 
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
+        $variantsData = $this->buildVariantsData($variants, $descriptionRenderer, $locale);
+
         return $this->render('archetype/show.html.twig', [
             'archetype' => $archetype,
             'htmlContent' => $htmlContent,
             'latestDecks' => $latestDecks,
             'totalDeckCount' => $totalDeckCount,
+            'variants' => $variants,
+            'variantsData' => $variantsData,
         ]);
+    }
+
+    /**
+     * Build serializable variant data for the React variant selector.
+     *
+     * @see docs/features.md F18.16 — Archetype detail: variant selector
+     *
+     * @param list<Deck> $variants
+     *
+     * @return list<array{id: int, name: string, canonical: bool, description: string|null, mosaicUrl: string|null, groupedCards: array<string, list<array{cardName: string, quantity: int, setCode: string, cardNumber: string, cardType: string, trainerSubtype: string|null, imageUrl: string|null}>>}>
+     */
+    private function buildVariantsData(array $variants, ArchetypeDescriptionRenderer $descriptionRenderer, string $locale): array
+    {
+        $data = [];
+
+        foreach ($variants as $variant) {
+            $version = $variant->getCurrentVersion();
+            $groupedCards = [];
+            $mosaicUrl = null;
+
+            if (null !== $version) {
+                $mosaicUrl = $version->getMosaicImageUrl();
+
+                foreach ($version->getCards() as $card) {
+                    $groupedCards[$card->getCardType()][] = $card;
+                }
+
+                foreach ($groupedCards as $type => &$cards) {
+                    usort($cards, static function (DeckCard $cardA, DeckCard $cardB) use ($type): int {
+                        if ('trainer' === $type) {
+                            $subtypeOrder = ['supporter' => 0, 'item' => 1, 'tool' => 2, 'stadium' => 3];
+                            $subtypeA = $subtypeOrder[strtolower((string) $cardA->getTrainerSubtype())] ?? 4;
+                            $subtypeB = $subtypeOrder[strtolower((string) $cardB->getTrainerSubtype())] ?? 4;
+
+                            if ($subtypeA !== $subtypeB) {
+                                return $subtypeA <=> $subtypeB;
+                            }
+                        }
+
+                        if ($cardA->getQuantity() !== $cardB->getQuantity()) {
+                            return $cardB->getQuantity() <=> $cardA->getQuantity();
+                        }
+
+                        return strcmp($cardA->getCardName(), $cardB->getCardName());
+                    });
+                }
+                unset($cards);
+            }
+
+            $orderedGroups = [];
+            foreach (['pokemon', 'trainer', 'energy'] as $section) {
+                if (isset($groupedCards[$section])) {
+                    $serialized = [];
+                    foreach ($groupedCards[$section] as $card) {
+                        $serialized[] = [
+                            'cardName' => $card->getCardName(),
+                            'quantity' => $card->getQuantity(),
+                            'setCode' => $card->getSetCode(),
+                            'cardNumber' => $card->getCardNumber(),
+                            'cardType' => $card->getCardType(),
+                            'trainerSubtype' => $card->getTrainerSubtype(),
+                            'imageUrl' => $card->getImageUrl(),
+                        ];
+                    }
+                    $orderedGroups[$section] = $serialized;
+                }
+            }
+
+            $description = $variant->getNotes();
+            $htmlDescription = null !== $description && '' !== $description
+                ? $descriptionRenderer->render($description, $locale)
+                : null;
+
+            /** @var int $variantId */
+            $variantId = $variant->getId();
+
+            $data[] = [
+                'id' => $variantId,
+                'name' => $variant->getName(),
+                'canonical' => $variant->isCanonical(),
+                'description' => $htmlDescription,
+                'mosaicUrl' => $mosaicUrl,
+                'groupedCards' => $orderedGroups,
+            ];
+        }
+
+        return $data;
     }
 }

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -126,6 +126,9 @@ MARKDOWN;
         $this->createRegidragoDeckVersion($manager, $lenderDeck);
         $this->createRegidragoDeckVersionTwo($manager, $lenderDeck);
 
+        // Archetype variant decks (no owner)
+        $this->createRegidragoVariants($manager, $archetypeRegidrago);
+
         $borrowerDeck = $this->createDeck($manager, $borrower, 'Lugia Archeops');
         $borrowerDeck->setArchetype($archetypeLugia);
         $borrowerDeck->setLanguages(['en']);
@@ -587,6 +590,134 @@ MARKDOWN;
         $archetype->addTranslation($translation);
 
         $manager->persist($translation);
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    private function createRegidragoVariants(ObjectManager $manager, Archetype $archetype): void
+    {
+        $rawList = <<<'LIST'
+Pokémon: 19
+4 Regidrago V SIT 135
+3 Regidrago VSTAR SIT 136
+1 Budew PRE 4
+1 Crobat V DAA 104
+1 Dedenne-GX UNB 57
+1 Dialga-GX UPR 100
+1 Dragapult ex TWM 130
+1 Giratina VSTAR LOR 131
+1 Kyurem SFA 47
+1 Latias ex SSP 76
+1 Noivern ex PAL 153
+1 Noivern-GX BUS 99
+1 Salamence ex JTG 114
+1 Tapu Lele-GX GRI 60
+
+Trainer: 31
+4 Mysterious Treasure FLI 113
+4 Professor's Research JTG 155
+4 Quick Ball FST 237
+3 VS Seeker PHF 109
+2 Battle Compressor PHF 92
+1 Crispin SCR 133
+1 Faba LOT 173
+1 Float Stone PLF 99
+1 Guzma BUS 115
+1 Hisuian Heavy Ball ASR 146
+1 Iono PAL 185
+1 Marnie SSH 169
+1 Megaton Blower SSP 182
+1 Muscle Band XY 121
+1 N FCO 105
+1 Parallel City BKT 145
+1 Path to the Peak CRE 148
+1 Raihan EVS 152
+1 Super Rod PAL 188
+
+Energy: 10
+4 Double Dragon Energy ROS 97
+4 Grass Energy SVE 1
+2 Fire Energy SVE 2
+
+Total Cards: 60
+LIST;
+
+        // Canonical variant: Regidrago
+        $canonical = new Deck();
+        $canonical->setName('Regidrago');
+        $canonical->setArchetype($archetype);
+        $canonical->setFormat('Expanded');
+        $canonical->setCanonical(true);
+        $canonical->setPokemonSlugs(['dialga']);
+        $canonical->setNotes(<<<'MARKDOWN'
+## Strategy
+
+Regidrago VSTAR leverages its **Apex Dragon** VSTAR Power to copy any attack from a Dragon-type Pokemon in the discard pile. The core engine uses [[card:SIT-136]] as the sole attacker, discarding Dragon-type Pokemon with powerful attacks early — then copying them for a single energy cost via **Double Turbo Energy**.
+
+## Key Combos
+
+- **Giratina VSTAR** in discard → copy **Lost Impact** (280 damage) for just one Double Turbo
+- **Dragonite V** in discard → copy **Dragon Gale** for spread damage + snipe
+- **Kyurem VMAX** in discard → copy **Max Frost** for scaling damage based on energy
+
+## Setup
+
+Turn 1 priority: use **Battle VIP Pass** and **Nest Ball** to bench two Regidrago V. **Battle Compressor** and **Ultra Ball** discard Dragon attackers early. **Professor Juniper** fuels the discard while refreshing your hand.
+
+## Matchup Notes
+
+Strong against single-prize decks thanks to VSTAR bulk (270 HP) and one-shot potential. Weak to **Path to the Peak** (shuts off VSTAR Power) — run 2–3 **Chaotic Swell** or **Field Blower** to counter.
+MARKDOWN);
+        $canonicalVersion = new DeckVersion();
+        $canonicalVersion->setDeck($canonical);
+        $canonicalVersion->setVersionNumber(1);
+        $canonicalVersion->setRawList($rawList);
+        $manager->persist($canonical);
+        $manager->persist($canonicalVersion);
+        $canonical->setCurrentVersion($canonicalVersion);
+
+        // Alternate variant: Regidrago / Cinccino
+        $alternate = new Deck();
+        $alternate->setName('Alternate Regidrago');
+        $alternate->setArchetype($archetype);
+        $alternate->setFormat('Expanded');
+        $alternate->setPokemonSlugs(['dragonite']);
+        $alternate->setNotes(<<<'MARKDOWN'
+## Strategy
+
+The **Regidrago / Cinccino** variant trades raw power for consistency. Instead of relying solely on [[card:SIT-136]], this build pairs it with a **Cinccino** draw engine — **Make Do** lets you discard a card and draw two, simultaneously fueling the discard pile with Dragon attackers and keeping your hand stocked.
+
+## Key Differences from Canonical
+
+- **Cinccino line** (Minccino + Cinccino) replaces heavy Supporter reliance — less dependent on turn 1 Professor Juniper
+- Thinner Dragon target lineup (3–4 instead of 5–6) to make room for the draw engine
+- More resilient to **N** and **Marnie** hand disruption thanks to bench-based draw
+
+## Setup
+
+Turn 1: bench Regidrago V + Minccino. Turn 2: evolve both — Cinccino starts drawing while Regidrago VSTAR charges. Use **Level Ball** to search Minccino and Cinccino (both under 90 HP).
+
+## Weaknesses
+
+Bigger bench means more liability against **Sky Seal Stone** + Boss's Orders snipes. The Cinccino line gives up easy two-prize KOs if dragged active.
+MARKDOWN);
+        $alternateVersion = new DeckVersion();
+        $alternateVersion->setDeck($alternate);
+        $alternateVersion->setVersionNumber(1);
+        $alternateVersion->setRawList($rawList);
+        $manager->persist($alternate);
+        $manager->persist($alternateVersion);
+        $alternate->setCurrentVersion($alternateVersion);
+
+        // Third variant: minimal placeholder
+        $third = new Deck();
+        $third->setName('Third Regidrago');
+        $third->setArchetype($archetype);
+        $third->setFormat('Expanded');
+        $third->setPokemonSlugs(['dragapult']);
+        $third->setNotes('A lightweight Regidrago build focused on speed.');
+        $manager->persist($third);
     }
 
     private function createDeck(ObjectManager $manager, User $owner, string $name, DeckStatus $status = DeckStatus::Available): Deck

--- a/src/Form/ArchetypeVariantFormType.php
+++ b/src/Form/ArchetypeVariantFormType.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Form;
+
+use App\Entity\Deck;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form for creating/editing archetype variant decks.
+ * Only used in the archetype admin page — never on standard deck forms.
+ *
+ * @see docs/features.md F18.15 — Admin archetype variant management
+ *
+ * @extends AbstractType<Deck>
+ */
+class ArchetypeVariantFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'app.archetype.variant.name',
+            ])
+            ->add('canonical', CheckboxType::class, [
+                'label' => 'app.archetype.variant.canonical',
+                'required' => false,
+            ])
+            ->add('pokemonSlugs', HiddenType::class, [
+                'mapped' => false,
+            ])
+            ->add('rawList', TextareaType::class, [
+                'label' => 'app.archetype.variant.raw_list',
+                'mapped' => false,
+                'required' => false,
+                'attr' => [
+                    'rows' => 10,
+                    'placeholder' => 'app.archetype.variant.raw_list_placeholder',
+                ],
+            ])
+            ->add('notes', TextareaType::class, [
+                'label' => 'app.archetype.variant.description',
+                'required' => false,
+                'attr' => ['rows' => 15],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Deck::class,
+        ]);
+    }
+}

--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -162,6 +162,31 @@ class DeckRepository extends ServiceEntityRepository
     }
 
     /**
+     * Find archetype variant decks (no owner), ordered canonical first, then by creation date.
+     *
+     * @see docs/features.md F18.13 — Archetype variant decks
+     *
+     * @return list<Deck>
+     */
+    public function findVariantsByArchetype(Archetype $archetype): array
+    {
+        /** @var list<Deck> $decks */
+        $decks = $this->createQueryBuilder('d')
+            ->leftJoin('d.currentVersion', 'cv')
+            ->addSelect('cv')
+            ->where('d.archetype = :archetype')
+            ->andWhere('d.owner IS NULL')
+            ->andWhere('d.deletedAt IS NULL')
+            ->setParameter('archetype', $archetype)
+            ->orderBy('d.canonical', 'DESC')
+            ->addOrderBy('d.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return $decks;
+    }
+
+    /**
      * @see docs/features.md F2.1 — Register a new deck (owner)
      *
      * @return list<Deck>

--- a/templates/admin/archetype/edit.html.twig
+++ b/templates/admin/archetype/edit.html.twig
@@ -96,6 +96,76 @@
         </div>
     </div>
 
+    {# Variants — archetype editorial decklists #}
+    <div class="card shadow-sm mb-4">
+        <div class="card-header card-header-themed d-flex justify-content-between align-items-center">
+            <h5 class="mb-0">{{ 'app.archetype.variant.section_title'|trans }}</h5>
+            <a href="{{ path('app_admin_archetype_variant_new', {id: archetype.id}) }}" class="btn btn-sm btn-gold">
+                <i class="bi bi-plus-lg me-1"></i>{{ 'app.archetype.variant.add'|trans }}
+            </a>
+        </div>
+        <div class="card-body">
+            {% if variants is empty %}
+                <p class="text-muted mb-0">{{ 'app.archetype.variant.none'|trans }}</p>
+            {% else %}
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>{{ 'app.common.name'|trans }}</th>
+                                <th>{{ 'app.archetype.variant.canonical'|trans }}</th>
+                                <th>{{ 'app.archetype.variant.decklist'|trans }}</th>
+                                <th>{{ 'app.common.created_at'|trans }}</th>
+                                <th class="text-end">{{ 'app.common.actions'|trans }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for variant in variants %}
+                                <tr>
+                                    <td>
+                                        {% for slug in variant.effectivePokemonSlugs[:3] %}
+                                            <img src="{{ asset('build/sprites/pokemon/' ~ slug ~ '.png') }}" alt="{{ slug }}" class="archetype-sprite" style="height: 24px;">
+                                        {% endfor %}
+                                        {{ variant.name }}
+                                    </td>
+                                    <td>
+                                        {% if variant.canonical %}
+                                            <span class="badge bg-success">{{ 'app.archetype.variant.canonical'|trans }}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if variant.currentVersion %}
+                                            <span class="badge bg-primary">v{{ variant.currentVersion.versionNumber }}</span>
+                                            {% if variant.currentVersion.enrichmentStatus == 'done' %}
+                                                <span class="badge bg-success">{{ 'app.deck.enriched'|trans }}</span>
+                                            {% elseif variant.currentVersion.enrichmentStatus == 'pending' %}
+                                                <span class="badge bg-warning text-dark">{{ 'app.deck.pending'|trans }}</span>
+                                            {% endif %}
+                                        {% else %}
+                                            <span class="text-muted">—</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ variant.createdAt|date('Y-m-d') }}</td>
+                                    <td class="text-end">
+                                        <a href="{{ path('app_admin_archetype_variant_edit', {id: archetype.id, deckId: variant.id}) }}" class="btn btn-sm btn-outline-primary">
+                                            <i class="bi bi-pencil"></i>
+                                        </a>
+                                        <form method="post" action="{{ path('app_admin_archetype_variant_delete', {id: archetype.id, deckId: variant.id}) }}" class="d-inline" onsubmit="return confirm('{{ 'app.archetype.variant.delete_confirm'|trans|e('js') }}')">
+                                            <input type="hidden" name="_token" value="{{ csrf_token('variant-delete-' ~ variant.id) }}">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+
     {% if archetype.deletedAt is not null %}
         <div class="card shadow-sm border-warning mt-4">
             <div class="card-body">

--- a/templates/admin/archetype/variant_form.html.twig
+++ b/templates/admin/archetype/variant_form.html.twig
@@ -1,0 +1,78 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    {% if isNew %}
+        {{ 'app.archetype.variant.new_title'|trans({'%archetype%': archetype.name}) }} — {{ channel_param('brand_name', 'Expanded Decks') }}
+    {% else %}
+        {{ 'app.archetype.variant.edit_title'|trans({'%name%': deck.name, '%archetype%': archetype.name}) }} — {{ channel_param('brand_name', 'Expanded Decks') }}
+    {% endif %}
+{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    {{ encore_entry_link_tags('archetype_form') }}
+    {{ encore_entry_link_tags('page_form') }}
+{% endblock %}
+
+{% block body %}
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="mb-0">
+            {% if isNew %}
+                {{ 'app.archetype.variant.new_title'|trans({'%archetype%': archetype.name}) }}
+            {% else %}
+                {{ 'app.archetype.variant.edit_title'|trans({'%name%': deck.name, '%archetype%': archetype.name}) }}
+            {% endif %}
+        </h1>
+        <a href="{{ path('app_admin_archetype_edit', {id: archetype.id}) }}" class="btn btn-outline-secondary">{{ 'app.common.back'|trans }}</a>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-header card-header-themed">
+            <h5 class="mb-0">{{ 'app.archetype.variant.details'|trans }}</h5>
+        </div>
+        <div class="card-body">
+            {{ form_start(form) }}
+                {{ form_row(form.name) }}
+                {{ form_row(form.canonical) }}
+
+                <div class="mb-3">
+                    <label class="form-label">{{ 'app.archetype.pokemon_slugs_label'|trans }}</label>
+                    <div id="pokemon-sprite-select-root"
+                         data-values="{{ deck.pokemonSlugs|json_encode }}"
+                         data-hidden-input-name="archetype_variant_form[pokemonSlugs]"></div>
+                    {{ form_widget(form.pokemonSlugs) }}
+                </div>
+
+                {{ form_row(form.rawList) }}
+
+                {% if not isNew and deck.currentVersion %}
+                    <div class="alert alert-info mb-3">
+                        <strong>{{ 'app.archetype.variant.current_version'|trans }}:</strong>
+                        v{{ deck.currentVersion.versionNumber }}
+                        ({{ deck.currentVersion.enrichmentStatus }})
+                        — {{ 'app.archetype.variant.paste_to_replace'|trans }}
+                    </div>
+                {% endif %}
+
+                {% from 'admin/_rich_text_editor.html.twig' import rich_text_editor %}
+                {{ rich_text_editor(form.notes) }}
+
+                <button type="submit" class="btn btn-gold mt-3">{{ 'app.common.save'|trans }}</button>
+            {{ form_end(form) }}
+        </div>
+    </div>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {{ encore_entry_script_tags('archetype_form') }}
+    {{ encore_entry_script_tags('page_form') }}
+{% endblock %}

--- a/templates/archetype/show.html.twig
+++ b/templates/archetype/show.html.twig
@@ -19,6 +19,13 @@
     <meta property="og:title" content="{{ archetype.localizedName(app.request.locale) }} — Expanded Decks">
 {% endblock %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    {% if variants is not empty %}
+        {{ encore_entry_link_tags('archetype_variants') }}
+    {% endif %}
+{% endblock %}
+
 {% block body %}
     {% if not archetype.published %}
         <div class="alert alert-warning"><i class="bi bi-eye me-1"></i>{{ 'app.archetype.draft_notice'|trans }}</div>
@@ -52,6 +59,29 @@
             {% endif %}
         </div>
 
+        {% if variants is not empty %}
+            <div class="card shadow-sm mb-4">
+                <div class="card-header card-header-themed">
+                    <h5 class="mb-0">{{ 'app.archetype.variant.section_title'|trans }}</h5>
+                </div>
+                <div class="card-body">
+                    <div id="archetype-variant-selector-root"
+                         data-variants="{{ variantsData|json_encode|e('html_attr') }}"
+                         data-label-view-table="{{ 'app.deck.view_table'|trans }}"
+                         data-label-view-mosaic="{{ 'app.deck.view_mosaic'|trans }}"
+                         data-label-mosaic-alt="{{ 'app.deck.mosaic_alt'|trans({'%name%': archetype.localizedName(app.request.locale)}) }}"
+                         data-label-section-pokemon="{{ 'app.deck.section_pokemon'|trans }}"
+                         data-label-section-trainer="{{ 'app.deck.section_trainer'|trans }}"
+                         data-label-section-energy="{{ 'app.deck.section_energy'|trans }}"
+                         data-label-table-qty="{{ 'app.deck.table_qty'|trans }}"
+                         data-label-table-card="{{ 'app.deck.table_card'|trans }}"
+                         data-label-table-set="{{ 'app.deck.table_set'|trans }}"
+                         data-label-more-variants="{{ 'app.archetype.variant.more'|trans }}">
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+
         {% set channel = current_channel() %}
         {% if channel.enableDecks and latestDecks is not empty %}
             <div class="card shadow-sm">
@@ -64,7 +94,7 @@
                             <span class="badge bg-dark badge-short-id me-2">{{ deck.shortTag }}</span>
                             {{ archetype_sprites(archetype) }}
                             <span class="ms-1">{{ deck.name }}</span>
-                            <span class="text-muted ms-auto small">{{ deck.owner.screenName }}</span>
+                            <span class="text-muted ms-auto small">{{ deck.owner ? deck.owner.screenName : '' }}</span>
                         </a>
                     {% endfor %}
                 </div>
@@ -100,4 +130,7 @@
 {% block javascripts %}
     {{ parent() }}
     {{ encore_entry_script_tags('archetype_show') }}
+    {% if variants is not empty %}
+        {{ encore_entry_script_tags('archetype_variants') }}
+    {% endif %}
 {% endblock %}

--- a/tests/Functional/AdminArchetypeControllerTest.php
+++ b/tests/Functional/AdminArchetypeControllerTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\Entity\Archetype;
+use App\Entity\Deck;
+use App\Repository\DeckRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -230,6 +232,149 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
         self::assertContains('Control', $refreshed->getPlaystyleTags());
     }
 
+    // ---------------------------------------------------------------
+    // Archetype variant management (F18.15)
+    // ---------------------------------------------------------------
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    public function testEditPageDisplaysVariantsSection(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $this->client->request('GET', '/admin/archetypes/'.$archetype->getId());
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('a[href*="variants/new"]');
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    public function testEditPageListsExistingVariants(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $crawler = $this->client->request('GET', '/admin/archetypes/'.$archetype->getId());
+
+        self::assertResponseIsSuccessful();
+
+        // Fixture creates 3 Regidrago variants
+        $variantRows = $crawler->filter('table tbody tr');
+        self::assertGreaterThanOrEqual(3, $variantRows->count());
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    public function testNewVariantFormAccessible(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/new');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('form[name="archetype_variant_form"]');
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    public function testCreateVariant(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $crawler = $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/new');
+
+        $form = $crawler->selectButton('Save')->form();
+        $form['archetype_variant_form[name]'] = 'Test Variant';
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    public function testEditVariantFormAccessible(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $variant = $this->getVariantByName('Regidrago', $archetype);
+
+        $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/'.$variant->getId());
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('form[name="archetype_variant_form"]');
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    public function testEditVariantUpdates(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $variant = $this->getVariantByName('Regidrago', $archetype);
+
+        $crawler = $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/'.$variant->getId());
+
+        $form = $crawler->selectButton('Save')->form();
+        $form['archetype_variant_form[name]'] = 'Updated Regidrago';
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    public function testDeleteVariant(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $variant = $this->getVariantByName('Third Regidrago', $archetype);
+
+        // Load the edit page first to get a valid session for CSRF
+        $crawler = $this->client->request('GET', '/admin/archetypes/'.$archetype->getId());
+
+        // Find the delete form for this variant and submit it
+        $deleteForm = $crawler->filter('form[action*="variants/'.$variant->getId().'/delete"]');
+        self::assertGreaterThan(0, $deleteForm->count(), 'Delete form for variant should exist.');
+
+        $form = $deleteForm->form();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+    }
+
+    /**
+     * @see docs/features.md F18.15 — Admin archetype variant management
+     */
+    public function testVariantRequiresAdmin(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/new');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
     private function getArchetype(string $name): Archetype
     {
         /** @var EntityManagerInterface $em */
@@ -239,5 +384,21 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
         $archetype = $em->getRepository(Archetype::class)->findOneBy(['name' => $name]);
 
         return $archetype;
+    }
+
+    private function getVariantByName(string $name, Archetype $archetype): Deck
+    {
+        /** @var DeckRepository $deckRepository */
+        $deckRepository = static::getContainer()->get(DeckRepository::class);
+
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
+
+        foreach ($variants as $variant) {
+            if ($variant->getName() === $name) {
+                return $variant;
+            }
+        }
+
+        self::fail(\sprintf('Variant "%s" not found for archetype "%s".', $name, $archetype->getName()));
     }
 }

--- a/tests/Functional/ArchetypeDetailControllerTest.php
+++ b/tests/Functional/ArchetypeDetailControllerTest.php
@@ -172,6 +172,87 @@ class ArchetypeDetailControllerTest extends AbstractFunctionalTest
         self::assertSelectorExists('img.archetype-sprite[title="Flutter Mane"]');
     }
 
+    // ---------------------------------------------------------------
+    // Archetype variant selector (F18.16)
+    // ---------------------------------------------------------------
+
+    /**
+     * @see docs/features.md F18.16 — Archetype detail: variant selector
+     */
+    public function testArchetypeWithVariantsShowsVariantSelector(): void
+    {
+        $crawler = $this->client->request('GET', '/archetypes/regidrago');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('#archetype-variant-selector-root');
+
+        $selectorRoot = $crawler->filter('#archetype-variant-selector-root');
+        $variantsJson = $selectorRoot->attr('data-variants');
+        self::assertNotNull($variantsJson);
+
+        /** @var list<array{id: int, name: string, canonical: bool}> $variants */
+        $variants = json_decode($variantsJson, true);
+        self::assertIsArray($variants);
+        self::assertGreaterThanOrEqual(2, \count($variants));
+
+        // Canonical variant should be first
+        self::assertTrue($variants[0]['canonical']);
+    }
+
+    /**
+     * @see docs/features.md F18.16 — Archetype detail: variant selector
+     */
+    public function testVariantDataContainsExpectedFields(): void
+    {
+        $crawler = $this->client->request('GET', '/archetypes/regidrago');
+
+        self::assertResponseIsSuccessful();
+
+        $selectorRoot = $crawler->filter('#archetype-variant-selector-root');
+
+        /** @var list<array{id: int, name: string, canonical: bool, sprites: list<string>, groupedCards: array<string, mixed>}> $variants */
+        $variants = json_decode((string) $selectorRoot->attr('data-variants'), true);
+
+        $canonical = $variants[0];
+        self::assertArrayHasKey('id', $canonical);
+        self::assertArrayHasKey('name', $canonical);
+        self::assertArrayHasKey('canonical', $canonical);
+        self::assertArrayHasKey('sprites', $canonical);
+        self::assertArrayHasKey('groupedCards', $canonical);
+        self::assertArrayHasKey('mosaicUrl', $canonical);
+        self::assertArrayHasKey('description', $canonical);
+    }
+
+    /**
+     * @see docs/features.md F18.16 — Archetype detail: variant selector
+     */
+    public function testVariantDataContainsDescription(): void
+    {
+        $crawler = $this->client->request('GET', '/archetypes/regidrago');
+
+        self::assertResponseIsSuccessful();
+
+        $selectorRoot = $crawler->filter('#archetype-variant-selector-root');
+
+        /** @var list<array{description: string|null}> $variants */
+        $variants = json_decode((string) $selectorRoot->attr('data-variants'), true);
+
+        // Canonical variant has a markdown description rendered to HTML
+        self::assertNotNull($variants[0]['description']);
+        self::assertStringContainsString('Strategy', $variants[0]['description']);
+    }
+
+    /**
+     * @see docs/features.md F18.16 — Archetype detail: variant selector
+     */
+    public function testArchetypeWithoutVariantsHasNoSelector(): void
+    {
+        $this->client->request('GET', '/archetypes/iron-thorns-ex');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('#archetype-variant-selector-root');
+    }
+
     private function getEntityManager(): EntityManagerInterface
     {
         /** @var EntityManagerInterface $entityManager */

--- a/tests/Functional/DeckRepositoryCoverageTest.php
+++ b/tests/Functional/DeckRepositoryCoverageTest.php
@@ -229,4 +229,96 @@ class DeckRepositoryCoverageTest extends AbstractFunctionalTest
         // currentVersion can be null for some decks, but the join is a leftJoin
         // so this just verifies the query does not error
     }
+
+    // ---------------------------------------------------------------
+    // findVariantsByArchetype
+    // ---------------------------------------------------------------
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testFindVariantsByArchetypeReturnsOnlyOwnerlessDecks(): void
+    {
+        $deckRepository = $this->getDeckRepository();
+        $entityManager = $this->getEntityManager();
+
+        $archetype = $entityManager->getRepository(\App\Entity\Archetype::class)->findOneBy(['name' => 'Regidrago']);
+        self::assertNotNull($archetype);
+
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
+
+        self::assertNotEmpty($variants, 'Regidrago archetype should have variant decks from fixtures.');
+
+        foreach ($variants as $variant) {
+            self::assertNull($variant->getOwner(), 'Variant decks must have no owner.');
+            self::assertTrue($variant->isArchetypeVariant());
+        }
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testFindVariantsByArchetypeOrdersCanonicalFirst(): void
+    {
+        $deckRepository = $this->getDeckRepository();
+        $entityManager = $this->getEntityManager();
+
+        $archetype = $entityManager->getRepository(\App\Entity\Archetype::class)->findOneBy(['name' => 'Regidrago']);
+        self::assertNotNull($archetype);
+
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
+        self::assertGreaterThanOrEqual(2, \count($variants));
+
+        $firstVariant = $variants[0];
+        self::assertTrue($firstVariant->isCanonical(), 'First variant should be the canonical one.');
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testFindVariantsByArchetypeExcludesOwnedDecks(): void
+    {
+        $deckRepository = $this->getDeckRepository();
+        $entityManager = $this->getEntityManager();
+
+        $archetype = $entityManager->getRepository(\App\Entity\Archetype::class)->findOneBy(['name' => 'Regidrago']);
+        self::assertNotNull($archetype);
+
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
+
+        // None of the returned decks should have an owner
+        foreach ($variants as $variant) {
+            self::assertNull($variant->getOwner(), 'User-owned decks must be excluded from variants.');
+        }
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testFindVariantsByArchetypeReturnsEmptyForArchetypeWithoutVariants(): void
+    {
+        $deckRepository = $this->getDeckRepository();
+        $entityManager = $this->getEntityManager();
+
+        $archetype = $entityManager->getRepository(\App\Entity\Archetype::class)->findOneBy(['name' => 'Iron Thorns ex']);
+        self::assertNotNull($archetype);
+
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
+
+        self::assertEmpty($variants, 'Iron Thorns should have no variant decks.');
+    }
+
+    /**
+     * @see docs/features.md F18.13 — Archetype variant decks
+     */
+    public function testFindAvailableDecksExcludesVariants(): void
+    {
+        $deckRepository = $this->getDeckRepository();
+
+        $decks = $deckRepository->findAvailableDecks();
+
+        foreach ($decks as $deck) {
+            self::assertNotNull($deck->getOwner(), 'findAvailableDecks must never return ownerless (variant) decks.');
+        }
+    }
 }

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -75,6 +75,11 @@
                 <target>Actions</target>
                 <note>Aria label for contextual action menus</note>
             </trans-unit>
+            <trans-unit id="app.common.created_at">
+                <source>app.common.created_at</source>
+                <target>Created</target>
+                <note>Table header for creation date column</note>
+            </trans-unit>
             <trans-unit id="app.common.cancel">
                 <source>app.common.cancel</source>
                 <target>Cancel</target>
@@ -3522,6 +3527,98 @@
                 <source>app.archetype.no_results</source>
                 <target>No archetypes match your filter.</target>
                 <note>Empty state on archetype catalog when filters yield no results</note>
+            </trans-unit>
+
+            <!-- Archetype variants (F18.15) -->
+            <trans-unit id="app.archetype.variant.section_title">
+                <source>app.archetype.variant.section_title</source>
+                <target>Variants</target>
+                <note>Card header for variant section on archetype edit page</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.add">
+                <source>app.archetype.variant.add</source>
+                <target>Add variant</target>
+                <note>Button to add a new archetype variant deck</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.none">
+                <source>app.archetype.variant.none</source>
+                <target>No variants yet. Add one to display editorial decklists on the archetype page.</target>
+                <note>Empty state when archetype has no variant decks</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.name">
+                <source>app.archetype.variant.name</source>
+                <target>Variant name</target>
+                <note>Label for variant deck name field</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.canonical">
+                <source>app.archetype.variant.canonical</source>
+                <target>Canonical</target>
+                <note>Label for canonical variant toggle</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.decklist">
+                <source>app.archetype.variant.decklist</source>
+                <target>Decklist</target>
+                <note>Table header for decklist column in variant list</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.raw_list">
+                <source>app.archetype.variant.raw_list</source>
+                <target>Decklist (PTCG text format)</target>
+                <note>Label for raw list paste field on variant form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.raw_list_placeholder">
+                <source>app.archetype.variant.raw_list_placeholder</source>
+                <target>Paste a PTCG text format decklist here…</target>
+                <note>Placeholder for raw list field</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.description">
+                <source>app.archetype.variant.description</source>
+                <target>Description</target>
+                <note>Label for variant description field (Markdown, rendered with RTE)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.new_title">
+                <source>app.archetype.variant.new_title</source>
+                <target>New variant for %archetype%</target>
+                <note>Page title for new variant form. %archetype% = archetype name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.edit_title">
+                <source>app.archetype.variant.edit_title</source>
+                <target>Edit variant: %name% (%archetype%)</target>
+                <note>Page title for edit variant form. %name% = variant name, %archetype% = archetype name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.details">
+                <source>app.archetype.variant.details</source>
+                <target>Variant details</target>
+                <note>Card header for variant form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.current_version">
+                <source>app.archetype.variant.current_version</source>
+                <target>Current version</target>
+                <note>Label showing existing decklist version on edit form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.paste_to_replace">
+                <source>app.archetype.variant.paste_to_replace</source>
+                <target>Paste a new list above to create a new version</target>
+                <note>Help text for replacing existing decklist</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.created">
+                <source>app.archetype.variant.created</source>
+                <target>Variant "%name%" created.</target>
+                <note>Flash message after creating variant. %name% = variant name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.updated">
+                <source>app.archetype.variant.updated</source>
+                <target>Variant "%name%" updated.</target>
+                <note>Flash message after updating variant. %name% = variant name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.deleted">
+                <source>app.archetype.variant.deleted</source>
+                <target>Variant "%name%" deleted.</target>
+                <note>Flash message after deleting variant. %name% = variant name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.delete_confirm">
+                <source>app.archetype.variant.delete_confirm</source>
+                <target>Are you sure you want to delete this variant?</target>
+                <note>Confirmation dialog for variant deletion</note>
             </trans-unit>
 
             <!-- Admin: User management -->

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -3615,6 +3615,11 @@
                 <target>Variant "%name%" deleted.</target>
                 <note>Flash message after deleting variant. %name% = variant name</note>
             </trans-unit>
+            <trans-unit id="app.archetype.variant.more">
+                <source>app.archetype.variant.more</source>
+                <target>More variants…</target>
+                <note>Dropdown label when archetype has more than 5 variants</note>
+            </trans-unit>
             <trans-unit id="app.archetype.variant.delete_confirm">
                 <source>app.archetype.variant.delete_confirm</source>
                 <target>Are you sure you want to delete this variant?</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -75,6 +75,11 @@
                 <target>Actions</target>
                 <note>Aria label for contextual action menus</note>
             </trans-unit>
+            <trans-unit id="app.common.created_at">
+                <source>app.common.created_at</source>
+                <target>Créé le</target>
+                <note>Table header for creation date column</note>
+            </trans-unit>
             <trans-unit id="app.common.cancel">
                 <source>app.common.cancel</source>
                 <target>Annuler</target>
@@ -3512,6 +3517,98 @@
                 <source>app.archetype.no_results</source>
                 <target>Aucun archétype ne correspond à votre filtre.</target>
                 <note>Empty state on archetype catalog when filters yield no results</note>
+            </trans-unit>
+
+            <!-- Archetype variants (F18.15) -->
+            <trans-unit id="app.archetype.variant.section_title">
+                <source>app.archetype.variant.section_title</source>
+                <target>Variantes</target>
+                <note>Card header for variant section on archetype edit page</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.add">
+                <source>app.archetype.variant.add</source>
+                <target>Ajouter une variante</target>
+                <note>Button to add a new archetype variant deck</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.none">
+                <source>app.archetype.variant.none</source>
+                <target>Aucune variante. Ajoutez-en une pour afficher des decklists sur la page de l'archétype.</target>
+                <note>Empty state when archetype has no variant decks</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.name">
+                <source>app.archetype.variant.name</source>
+                <target>Nom de la variante</target>
+                <note>Label for variant deck name field</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.canonical">
+                <source>app.archetype.variant.canonical</source>
+                <target>Canonique</target>
+                <note>Label for canonical variant toggle</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.decklist">
+                <source>app.archetype.variant.decklist</source>
+                <target>Decklist</target>
+                <note>Table header for decklist column in variant list</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.raw_list">
+                <source>app.archetype.variant.raw_list</source>
+                <target>Decklist (format texte PTCG)</target>
+                <note>Label for raw list paste field on variant form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.raw_list_placeholder">
+                <source>app.archetype.variant.raw_list_placeholder</source>
+                <target>Collez une decklist au format texte PTCG ici…</target>
+                <note>Placeholder for raw list field</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.description">
+                <source>app.archetype.variant.description</source>
+                <target>Description</target>
+                <note>Label for variant description field (Markdown, rendered with RTE)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.new_title">
+                <source>app.archetype.variant.new_title</source>
+                <target>Nouvelle variante pour %archetype%</target>
+                <note>Page title for new variant form. %archetype% = archetype name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.edit_title">
+                <source>app.archetype.variant.edit_title</source>
+                <target>Modifier la variante : %name% (%archetype%)</target>
+                <note>Page title for edit variant form. %name% = variant name, %archetype% = archetype name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.details">
+                <source>app.archetype.variant.details</source>
+                <target>Détails de la variante</target>
+                <note>Card header for variant form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.current_version">
+                <source>app.archetype.variant.current_version</source>
+                <target>Version actuelle</target>
+                <note>Label showing existing decklist version on edit form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.paste_to_replace">
+                <source>app.archetype.variant.paste_to_replace</source>
+                <target>Collez une nouvelle liste ci-dessus pour créer une nouvelle version</target>
+                <note>Help text for replacing existing decklist</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.created">
+                <source>app.archetype.variant.created</source>
+                <target>Variante « %name% » créée.</target>
+                <note>Flash message after creating variant. %name% = variant name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.updated">
+                <source>app.archetype.variant.updated</source>
+                <target>Variante « %name% » mise à jour.</target>
+                <note>Flash message after updating variant. %name% = variant name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.deleted">
+                <source>app.archetype.variant.deleted</source>
+                <target>Variante « %name% » supprimée.</target>
+                <note>Flash message after deleting variant. %name% = variant name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.delete_confirm">
+                <source>app.archetype.variant.delete_confirm</source>
+                <target>Voulez-vous vraiment supprimer cette variante ?</target>
+                <note>Confirmation dialog for variant deletion</note>
             </trans-unit>
 
             <!-- Admin: User management -->

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -3605,6 +3605,11 @@
                 <target>Variante « %name% » supprimée.</target>
                 <note>Flash message after deleting variant. %name% = variant name</note>
             </trans-unit>
+            <trans-unit id="app.archetype.variant.more">
+                <source>app.archetype.variant.more</source>
+                <target>Plus de variantes…</target>
+                <note>Dropdown label when archetype has more than 5 variants</note>
+            </trans-unit>
             <trans-unit id="app.archetype.variant.delete_confirm">
                 <source>app.archetype.variant.delete_confirm</source>
                 <target>Voulez-vous vraiment supprimer cette variante ?</target>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ Encore
     .addEntry('deck_form', './assets/deck-form.tsx')
     .addEntry('deck_card_list', './assets/deck-card-list.tsx')
     .addEntry('archetype_show', './assets/archetype-show.ts')
+    .addEntry('archetype_variants', './assets/archetype-variants.tsx')
     .addEntry('page_show', './assets/page-show.ts')
     .addEntry('staff_autocomplete', './assets/staff-autocomplete.tsx')
     .addEntry('walk_up_autocomplete', './assets/walk-up-autocomplete.tsx')


### PR DESCRIPTION
## Summary

- **Admin variant management** (#349) — CRUD for archetype variant decks on the archetype edit page: create via `+` button (only entry point for ownerless decks), edit with name, canonical toggle, sprite selector, decklist paste (reuses DeckVersion enrichment pipeline), and Markdown description via RTE
- **Public variant selector** (#350) — client-side variant switcher on the archetype detail page with table/mosaic view toggle, card hover previews, and mobile swipe modal. Desktop: compact pill buttons with sprites. Mobile: Mantine Select dropdown with sprites in options. Defaults to mosaic view
- **Variant-specific sprites** — each variant shows its own `pokemonSlugs`, not the archetype fallback
- **Sprite hidden input fix** — `archetype-form.tsx` reads `data-hidden-input-name` so the sprite selector works on both archetype and variant forms
- **Card hover idempotent** — `initCardHover()` is now safe to call multiple times (module-scoped state, skip-if-initialized guard), enabling React re-renders
- **Fixtures** — three Regidrago archetype variants (canonical + alternate + minimal) for reproducible testing
- **Test coverage** — 5 new functional tests for `findVariantsByArchetype` (ownerless only, canonical first, excludes owned, empty for no variants, `findAvailableDecks` excludes variants)

Closes #349
Closes #350

## Test plan

- [ ] Run `make fixtures` to load variant fixture data
- [ ] Open archetype edit page — verify Variants section shows with `+ Add variant` button
- [ ] Create a new variant with name, sprites, decklist paste — verify enrichment runs
- [ ] Edit a variant — toggle canonical, verify only one canonical per archetype
- [ ] Delete a variant — verify soft delete with confirmation
- [ ] View archetype detail page — verify variant selector with pill buttons (desktop) and dropdown (mobile)
- [ ] Switch between variants — verify description and card list/mosaic update client-side
- [ ] Hover over card names in table view — verify image preview appears
- [ ] On mobile, tap card name — verify modal opens with swipe navigation
- [ ] 1683 tests pass, PHPStan level 10 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)