### PR TITLE
:sparkles: Feature: drag-and-drop ordering for archetypes and variants

### DIFF
--- a/assets/admin-archetype-edit.ts
+++ b/assets/admin-archetype-edit.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @see docs/features.md F18.19 — Archetype variant ordering
+ */
+
+import { initSortableTable } from './shared/sortable-table';
+
+initSortableTable('sortable-variants', 'variant');

--- a/assets/admin-archetype-list.ts
+++ b/assets/admin-archetype-list.ts
@@ -1,0 +1,16 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @see docs/features.md F18.12 — Admin drag-and-drop archetype ordering
+ */
+
+import { initSortableTable } from './shared/sortable-table';
+
+initSortableTable('sortable-archetypes', 'archetype');

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -163,15 +163,15 @@ function DesktopSelector({ variants, selectedIndex, onSelect }: {
     const dropdownVariants = variants.slice(MAX_BUTTONS);
 
     return (
-        <Group gap={4} wrap="wrap">
+        <Group gap="xs" wrap="wrap">
             {buttonVariants.map((variant, index) => (
                 <Button
                     key={variant.id}
                     variant={index === selectedIndex ? 'filled' : 'outline'}
-                    size="compact-sm"
+                    size="sm"
                     radius="xl"
                     onClick={() => onSelect(index)}
-                    leftSection={variant.sprites.length > 0 ? <SpriteList slugs={variant.sprites} height={18} /> : undefined}
+                    leftSection={variant.sprites.length > 0 ? <SpriteList slugs={variant.sprites} height={22} /> : undefined}
                 >
                     {variant.name}
                 </Button>
@@ -302,7 +302,7 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                                     <Button
                                         variant={copied ? 'filled' : 'outline'}
                                         color={copied ? 'teal' : 'gray'}
-                                        size="compact-sm"
+                                        size="sm"
                                         onClick={copy}
                                     >
                                         {copied ? labels.copied : labels.copyList}

--- a/assets/shared/sortable-table.ts
+++ b/assets/shared/sortable-table.ts
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Reusable drag-and-drop table sorting with SortableJS.
+ * Expects a <tbody> with:
+ *   - id matching the provided selector
+ *   - data-reorder-url — POST endpoint receiving a JSON array of IDs
+ *   - <tr data-{idAttribute}-id="N"> rows
+ *   - .sortable-handle elements as drag handles
+ *   - .move-up-btn / .move-down-btn for accessible fallback
+ *
+ * @see docs/features.md F7.10 — Admin pages: drag-and-drop sorting
+ * @see docs/features.md F18.12 — Admin drag-and-drop archetype ordering
+ * @see docs/features.md F18.19 — Archetype variant ordering
+ */
+
+import Sortable from 'sortablejs';
+
+export function initSortableTable(tbodyId: string, idAttribute: string): void {
+    const tbody = document.getElementById(tbodyId) as HTMLTableSectionElement | null;
+    if (!tbody) {
+        return;
+    }
+
+    const getIds = (): number[] =>
+        Array.from(tbody.querySelectorAll<HTMLTableRowElement>(`tr[data-${idAttribute}-id]`))
+            .map((row) => Number(row.dataset[`${toCamelCase(idAttribute)}Id`]));
+
+    const persistOrder = (): void => {
+        const url = tbody.dataset.reorderUrl;
+        if (!url) {
+            return;
+        }
+
+        fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(getIds()),
+        }).catch((error) => {
+            console.error('Reorder failed:', error);
+        });
+    };
+
+    Sortable.create(tbody, {
+        handle: '.sortable-handle',
+        animation: 150,
+        ghostClass: 'table-active',
+        onEnd: () => {
+            persistOrder();
+        },
+    });
+
+    // Accessible up/down arrow buttons
+    tbody.addEventListener('click', (event) => {
+        const target = event.target as HTMLElement;
+        const button = target.closest('.move-up-btn, .move-down-btn') as HTMLButtonElement | null;
+        if (!button) {
+            return;
+        }
+
+        const row = button.closest('tr') as HTMLTableRowElement;
+        if (!row) {
+            return;
+        }
+
+        if (button.classList.contains('move-up-btn') && row.previousElementSibling) {
+            row.parentNode?.insertBefore(row, row.previousElementSibling);
+            persistOrder();
+        } else if (button.classList.contains('move-down-btn') && row.nextElementSibling) {
+            row.parentNode?.insertBefore(row.nextElementSibling, row);
+            persistOrder();
+        }
+    });
+}
+
+function toCamelCase(kebab: string): string {
+    return kebab.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}

--- a/migrations/Version20260410160942.php
+++ b/migrations/Version20260410160942.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add position field to Archetype and Deck for drag-and-drop ordering.
+ *
+ * @see docs/features.md F18.11 — Archetype relevance ordering
+ * @see docs/features.md F18.19 — Archetype variant ordering
+ */
+final class Version20260410160942 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add position field to Archetype and Deck for ordering';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE archetype ADD position INT DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE deck ADD position INT DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE archetype DROP position');
+        $this->addSql('ALTER TABLE deck DROP position');
+    }
+}

--- a/src/Controller/AdminArchetypeController.php
+++ b/src/Controller/AdminArchetypeController.php
@@ -29,6 +29,7 @@ use App\Service\DeckListParser;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -57,7 +58,7 @@ class AdminArchetypeController extends AbstractAppController
     #[Route('', name: 'app_admin_archetype_list', methods: ['GET'])]
     public function list(ArchetypeRepository $archetypeRepository, DeckRepository $deckRepository): Response
     {
-        $archetypes = $archetypeRepository->findBy(['deletedAt' => null], ['name' => 'ASC']);
+        $archetypes = $archetypeRepository->findBy(['deletedAt' => null], ['position' => 'ASC', 'name' => 'ASC']);
 
         $deckCounts = [];
         foreach ($archetypes as $archetype) {
@@ -153,6 +154,52 @@ class AdminArchetypeController extends AbstractAppController
         $this->addFlash('success', 'app.flash.archetype.deleted');
 
         return $this->redirectToRoute('app_admin_archetype_list');
+    }
+
+    /**
+     * Persist archetype ordering from drag-and-drop.
+     * Expects a JSON array of archetype IDs in display order.
+     *
+     * @see docs/features.md F18.12 — Admin drag-and-drop archetype ordering
+     */
+    #[Route('/reorder', name: 'app_admin_archetype_reorder', methods: ['POST'])]
+    public function reorder(Request $request, ArchetypeRepository $archetypeRepository): JsonResponse
+    {
+        /** @var list<int> $ids */
+        $ids = json_decode($request->getContent(), true) ?? [];
+
+        foreach ($ids as $position => $id) {
+            $archetype = $archetypeRepository->find($id);
+            if ($archetype instanceof Archetype) {
+                $archetype->setPosition($position);
+            }
+        }
+        $this->em->flush();
+
+        return new JsonResponse(['ok' => true]);
+    }
+
+    /**
+     * Persist variant ordering from drag-and-drop within an archetype.
+     * Expects a JSON array of deck IDs in display order.
+     *
+     * @see docs/features.md F18.19 — Archetype variant ordering
+     */
+    #[Route('/{id}/variants/reorder', name: 'app_admin_archetype_variant_reorder', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function reorderVariants(Request $request, Archetype $archetype, DeckRepository $deckRepository): JsonResponse
+    {
+        /** @var list<int> $ids */
+        $ids = json_decode($request->getContent(), true) ?? [];
+
+        foreach ($ids as $position => $id) {
+            $deck = $deckRepository->find($id);
+            if ($deck instanceof Deck && $deck->isArchetypeVariant() && $deck->getArchetype()?->getId() === $archetype->getId()) {
+                $deck->setPosition($position);
+            }
+        }
+        $this->em->flush();
+
+        return new JsonResponse(['ok' => true]);
     }
 
     /**

--- a/src/Controller/AdminArchetypeController.php
+++ b/src/Controller/AdminArchetypeController.php
@@ -191,10 +191,18 @@ class AdminArchetypeController extends AbstractAppController
         /** @var list<int> $ids */
         $ids = json_decode($request->getContent(), true) ?? [];
 
-        foreach ($ids as $position => $id) {
+        $nonCanonicalPosition = 1;
+        foreach ($ids as $id) {
             $deck = $deckRepository->find($id);
-            if ($deck instanceof Deck && $deck->isArchetypeVariant() && $deck->getArchetype()?->getId() === $archetype->getId()) {
-                $deck->setPosition($position);
+            if (!$deck instanceof Deck || !$deck->isArchetypeVariant() || $deck->getArchetype()?->getId() !== $archetype->getId()) {
+                continue;
+            }
+
+            if ($deck->isCanonical()) {
+                $deck->setPosition(0);
+            } else {
+                $deck->setPosition($nonCanonicalPosition);
+                ++$nonCanonicalPosition;
             }
         }
         $this->em->flush();

--- a/src/Controller/ArchetypeCatalogController.php
+++ b/src/Controller/ArchetypeCatalogController.php
@@ -42,10 +42,10 @@ class ArchetypeCatalogController extends AbstractController
             /** @var list<string> $tags */
             $tags = $request->query->all('tags');
             $tags = array_values(array_filter($tags, static fn (string $tag): bool => '' !== $tag));
-            $sort = $request->query->getString('sort', 'name');
+            $sort = $request->query->getString('sort', 'position');
 
-            if (!\in_array($sort, ['name', 'decks'], true)) {
-                $sort = 'name';
+            if (!\in_array($sort, ['name', 'decks', 'position'], true)) {
+                $sort = 'position';
             }
 
             $results = $archetypeRepository->findPublishedWithDeckCounts($tags, $sort);

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -41,6 +41,7 @@ use App\Enum\EventVisibility;
 use App\Enum\NotificationType;
 use App\Enum\ParticipationMode;
 use App\Enum\TournamentStructure;
+use App\Service\DeckListParser;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -49,6 +50,7 @@ class DevFixtures extends Fixture
 {
     public function __construct(
         private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly DeckListParser $deckListParser,
     ) {
     }
 
@@ -671,13 +673,8 @@ Turn 1 priority: use **Battle VIP Pass** and **Nest Ball** to bench two Regidrag
 
 Strong against single-prize decks thanks to VSTAR bulk (270 HP) and one-shot potential. Weak to **Path to the Peak** (shuts off VSTAR Power) — run 2–3 **Chaotic Swell** or **Field Blower** to counter.
 MARKDOWN);
-        $canonicalVersion = new DeckVersion();
-        $canonicalVersion->setDeck($canonical);
-        $canonicalVersion->setVersionNumber(1);
-        $canonicalVersion->setRawList($rawList);
         $manager->persist($canonical);
-        $manager->persist($canonicalVersion);
-        $canonical->setCurrentVersion($canonicalVersion);
+        $this->createParsedDeckVersion($manager, $canonical, $rawList);
 
         // Alternate variant: Regidrago / Cinccino
         $alternate = new Deck();
@@ -705,13 +702,8 @@ Turn 1: bench Regidrago V + Minccino. Turn 2: evolve both — Cinccino starts dr
 
 Bigger bench means more liability against **Sky Seal Stone** + Boss's Orders snipes. The Cinccino line gives up easy two-prize KOs if dragged active.
 MARKDOWN);
-        $alternateVersion = new DeckVersion();
-        $alternateVersion->setDeck($alternate);
-        $alternateVersion->setVersionNumber(1);
-        $alternateVersion->setRawList($rawList);
         $manager->persist($alternate);
-        $manager->persist($alternateVersion);
-        $alternate->setCurrentVersion($alternateVersion);
+        $this->createParsedDeckVersion($manager, $alternate, $rawList);
 
         // Third variant: minimal placeholder
         $third = new Deck();
@@ -722,6 +714,32 @@ MARKDOWN);
         $third->setPokemonSlugs(['dragapult']);
         $third->setNotes('A lightweight Regidrago build focused on speed.');
         $manager->persist($third);
+    }
+
+    /**
+     * Parse a raw decklist and create a DeckVersion with DeckCard entities.
+     */
+    private function createParsedDeckVersion(ObjectManager $manager, Deck $deck, string $rawList): void
+    {
+        $result = $this->deckListParser->parse($rawList);
+
+        $version = new DeckVersion();
+        $version->setDeck($deck);
+        $version->setVersionNumber(1);
+        $version->setRawList($rawList);
+
+        foreach ($result->cards as $parsedCard) {
+            $card = new DeckCard();
+            $card->setCardName($parsedCard->cardName);
+            $card->setSetCode($parsedCard->setCode);
+            $card->setCardNumber($parsedCard->cardNumber);
+            $card->setQuantity($parsedCard->quantity);
+            $card->setCardType($parsedCard->cardType);
+            $version->addCard($card);
+        }
+
+        $manager->persist($version);
+        $deck->setCurrentVersion($version);
     }
 
     private function createDeck(ObjectManager $manager, User $owner, string $name, DeckStatus $status = DeckStatus::Available): Deck

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -69,10 +69,10 @@ class DevFixtures extends Fixture
         $this->createDraftEvent($manager, $organizer, $admin);
 
         // Create archetypes (descriptions are now stored as EN translations)
-        $archetypeIronThorns = $this->createArchetype($manager, 'Iron Thorns ex', ['iron-thorns'], true, ['Aggressive', 'Spread']);
+        $archetypeIronThorns = $this->createArchetype($manager, 'Iron Thorns ex', ['iron-thorns'], true, ['Aggressive', 'Spread'], 2);
         $this->addArchetypeTranslation($manager, $archetypeIronThorns, 'en', 'Iron Thorns ex', 'A powerful **Iron Thorns ex** deck built around the Paradox Pokemon. Uses heavy energy acceleration and spread damage to overwhelm opponents.');
 
-        $archetypeAncientBox = $this->createArchetype($manager, 'Ancient Box', ['roaring-moon', 'flutter-mane'], true, ['Toolbox', 'Aggressive']);
+        $archetypeAncientBox = $this->createArchetype($manager, 'Ancient Box', ['roaring-moon', 'flutter-mane'], true, ['Toolbox', 'Aggressive'], 7);
         $this->addArchetypeTranslation($manager, $archetypeAncientBox, 'en', 'Ancient Box', 'The **Ancient Box** archetype combines multiple Ancient Pokemon to leverage Ancient support cards for a versatile attack strategy.');
         $this->addArchetypeTranslation($manager, $archetypeAncientBox, 'fr', 'Box Anciens', "L'archétype **Box Anciens** combine plusieurs Pokémon Anciens pour tirer parti des cartes de support Anciennes dans une stratégie d'attaque polyvalente.");
 
@@ -83,7 +83,7 @@ Although Regidrago has been a top tier deck for a long time, it has gained many 
 
 It's gotten to the point where many lists are trying unconventional techs to try to get an edge in the mirror match.
 MARKDOWN;
-        $archetypeRegidrago = $this->createArchetype($manager, 'Regidrago', ['regidrago'], true, ['Combo', 'Lock', 'Toolbox']);
+        $archetypeRegidrago = $this->createArchetype($manager, 'Regidrago', ['regidrago'], true, ['Combo', 'Lock', 'Toolbox'], 0);
         $this->addArchetypeTranslation($manager, $archetypeRegidrago, 'en', 'Regidrago', $regidragoDescription);
         $regidragoDescriptionFr = <<<'MARKDOWN'
 **Regidrago VSTAR** est généralement considéré comme le meilleur deck du format. Il dispose de toutes les options possibles, et même plus. Il peut verrouiller l'adversaire de multiples façons (blocage d'Objets, blocage de Talents, blocage d'Énergies spéciales...), décimer les bancs de Bases avec [[archetype:kyurem]], mettre KO n'importe quoi avec [[archetype:salamence-ex]], et même prendre un tour supplémentaire avec [[card:UPR-100]].
@@ -94,15 +94,15 @@ On en est au point où de nombreuses listes essaient des techs non conventionnel
 MARKDOWN;
         $this->addArchetypeTranslation($manager, $archetypeRegidrago, 'fr', 'Regidrago', $regidragoDescriptionFr);
 
-        $archetypeKyurem = $this->createArchetype($manager, 'Kyurem', ['kyurem'], true, ['Spread']);
+        $archetypeKyurem = $this->createArchetype($manager, 'Kyurem', ['kyurem'], true, ['Spread'], 5);
         $this->addArchetypeTranslation($manager, $archetypeKyurem, 'en', 'Kyurem', 'A **Kyurem** archetype that punishes Basic-heavy boards with its spread attack, often teched into [[archetype:regidrago]] builds.');
 
-        $archetypeSalamence = $this->createArchetype($manager, 'Salamence ex', ['salamence'], true, ['Aggressive']);
+        $archetypeSalamence = $this->createArchetype($manager, 'Salamence ex', ['salamence'], true, ['Aggressive'], 4);
         $this->addArchetypeTranslation($manager, $archetypeSalamence, 'en', 'Salamence ex', 'The **Salamence ex** archetype leverages its massive damage output to oneshot virtually anything. Commonly used as a finisher in [[archetype:regidrago]] lists.');
 
-        $archetypeLugia = $this->createArchetype($manager, 'Lugia Archeops', ['lugia', 'archeops'], false);
+        $archetypeLugia = $this->createArchetype($manager, 'Lugia Archeops', ['lugia', 'archeops'], false, [], 3);
 
-        $archetypeCharizardEevee = $this->createArchetype($manager, 'Charizard Flareon', ['charizard', 'eevee'], true, ['Aggressive', 'Combo']);
+        $archetypeCharizardEevee = $this->createArchetype($manager, 'Charizard Flareon', ['charizard', 'eevee'], true, ['Aggressive', 'Combo'], 6);
         $this->addArchetypeTranslation($manager, $archetypeCharizardEevee, 'en', 'Charizard Flareon', 'A **Charizard & Flareon** deck that evolves Eevee into Flareon for energy acceleration, fueling Charizard\'s massive fire attacks.');
         $this->addArchetypeTranslation($manager, $archetypeCharizardEevee, 'fr', 'Dracaufeu Pyroli', "Un deck **Dracaufeu & Pyroli** qui fait évoluer Évoli en Pyroli pour l'accélération d'énergie, alimentant les attaques de feu massives de Dracaufeu.");
 
@@ -140,7 +140,7 @@ MARKDOWN;
         $charizardFlareon->setPublic(true);
         $this->createCharizardFlareonDeckVersion($manager, $charizardFlareon);
 
-        $archetypeShadowRider = $this->createArchetype($manager, 'Shadow Rider Calyrex', ['calyrex-shadow-rider'], true, ['Control']);
+        $archetypeShadowRider = $this->createArchetype($manager, 'Shadow Rider Calyrex', ['calyrex-shadow-rider'], true, ['Control'], 1);
         $this->addArchetypeTranslation($manager, $archetypeShadowRider, 'en', 'Shadow Rider Calyrex', 'A **Shadow Rider Calyrex VMAX** control deck that uses hand disruption and item lock to starve the opponent of resources.');
         $shadowRider = $this->createDeck($manager, $admin, 'Shadow Rider Calyrex');
         $shadowRider->setArchetype($archetypeShadowRider);
@@ -561,12 +561,13 @@ MARKDOWN;
      * @param list<string> $pokemonSlugs
      * @param list<string> $playstyleTags
      */
-    private function createArchetype(ObjectManager $manager, string $name, array $pokemonSlugs = [], bool $isPublished = false, array $playstyleTags = []): Archetype
+    private function createArchetype(ObjectManager $manager, string $name, array $pokemonSlugs = [], bool $isPublished = false, array $playstyleTags = [], int $position = 0): Archetype
     {
         $archetype = new Archetype();
         $archetype->setName($name);
         $archetype->setPokemonSlugs($pokemonSlugs);
         $archetype->setIsPublished($isPublished);
+        $archetype->setPosition($position);
         $archetype->setPlaystyleTags(array_map(
             static fn (string $tag): string => mb_convert_case(trim($tag), \MB_CASE_TITLE),
             $playstyleTags,
@@ -649,6 +650,7 @@ LIST;
         $canonical->setArchetype($archetype);
         $canonical->setFormat('Expanded');
         $canonical->setCanonical(true);
+        $canonical->setPosition(0);
         $canonical->setPokemonSlugs(['dialga']);
         $canonical->setNotes(<<<'MARKDOWN'
 ## Strategy
@@ -682,6 +684,7 @@ MARKDOWN);
         $alternate->setName('Alternate Regidrago');
         $alternate->setArchetype($archetype);
         $alternate->setFormat('Expanded');
+        $alternate->setPosition(1);
         $alternate->setPokemonSlugs(['dragonite']);
         $alternate->setNotes(<<<'MARKDOWN'
 ## Strategy
@@ -715,6 +718,7 @@ MARKDOWN);
         $third->setName('Third Regidrago');
         $third->setArchetype($archetype);
         $third->setFormat('Expanded');
+        $third->setPosition(2);
         $third->setPokemonSlugs(['dragapult']);
         $third->setNotes('A lightweight Regidrago build focused on speed.');
         $manager->persist($third);

--- a/src/Entity/Archetype.php
+++ b/src/Entity/Archetype.php
@@ -65,6 +65,14 @@ class Archetype
     #[ORM\Column]
     private bool $isPublished = false;
 
+    /**
+     * Display order in the archetype catalog (lower = first).
+     *
+     * @see docs/features.md F18.11 — Archetype relevance ordering
+     */
+    #[ORM\Column(options: ['default' => 0])]
+    private int $position = 0;
+
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
 
@@ -180,6 +188,24 @@ class Archetype
     public function setIsPublished(bool $isPublished): static
     {
         $this->isPublished = $isPublished;
+
+        return $this;
+    }
+
+    /**
+     * @see docs/features.md F18.11 — Archetype relevance ordering
+     */
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    /**
+     * @see docs/features.md F18.11 — Archetype relevance ordering
+     */
+    public function setPosition(int $position): static
+    {
+        $this->position = $position;
 
         return $this;
     }

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -74,6 +74,15 @@ class Deck
     #[ORM\Column(options: ['default' => false])]
     private bool $canonical = false;
 
+    /**
+     * Display order within an archetype's variant list (lower = first).
+     * Only meaningful for archetype variant decks (owner = null).
+     *
+     * @see docs/features.md F18.19 — Archetype variant ordering
+     */
+    #[ORM\Column(options: ['default' => 0])]
+    private int $position = 0;
+
     /** @var list<string> */
     #[ORM\Column(type: Types::JSON)]
     private array $languages = [];
@@ -187,6 +196,24 @@ class Deck
     public function setCanonical(bool $canonical): static
     {
         $this->canonical = $canonical;
+
+        return $this;
+    }
+
+    /**
+     * @see docs/features.md F18.19 — Archetype variant ordering
+     */
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    /**
+     * @see docs/features.md F18.19 — Archetype variant ordering
+     */
+    public function setPosition(int $position): static
+    {
+        $this->position = $position;
 
         return $this;
     }

--- a/src/Repository/ArchetypeRepository.php
+++ b/src/Repository/ArchetypeRepository.php
@@ -120,6 +120,9 @@ class ArchetypeRepository extends ServiceEntityRepository
         if ('decks' === $sort) {
             $qb->orderBy('deckCount', 'DESC')
                 ->addOrderBy('a.name', 'ASC');
+        } elseif ('position' === $sort) {
+            $qb->orderBy('a.position', 'ASC')
+                ->addOrderBy('a.name', 'ASC');
         } else {
             $qb->orderBy('a.name', 'ASC');
         }

--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -178,7 +178,7 @@ class DeckRepository extends ServiceEntityRepository
             ->andWhere('d.owner IS NULL')
             ->andWhere('d.deletedAt IS NULL')
             ->setParameter('archetype', $archetype)
-            ->orderBy('d.canonical', 'DESC')
+            ->orderBy('d.position', 'ASC')
             ->addOrderBy('d.createdAt', 'DESC')
             ->getQuery()
             ->getResult();

--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -178,7 +178,8 @@ class DeckRepository extends ServiceEntityRepository
             ->andWhere('d.owner IS NULL')
             ->andWhere('d.deletedAt IS NULL')
             ->setParameter('archetype', $archetype)
-            ->orderBy('d.position', 'ASC')
+            ->orderBy('d.canonical', 'DESC')
+            ->addOrderBy('d.position', 'ASC')
             ->addOrderBy('d.createdAt', 'DESC')
             ->getQuery()
             ->getResult();

--- a/templates/admin/archetype/edit.html.twig
+++ b/templates/admin/archetype/edit.html.twig
@@ -112,6 +112,7 @@
                     <table class="table table-sm table-hover align-middle mb-0">
                         <thead>
                             <tr>
+                                <th style="width: 40px"></th>
                                 <th>{{ 'app.common.name'|trans }}</th>
                                 <th>{{ 'app.archetype.variant.canonical'|trans }}</th>
                                 <th>{{ 'app.archetype.variant.decklist'|trans }}</th>
@@ -119,9 +120,16 @@
                                 <th class="text-end">{{ 'app.common.actions'|trans }}</th>
                             </tr>
                         </thead>
-                        <tbody>
+                        <tbody id="sortable-variants" data-reorder-url="{{ path('app_admin_archetype_variant_reorder', {id: archetype.id}) }}">
                             {% for variant in variants %}
-                                <tr>
+                                <tr data-variant-id="{{ variant.id }}">
+                                    <td class="text-center align-middle">
+                                        <span class="sortable-handle d-none d-md-inline" style="cursor: grab" aria-label="{{ 'app.cms.admin.drag_to_reorder'|trans }}"><i class="bi bi-grip-vertical"></i></span>
+                                        <span class="d-inline d-md-none">
+                                            <button type="button" class="btn btn-sm btn-link p-0 move-up-btn" aria-label="{{ 'app.cms.admin.move_up'|trans }}"><i class="bi bi-chevron-up"></i></button>
+                                            <button type="button" class="btn btn-sm btn-link p-0 move-down-btn" aria-label="{{ 'app.cms.admin.move_down'|trans }}"><i class="bi bi-chevron-down"></i></button>
+                                        </span>
+                                    </td>
                                     <td>
                                         {% for slug in variant.effectivePokemonSlugs[:3] %}
                                             <img src="{{ asset('build/sprites/pokemon/' ~ slug ~ '.png') }}" alt="{{ slug }}" class="archetype-sprite" style="height: 24px;">
@@ -188,6 +196,7 @@
 {% block javascripts %}
     {{ parent() }}
     {{ encore_entry_script_tags('archetype_form') }}
+    {{ encore_entry_script_tags('admin_archetype_edit') }}
     <script>
         {# Activate the correct translation tab based on URL hash #}
         (function() {

--- a/templates/admin/archetype/list.html.twig
+++ b/templates/admin/archetype/list.html.twig
@@ -24,6 +24,7 @@
                 <table class="table table-striped table-themed mb-0">
                     <thead>
                         <tr>
+                            <th style="width: 40px"></th>
                             <th>{{ 'app.common.name'|trans }}</th>
                             <th style="width: 120px">{{ 'app.common.slug'|trans }}</th>
                             <th style="width: 120px">{{ 'app.archetype.table.pokemon'|trans }}</th>
@@ -33,9 +34,16 @@
                             <th style="width: 80px"></th>
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody id="sortable-archetypes" data-reorder-url="{{ path('app_admin_archetype_reorder') }}">
                         {% for archetype in archetypes %}
-                            <tr>
+                            <tr data-archetype-id="{{ archetype.id }}">
+                                <td class="text-center align-middle">
+                                    <span class="sortable-handle d-none d-md-inline" style="cursor: grab" aria-label="{{ 'app.cms.admin.drag_to_reorder'|trans }}"><i class="bi bi-grip-vertical"></i></span>
+                                    <span class="d-inline d-md-none">
+                                        <button type="button" class="btn btn-sm btn-link p-0 move-up-btn" aria-label="{{ 'app.cms.admin.move_up'|trans }}"><i class="bi bi-chevron-up"></i></button>
+                                        <button type="button" class="btn btn-sm btn-link p-0 move-down-btn" aria-label="{{ 'app.cms.admin.move_down'|trans }}"><i class="bi bi-chevron-down"></i></button>
+                                    </span>
+                                </td>
                                 <td>
                                     {{ archetype_sprites(archetype) }}
                                     <a href="{{ path('app_archetype_show', {slug: archetype.slug}) }}">{{ archetype.name }}</a>
@@ -82,4 +90,9 @@
     {% else %}
         <div class="alert alert-info">{{ 'app.archetype.no_archetypes'|trans }}</div>
     {% endif %}
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {{ encore_entry_script_tags('admin_archetype_list') }}
 {% endblock %}

--- a/templates/archetype/list.html.twig
+++ b/templates/archetype/list.html.twig
@@ -44,6 +44,9 @@
                 <div class="col-md-3 ms-auto">
                     <label class="form-label">{{ 'app.archetype.sort_by'|trans }}</label>
                     <select class="form-select form-select-sm" onchange="window.location.href=this.value">
+                        <option value="{{ path('app_archetype_list', {'tags': currentTags, sort: 'position'}) }}" {{ currentSort == 'position' ? 'selected' }}>
+                            {{ 'app.archetype.sort_relevance'|trans }}
+                        </option>
                         <option value="{{ path('app_archetype_list', {'tags': currentTags, sort: 'name'}) }}" {{ currentSort == 'name' ? 'selected' }}>
                             {{ 'app.common.name'|trans }}
                         </option>

--- a/tests/Entity/ArchetypeTest.php
+++ b/tests/Entity/ArchetypeTest.php
@@ -224,4 +224,25 @@ class ArchetypeTest extends TestCase
         $archetype->removeTranslation($translation);
         self::assertCount(0, $archetype->getTranslations());
     }
+
+    /**
+     * @see docs/features.md F18.11 — Archetype relevance ordering
+     */
+    public function testPositionDefaultsToZero(): void
+    {
+        $archetype = new Archetype();
+
+        self::assertSame(0, $archetype->getPosition());
+    }
+
+    /**
+     * @see docs/features.md F18.11 — Archetype relevance ordering
+     */
+    public function testSetPosition(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setPosition(5);
+
+        self::assertSame(5, $archetype->getPosition());
+    }
 }

--- a/tests/Entity/DeckTest.php
+++ b/tests/Entity/DeckTest.php
@@ -323,4 +323,25 @@ class DeckTest extends TestCase
         $this->expectException(\LogicException::class);
         $deck->getOwnerOrFail();
     }
+
+    /**
+     * @see docs/features.md F18.19 — Archetype variant ordering
+     */
+    public function testPositionDefaultsToZero(): void
+    {
+        $deck = new Deck();
+
+        self::assertSame(0, $deck->getPosition());
+    }
+
+    /**
+     * @see docs/features.md F18.19 — Archetype variant ordering
+     */
+    public function testSetPosition(): void
+    {
+        $deck = new Deck();
+        $deck->setPosition(3);
+
+        self::assertSame(3, $deck->getPosition());
+    }
 }

--- a/tests/Functional/AdminArchetypeControllerTest.php
+++ b/tests/Functional/AdminArchetypeControllerTest.php
@@ -386,6 +386,131 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
         return $archetype;
     }
 
+    // ---------------------------------------------------------------
+    // Reorder endpoints (F18.12, F18.19)
+    // ---------------------------------------------------------------
+
+    /**
+     * @see docs/features.md F18.12 — Admin drag-and-drop archetype ordering
+     */
+    public function testReorderArchetypes(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $archetypes = $entityManager->getRepository(Archetype::class)->findBy(['deletedAt' => null], ['position' => 'ASC']);
+
+        // Reverse the order
+        $ids = array_map(static fn (Archetype $archetype): int => (int) $archetype->getId(), $archetypes);
+        $reversed = array_reverse($ids);
+
+        $this->client->request('POST', '/admin/archetypes/reorder', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], (string) json_encode($reversed));
+
+        self::assertResponseIsSuccessful();
+
+        /** @var string $content */
+        $content = $this->client->getResponse()->getContent();
+        /** @var array{ok: bool} $data */
+        $data = json_decode($content, true);
+        self::assertTrue($data['ok']);
+
+        // Verify first archetype now has position 0
+        $entityManager->clear();
+        $first = $entityManager->getRepository(Archetype::class)->find($reversed[0]);
+        self::assertNotNull($first);
+        self::assertSame(0, $first->getPosition());
+    }
+
+    /**
+     * @see docs/features.md F18.19 — Archetype variant ordering
+     */
+    public function testReorderVariants(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+
+        /** @var DeckRepository $deckRepository */
+        $deckRepository = static::getContainer()->get(DeckRepository::class);
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
+        self::assertGreaterThanOrEqual(2, \count($variants));
+
+        // Reverse the order
+        $ids = array_map(static fn (Deck $deck): int => (int) $deck->getId(), $variants);
+        $reversed = array_reverse($ids);
+
+        $this->client->request('POST', '/admin/archetypes/'.$archetype->getId().'/variants/reorder', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], (string) json_encode($reversed));
+
+        self::assertResponseIsSuccessful();
+
+        /** @var string $content */
+        $content = $this->client->getResponse()->getContent();
+        /** @var array{ok: bool} $data */
+        $data = json_decode($content, true);
+        self::assertTrue($data['ok']);
+    }
+
+    /**
+     * @see docs/features.md F18.19 — Archetype variant ordering
+     */
+    public function testReorderVariantsKeepsCanonicalAtPositionZero(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+
+        /** @var DeckRepository $deckRepository */
+        $deckRepository = static::getContainer()->get(DeckRepository::class);
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
+
+        // Send reversed order
+        $ids = array_map(static fn (Deck $deck): int => (int) $deck->getId(), $variants);
+        $reversed = array_reverse($ids);
+
+        $this->client->request('POST', '/admin/archetypes/'.$archetype->getId().'/variants/reorder', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], (string) json_encode($reversed));
+
+        self::assertResponseIsSuccessful();
+
+        // Verify canonical variant has position 0
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager->clear();
+
+        $refreshedVariants = $deckRepository->findVariantsByArchetype($archetype);
+        $canonical = null;
+        foreach ($refreshedVariants as $variant) {
+            if ($variant->isCanonical()) {
+                $canonical = $variant;
+
+                break;
+            }
+        }
+
+        self::assertNotNull($canonical);
+        self::assertSame(0, $canonical->getPosition());
+    }
+
+    /**
+     * @see docs/features.md F18.12 — Admin drag-and-drop archetype ordering
+     */
+    public function testReorderRequiresAdmin(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $this->client->request('POST', '/admin/archetypes/reorder', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '[1,2,3]');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
     private function getVariantByName(string $name, Archetype $archetype): Deck
     {
         /** @var DeckRepository $deckRepository */

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -3508,6 +3508,11 @@
                 <target>Sort by</target>
                 <note>Label for sort dropdown on archetype catalog</note>
             </trans-unit>
+            <trans-unit id="app.archetype.sort_relevance">
+                <source>app.archetype.sort_relevance</source>
+                <target>Relevance</target>
+                <note>Sort option: by admin-defined position (most relevant first)</note>
+            </trans-unit>
             <trans-unit id="app.archetype.sort_decks">
                 <source>app.archetype.sort_decks</source>
                 <target>Most decks</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -3498,6 +3498,11 @@
                 <target>Trier par</target>
                 <note>Label for sort dropdown on archetype catalog</note>
             </trans-unit>
+            <trans-unit id="app.archetype.sort_relevance">
+                <source>app.archetype.sort_relevance</source>
+                <target>Pertinence</target>
+                <note>Sort option: by admin-defined position (most relevant first)</note>
+            </trans-unit>
             <trans-unit id="app.archetype.sort_decks">
                 <source>app.archetype.sort_decks</source>
                 <target>Plus de decks</target>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,8 @@ Encore
     .addStyleEntry('theme_expandedtalks', './assets/styles/themes/expandedtalks/theme.scss')
     .addEntry('deck_form', './assets/deck-form.tsx')
     .addEntry('deck_card_list', './assets/deck-card-list.tsx')
+    .addEntry('admin_archetype_list', './assets/admin-archetype-list.ts')
+    .addEntry('admin_archetype_edit', './assets/admin-archetype-edit.ts')
     .addEntry('archetype_show', './assets/archetype-show.ts')
     .addEntry('archetype_variants', './assets/archetype-variants.tsx')
     .addEntry('page_show', './assets/page-show.ts')


### PR DESCRIPTION
## Summary

- **Archetype position field** (#345) — `Archetype.position` int column for catalog relevance ordering
- **Deck position field** (#390) — `Deck.position` int column for variant ordering within an archetype
- **Admin archetype list** (#346) — drag-and-drop sortable with SortableJS, accessible up/down buttons on mobile, AJAX `POST /admin/archetypes/reorder`
- **Admin variant list** (#390) — drag-and-drop sortable in the archetype edit page, AJAX `POST /admin/archetypes/{id}/variants/reorder`. Canonical variant always pinned at position 0.
- **Reusable `sortable-table.ts`** — shared SortableJS helper for both lists, parameterized by tbody ID and data attribute name
- **Relevance sort in catalog** — archetype catalog defaults to position-based "Relevance" sort, with dropdown option listed first
- **Variant selector buttons** — increased to `size="sm"` with 22px sprites for better readability
- **Canonical always first** — variant query orders by `canonical DESC, position ASC`; reorder endpoint pins canonical at position 0
- **Parsed variant fixtures** — `DeckListParser` injected into `DevFixtures` to parse raw decklists into `DeckCard` entities, enabling enrichment pipeline (mosaics, card images)
- **Fixture positions** — archetype positions (Regidrago=0 through Ancient Box=7) and variant positions (0/1/2) match current dev DB
- **Migration** — adds `position` column to both `archetype` and `deck` tables

Closes #345
Closes #346
Closes #390

## Test plan

- [ ] Run migration, then `make fixtures` and `make worker.enrichment` — verify variant mosaics generate
- [ ] Admin archetype list — drag rows to reorder, verify positions persist on reload
- [ ] Mobile archetype list — use up/down arrow buttons to reorder
- [ ] Admin archetype edit — drag variant rows to reorder, verify canonical stays first
- [ ] Public archetype catalog — verify default sort is "Relevance", archetypes display in admin-set order
- [ ] Public archetype detail — verify variants display with card data and mosaic
- [ ] PHPStan level 10 clean, all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)