### PR TITLE
:sparkles: Feature: copy-to-clipboard, card hover scoping & mobile UX

### DIFF
--- a/assets/archetype-variants.tsx
+++ b/assets/archetype-variants.tsx
@@ -31,6 +31,8 @@ if (root) {
         tableCard: root.dataset.labelTableCard ?? 'Card',
         tableSet: root.dataset.labelTableSet ?? 'Set',
         moreVariants: root.dataset.labelMoreVariants ?? 'More variants\u2026',
+        copyList: root.dataset.labelCopyList ?? 'Copy list',
+        copied: root.dataset.labelCopied ?? 'Copied!',
     };
 
     createRoot(root).render(

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -242,9 +242,11 @@ function MobileSelector({ variants, selectedIndex, onSelect }: {
 export default function ArchetypeVariantSelector({ variants, labels }: ArchetypeVariantSelectorProps) {
     const canonicalIndex = variants.findIndex((variant) => variant.canonical);
     const [selectedIndex, setSelectedIndex] = useState(canonicalIndex >= 0 ? canonicalIndex : 0);
-    const [viewMode, setViewMode] = useState<ViewMode>('mosaic');
     const containerRef = useRef<HTMLDivElement>(null);
     const isMobile = useMediaQuery('(max-width: 767.98px)');
+    const [viewMode, setViewMode] = useState<ViewMode>(
+        () => window.matchMedia('(max-width: 767.98px)').matches ? 'table' : 'mosaic',
+    );
 
     useEffect(() => {
         if (viewMode === 'table') {

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -248,10 +248,11 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
         () => window.matchMedia('(max-width: 767.98px)').matches ? 'table' : 'mosaic',
     );
 
+    // Re-initialize card hover after every render — description HTML contains
+    // .card-hover elements from [[card:...]] tags, and they get recreated on
+    // variant switch via dangerouslySetInnerHTML.
     useEffect(() => {
-        if (viewMode === 'table') {
-            initCardHover();
-        }
+        initCardHover();
     }, [selectedIndex, viewMode]);
 
     if (variants.length === 0) {

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -250,9 +250,12 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
 
     // Re-initialize card hover after every render — description HTML contains
     // .card-hover elements from [[card:...]] tags, and they get recreated on
-    // variant switch via dangerouslySetInnerHTML.
+    // variant switch via dangerouslySetInnerHTML. Use requestAnimationFrame
+    // to ensure the DOM is fully committed before scanning for elements.
     useEffect(() => {
-        initCardHover();
+        requestAnimationFrame(() => {
+            initCardHover();
+        });
     }, [selectedIndex, viewMode]);
 
     if (variants.length === 0) {

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Button, Group, Select, SegmentedControl, Stack } from '@mantine/core';
+import { Button, CopyButton, Group, Select, SegmentedControl, Stack } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { initCardHover } from '../shared/card-hover';
 
@@ -33,6 +33,7 @@ interface VariantData {
     sprites: string[];
     description: string | null;
     mosaicUrl: string | null;
+    rawList: string | null;
     groupedCards: Record<string, CardData[]>;
 }
 
@@ -47,6 +48,8 @@ interface Labels {
     tableCard: string;
     tableSet: string;
     moreVariants: string;
+    copyList: string;
+    copied: string;
 }
 
 interface ArchetypeVariantSelectorProps {
@@ -274,18 +277,34 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                 <div className="cms-content mb-3" dangerouslySetInnerHTML={{ __html: selectedVariant.description }} />
             )}
 
-            {/* View mode toggle + card display */}
+            {/* View mode toggle + copy button + card display */}
             {hasCards && (
                 <Stack gap="sm">
-                    <SegmentedControl
-                        value={viewMode}
-                        onChange={(value) => setViewMode(value as ViewMode)}
-                        data={[
-                            { label: labels.viewTable, value: 'table' },
-                            { label: labels.viewMosaic, value: 'mosaic' },
-                        ]}
-                        size="xs"
-                    />
+                    <Group justify="space-between" align="center">
+                        <SegmentedControl
+                            value={viewMode}
+                            onChange={(value) => setViewMode(value as ViewMode)}
+                            data={[
+                                { label: labels.viewTable, value: 'table' },
+                                { label: labels.viewMosaic, value: 'mosaic' },
+                            ]}
+                            size="xs"
+                        />
+                        {selectedVariant.rawList && (
+                            <CopyButton value={selectedVariant.rawList} timeout={2000}>
+                                {({ copied, copy }) => (
+                                    <Button
+                                        variant={copied ? 'filled' : 'outline'}
+                                        color={copied ? 'teal' : 'gray'}
+                                        size="compact-sm"
+                                        onClick={copy}
+                                    >
+                                        {copied ? labels.copied : labels.copyList}
+                                    </Button>
+                                )}
+                            </CopyButton>
+                        )}
+                    </Group>
 
                     {viewMode === 'table' && (
                         <CardTable groupedCards={selectedVariant.groupedCards} labels={labels} />

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -98,7 +98,7 @@ function CardSection({ title, cards, labels }: { title: string; cards: CardData[
                 <tbody>
                     {cards.map((card, index) => (
                         <tr key={index}>
-                            <td>{card.quantity} &times;</td>
+                            <td>{card.quantity}</td>
                             <td>
                                 {card.imageUrl ? (
                                     <span className="card-hover" data-quantity={card.quantity} data-card-hover-group="variant-decklist">

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -98,10 +98,10 @@ function CardSection({ title, cards, labels }: { title: string; cards: CardData[
                 <tbody>
                     {cards.map((card, index) => (
                         <tr key={index}>
-                            <td>{card.quantity}</td>
+                            <td>{card.quantity} &times;</td>
                             <td>
                                 {card.imageUrl ? (
-                                    <span className="card-hover" data-quantity={card.quantity}>
+                                    <span className="card-hover" data-quantity={card.quantity} data-card-hover-group="variant-decklist">
                                         {card.cardName}
                                         <img
                                             className="card-hover-img"

--- a/assets/shared/card-hover.ts
+++ b/assets/shared/card-hover.ts
@@ -16,7 +16,11 @@ import { Modal } from 'bootstrap';
  * On touch devices (< md), hover is disabled via CSS. Instead, tapping
  * a card name opens a centered Bootstrap modal with the card image.
  * The modal is swipeable: prev/next buttons and touch swipe navigate
- * through all card images in list order.
+ * through all card images in the same sweep group.
+ *
+ * Sweep groups: elements with `data-card-hover-group="name"` are grouped
+ * together for prev/next navigation. Elements without a group open the
+ * modal but do not participate in sweep navigation (standalone).
  *
  * @see docs/features.md F6.2 — TCGdex card data enrichment
  */
@@ -25,6 +29,8 @@ interface CardEntry {
     src: string;
     name: string;
     quantity: number;
+    group: string | null;
+    globalIndex: number;
 }
 
 const isTouchDevice = (): boolean => window.matchMedia('(max-width: 767.98px)').matches;
@@ -44,12 +50,28 @@ function showCard(index: number): void {
     modalImg.src = card.src;
     modalImg.alt = card.name;
     if (modalLabel) {
-        modalLabel.textContent = card.quantity > 1 ? `${card.quantity} x ${card.name}` : card.name;
+        modalLabel.textContent = card.quantity > 1 ? `${card.quantity} \u00d7 ${card.name}` : card.name;
     }
 }
 
+function getGroupIndices(index: number): number[] {
+    const card = cards[index];
+    if (!card.group) {
+        return [index];
+    }
+
+    return cards
+        .filter((entry) => entry.group === card.group)
+        .map((entry) => entry.globalIndex);
+}
+
 function navigate(direction: number): void {
-    currentIndex = (currentIndex + direction + cards.length) % cards.length;
+    const groupIndices = getGroupIndices(currentIndex);
+    if (groupIndices.length <= 1) return;
+
+    const positionInGroup = groupIndices.indexOf(currentIndex);
+    const nextPosition = (positionInGroup + direction + groupIndices.length) % groupIndices.length;
+    currentIndex = groupIndices[nextPosition];
     showCard(currentIndex);
 }
 
@@ -65,9 +87,10 @@ export function initCardHover(): void {
         const img = element.querySelector<HTMLImageElement>('.card-hover-img');
         if (!img) return;
 
-        const index = cards.length;
+        const globalIndex = cards.length;
         const quantity = parseInt(element.dataset.quantity || '1', 10);
-        cards.push({ src: img.src, name: img.alt, quantity });
+        const group = element.dataset.cardHoverGroup ?? null;
+        cards.push({ src: img.src, name: img.alt, quantity, group, globalIndex });
 
         element.addEventListener('mouseenter', () => {
             if (isTouchDevice()) return;
@@ -103,11 +126,18 @@ export function initCardHover(): void {
             if (!isTouchDevice()) return;
 
             event.preventDefault();
-            currentIndex = index;
+            currentIndex = globalIndex;
             showCard(currentIndex);
 
             const modalElement = document.getElementById('cardImageModal');
             if (!modalElement) return;
+
+            // Hide prev/next for standalone cards (no sweep group)
+            const prevButton = document.getElementById('cardImageModalPrev');
+            const nextButton = document.getElementById('cardImageModalNext');
+            const groupSize = getGroupIndices(globalIndex).length;
+            if (prevButton) prevButton.style.display = groupSize > 1 ? '' : 'none';
+            if (nextButton) nextButton.style.display = groupSize > 1 ? '' : 'none';
 
             const bsModal = Modal.getOrCreateInstance(modalElement);
             bsModal.show();

--- a/assets/shared/card-hover.ts
+++ b/assets/shared/card-hover.ts
@@ -50,7 +50,7 @@ function showCard(index: number): void {
     modalImg.src = card.src;
     modalImg.alt = card.name;
     if (modalLabel) {
-        modalLabel.textContent = card.quantity > 1 ? `${card.quantity} \u00d7 ${card.name}` : card.name;
+        modalLabel.textContent = `${card.quantity} \u00d7 ${card.name}`;
     }
 }
 

--- a/assets/shared/card-hover.ts
+++ b/assets/shared/card-hover.ts
@@ -50,7 +50,9 @@ function showCard(index: number): void {
     modalImg.src = card.src;
     modalImg.alt = card.name;
     if (modalLabel) {
-        modalLabel.textContent = `${card.quantity} \u00d7 ${card.name}`;
+        modalLabel.textContent = card.group
+            ? `${card.quantity} \u00d7 ${card.name}`
+            : card.name;
     }
 }
 

--- a/src/Controller/ArchetypeDetailController.php
+++ b/src/Controller/ArchetypeDetailController.php
@@ -156,6 +156,7 @@ class ArchetypeDetailController extends AbstractController
                 'sprites' => $variant->getPokemonSlugs(),
                 'description' => $htmlDescription,
                 'mosaicUrl' => $mosaicUrl,
+                'rawList' => $version?->getRawList(),
                 'groupedCards' => $orderedGroups,
             ];
         }

--- a/templates/archetype/show.html.twig
+++ b/templates/archetype/show.html.twig
@@ -76,7 +76,9 @@
                          data-label-table-qty="{{ 'app.deck.table_qty'|trans }}"
                          data-label-table-card="{{ 'app.deck.table_card'|trans }}"
                          data-label-table-set="{{ 'app.deck.table_set'|trans }}"
-                         data-label-more-variants="{{ 'app.archetype.variant.more'|trans }}">
+                         data-label-more-variants="{{ 'app.archetype.variant.more'|trans }}"
+                         data-label-copy-list="{{ 'app.deck.export_copy_button'|trans }}"
+                         data-label-copied="{{ 'app.deck.export_copied'|trans }}">
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- **Copy-to-clipboard** — "Copy list" button next to table/mosaic toggle copies the variant's raw decklist (PTCG format) to clipboard. Uses Mantine `CopyButton` with 2s "Copied!" feedback. Reuses existing translation keys.
- **Card sweep groups** — `initCardHover()` now supports `data-card-hover-group` scoping. Decklist cards sweep together (prev/next navigation). Card references from `[[card:...]]` in descriptions open the modal standalone without sweep arrows.
- **Modal title** — always shows `"N × Card Name"` for decklist cards; just `"Card Name"` for standalone description references
- **Default view mode** — mosaic on desktop, table on mobile (via `window.matchMedia` in useState initializer)
- **Card hover fix** — `requestAnimationFrame` in useEffect ensures `initCardHover()` runs after React commits the DOM, fixing `.card-hover` elements from `dangerouslySetInnerHTML` not being tappable on mobile
- **Raw list in variant data** — `DeckVersion.rawList` passed from controller to React component

Closes #351

## Test plan

- [ ] View archetype with variants — verify "Copy list" button appears
- [ ] Click "Copy list" — verify PTCG format decklist copied to clipboard
- [ ] Tap a card name in the decklist (mobile) — modal opens with sweep arrows
- [ ] Tap a `[[card:...]]` reference in the description — modal opens without sweep arrows, title shows just the card name
- [ ] Desktop: hover over card name in table — verify image preview
- [ ] Desktop: hover over `[[card:...]]` in description — verify image preview
- [ ] Mobile: verify default view is table; desktop: verify default is mosaic

🤖 Generated with [Claude Code](https://claude.com/claude-code)