### PR TITLE
:bug: Fix: smart cache TTL and admin cache management

### DIFF
--- a/src/Controller/AdminTechnicalController.php
+++ b/src/Controller/AdminTechnicalController.php
@@ -22,11 +22,13 @@ use App\Service\BannedCardsSyncService;
 use App\Service\EnrichmentFlushService;
 use App\Service\Mosaic\MosaicRedispatchService;
 use App\Twig\Runtime\MenuRuntime;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/admin/technical')]
@@ -185,6 +187,50 @@ class AdminTechnicalController extends AbstractAppController
 
         $menuRuntime->invalidateCache();
         $this->addFlash('success', 'app.admin.technical.clear_cache.done');
+
+        return $this->redirectToRoute('app_admin_technical_dashboard');
+    }
+
+    /**
+     * Clear the entire application cache pool.
+     */
+    #[Route('/clear-app-cache', name: 'app_admin_technical_clear_app_cache', methods: ['POST'])]
+    public function clearAppCache(Request $request, CacheItemPoolInterface $cache): Response
+    {
+        if (!$this->isCsrfTokenValid('technical-clear-app-cache', $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        $cache->clear();
+        $this->addFlash('success', 'app.admin.technical.clear_app_cache.done');
+
+        return $this->redirectToRoute('app_admin_technical_dashboard');
+    }
+
+    /**
+     * Delete a specific key from the application cache pool.
+     */
+    #[Route('/clear-cache-key', name: 'app_admin_technical_clear_cache_key', methods: ['POST'])]
+    public function clearCacheKey(Request $request, CacheInterface $cache): Response
+    {
+        if (!$this->isCsrfTokenValid('technical-clear-cache-key', $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        $key = trim($request->getPayload()->getString('cache_key'));
+
+        if ('' === $key) {
+            $this->addFlash('warning', 'app.admin.technical.clear_cache_key.empty');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        $cache->delete($key);
+        $this->addFlash('success', 'app.admin.technical.clear_cache_key.done', ['%key%' => $key]);
 
         return $this->redirectToRoute('app_admin_technical_dashboard');
     }

--- a/src/Service/ArchetypeDescriptionRenderer.php
+++ b/src/Service/ArchetypeDescriptionRenderer.php
@@ -160,10 +160,10 @@ class ArchetypeDescriptionRenderer
     {
         /** @var array{name: string, imageUrl: string|null}|null $data */
         $data = $this->cache->get('archetype_desc.card.'.strtoupper($reference), function (ItemInterface $item) use ($reference): ?array {
-            $item->expiresAfter(86400);
-
             $lastHyphen = strrpos($reference, '-');
             if (false === $lastHyphen) {
+                $item->expiresAfter(300);
+
                 return null;
             }
 
@@ -173,6 +173,8 @@ class ArchetypeDescriptionRenderer
             // Try local DB first (enriched cards)
             $deckCard = $this->deckCardRepository->findOneBySetCodeAndCardNumber($setCode, $cardNumber);
             if (null !== $deckCard) {
+                $item->expiresAfter(null !== $deckCard->getImageUrl() ? 86400 : 300);
+
                 return [
                     'name' => $deckCard->getCardName(),
                     'imageUrl' => $deckCard->getImageUrl(),
@@ -182,11 +184,16 @@ class ArchetypeDescriptionRenderer
             // Fall back to TCGdex API
             $tcgdexCard = $this->tcgdexApiClient->findCard($setCode, $cardNumber);
             if (null !== $tcgdexCard) {
+                $item->expiresAfter(null !== $tcgdexCard->imageUrl ? 86400 : 300);
+
                 return [
                     'name' => $tcgdexCard->name,
                     'imageUrl' => $tcgdexCard->imageUrl,
                 ];
             }
+
+            // Card not found — cache briefly so we retry soon
+            $item->expiresAfter(300);
 
             return null;
         });

--- a/templates/admin/technical/dashboard.html.twig
+++ b/templates/admin/technical/dashboard.html.twig
@@ -171,17 +171,40 @@
         </div>
     </div>
 
-    {# Clear cache card #}
+    {# Cache management card #}
     <div class="card shadow-sm mb-3">
         <div class="card-header card-header-themed">
-            <h5 class="mb-0">{{ 'app.admin.technical.clear_cache.title'|trans }}</h5>
+            <h5 class="mb-0">{{ 'app.admin.technical.cache.title'|trans }}</h5>
         </div>
         <div class="card-body">
-            <p>{{ 'app.admin.technical.clear_cache.description'|trans }}</p>
-            <form method="post" action="{{ path('app_admin_technical_clear_cache') }}">
+            <h6>{{ 'app.admin.technical.clear_cache.title'|trans }}</h6>
+            <p class="text-muted small">{{ 'app.admin.technical.clear_cache.description'|trans }}</p>
+            <form method="post" action="{{ path('app_admin_technical_clear_cache') }}" class="mb-4">
                 <input type="hidden" name="_token" value="{{ csrf_token('technical-clear-cache') }}">
-                <button type="submit" class="btn btn-outline-secondary">
+                <button type="submit" class="btn btn-outline-secondary btn-sm">
                     {{ 'app.admin.technical.clear_cache.button'|trans }}
+                </button>
+            </form>
+
+            <h6>{{ 'app.admin.technical.clear_app_cache.title'|trans }}</h6>
+            <p class="text-muted small">{{ 'app.admin.technical.clear_app_cache.description'|trans }}</p>
+            <form method="post" action="{{ path('app_admin_technical_clear_app_cache') }}" class="mb-4"
+                  onsubmit="return confirm('{{ 'app.admin.technical.clear_app_cache.confirm'|trans|e('js') }}')">
+                <input type="hidden" name="_token" value="{{ csrf_token('technical-clear-app-cache') }}">
+                <button type="submit" class="btn btn-outline-warning btn-sm">
+                    {{ 'app.admin.technical.clear_app_cache.button'|trans }}
+                </button>
+            </form>
+
+            <h6>{{ 'app.admin.technical.clear_cache_key.title'|trans }}</h6>
+            <p class="text-muted small">{{ 'app.admin.technical.clear_cache_key.description'|trans }}</p>
+            <form method="post" action="{{ path('app_admin_technical_clear_cache_key') }}" class="d-flex gap-2 align-items-end">
+                <input type="hidden" name="_token" value="{{ csrf_token('technical-clear-cache-key') }}">
+                <div class="flex-grow-1">
+                    <input type="text" name="cache_key" class="form-control form-control-sm" placeholder="{{ 'app.admin.technical.clear_cache_key.placeholder'|trans }}" required>
+                </div>
+                <button type="submit" class="btn btn-outline-secondary btn-sm">
+                    {{ 'app.admin.technical.clear_cache_key.button'|trans }}
                 </button>
             </form>
         </div>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -638,6 +638,16 @@
                 <source>app.deck.mosaic_alt</source>
                 <target>Card mosaic for %name%</target>
             </trans-unit>
+            <trans-unit id="app.deck.enriched">
+                <source>app.deck.enriched</source>
+                <target>Enriched</target>
+                <note>Badge label for a deck version that has been enriched with card data</note>
+            </trans-unit>
+            <trans-unit id="app.deck.pending">
+                <source>app.deck.pending</source>
+                <target>Pending</target>
+                <note>Badge label for a deck version awaiting enrichment</note>
+            </trans-unit>
             <trans-unit id="app.deck.no_list">
                 <source>app.deck.no_list</source>
                 <target>No deck list imported yet.</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -4438,6 +4438,66 @@
                 <source>app.admin.technical.clear_cache.done</source>
                 <target>Navigation cache cleared.</target>
             </trans-unit>
+            <trans-unit id="app.admin.technical.cache.title">
+                <source>app.admin.technical.cache.title</source>
+                <target>Cache Management</target>
+                <note>Card header for the cache management section on technical dashboard</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.title">
+                <source>app.admin.technical.clear_app_cache.title</source>
+                <target>Clear all application cache</target>
+                <note>Subtitle for clearing the entire cache.app pool</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.description">
+                <source>app.admin.technical.clear_app_cache.description</source>
+                <target>Clears the entire application cache pool (card data, rendered descriptions, etc.).</target>
+                <note>Description for the clear all app cache action</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.button">
+                <source>app.admin.technical.clear_app_cache.button</source>
+                <target>Clear all app cache</target>
+                <note>Button label for clearing all app cache</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.confirm">
+                <source>app.admin.technical.clear_app_cache.confirm</source>
+                <target>This will clear all cached data (card images, descriptions, etc.). Continue?</target>
+                <note>Confirmation dialog for clearing all app cache</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.done">
+                <source>app.admin.technical.clear_app_cache.done</source>
+                <target>Application cache cleared.</target>
+                <note>Flash message after clearing all app cache</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.title">
+                <source>app.admin.technical.clear_cache_key.title</source>
+                <target>Clear specific cache key</target>
+                <note>Subtitle for clearing a specific cache key</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.description">
+                <source>app.admin.technical.clear_cache_key.description</source>
+                <target>Delete a specific entry from the cache by its key (e.g. archetype_desc.card.UNM-205).</target>
+                <note>Description for the clear cache key action</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.placeholder">
+                <source>app.admin.technical.clear_cache_key.placeholder</source>
+                <target>Cache key…</target>
+                <note>Placeholder for the cache key input field</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.button">
+                <source>app.admin.technical.clear_cache_key.button</source>
+                <target>Delete key</target>
+                <note>Button label for deleting a specific cache key</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.done">
+                <source>app.admin.technical.clear_cache_key.done</source>
+                <target>Cache key "%key%" deleted.</target>
+                <note>Flash message after deleting a cache key. %key% = the cache key</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.empty">
+                <source>app.admin.technical.clear_cache_key.empty</source>
+                <target>Please enter a cache key.</target>
+                <note>Warning when no cache key is provided</note>
+            </trans-unit>
             <trans-unit id="app.admin.technical.flush_reenrich.title">
                 <source>app.admin.technical.flush_reenrich.title</source>
                 <target>Flush &amp; Re-enrich All</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -638,6 +638,16 @@
                 <source>app.deck.mosaic_alt</source>
                 <target>Mosaïque de cartes pour %name%</target>
             </trans-unit>
+            <trans-unit id="app.deck.enriched">
+                <source>app.deck.enriched</source>
+                <target>Enrichi</target>
+                <note>Badge label for a deck version that has been enriched with card data</note>
+            </trans-unit>
+            <trans-unit id="app.deck.pending">
+                <source>app.deck.pending</source>
+                <target>En attente</target>
+                <note>Badge label for a deck version awaiting enrichment</note>
+            </trans-unit>
             <trans-unit id="app.deck.no_list">
                 <source>app.deck.no_list</source>
                 <target>Aucune decklist importée pour le moment.</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -4428,6 +4428,54 @@
                 <source>app.admin.technical.clear_cache.done</source>
                 <target>Cache de navigation vidé.</target>
             </trans-unit>
+            <trans-unit id="app.admin.technical.cache.title">
+                <source>app.admin.technical.cache.title</source>
+                <target>Gestion du cache</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.title">
+                <source>app.admin.technical.clear_app_cache.title</source>
+                <target>Vider tout le cache applicatif</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.description">
+                <source>app.admin.technical.clear_app_cache.description</source>
+                <target>Vide l'intégralité du cache applicatif (données de cartes, descriptions rendues, etc.).</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.button">
+                <source>app.admin.technical.clear_app_cache.button</source>
+                <target>Vider tout le cache</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.confirm">
+                <source>app.admin.technical.clear_app_cache.confirm</source>
+                <target>Cela va vider toutes les données en cache (images de cartes, descriptions, etc.). Continuer ?</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_app_cache.done">
+                <source>app.admin.technical.clear_app_cache.done</source>
+                <target>Cache applicatif vidé.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.title">
+                <source>app.admin.technical.clear_cache_key.title</source>
+                <target>Supprimer une clé de cache</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.description">
+                <source>app.admin.technical.clear_cache_key.description</source>
+                <target>Supprime une entrée spécifique du cache par sa clé (ex. archetype_desc.card.UNM-205).</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.placeholder">
+                <source>app.admin.technical.clear_cache_key.placeholder</source>
+                <target>Clé de cache…</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.button">
+                <source>app.admin.technical.clear_cache_key.button</source>
+                <target>Supprimer la clé</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.done">
+                <source>app.admin.technical.clear_cache_key.done</source>
+                <target>Clé de cache « %key% » supprimée.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.clear_cache_key.empty">
+                <source>app.admin.technical.clear_cache_key.empty</source>
+                <target>Veuillez saisir une clé de cache.</target>
+            </trans-unit>
             <trans-unit id="app.admin.technical.flush_reenrich.title">
                 <source>app.admin.technical.flush_reenrich.title</source>
                 <target>Purger et ré-enrichir tout</target>


### PR DESCRIPTION
## Summary

- **Smart cache TTL** — card data cached for 24h only when both name and image URL are present. Uses 5-minute TTL for cards with missing images or unresolved references, so they are retried quickly instead of being stuck for a full day.
- **Clear all app cache** — new button on technical admin dashboard clears the entire `cache.app` pool (card data, rendered descriptions, etc.). Confirmation dialog before clearing.
- **Delete specific cache key** — text input on technical admin dashboard to delete a specific cache entry by key (e.g. `archetype_desc.card.UNM-205`).
- **Missing translation keys** — added `app.deck.enriched` and `app.deck.pending` (EN/FR) used in the variant list enrichment status badges.

## Test plan

- [ ] Technical dashboard shows three cache actions: navigation cache, all app cache, specific key
- [ ] "Clear all app cache" clears cached card data and rendered descriptions
- [ ] "Delete key" with a specific key removes that entry
- [ ] Card with missing image is retried within 5 minutes (not stuck for 24h)
- [ ] Variant list shows "Enriched" / "Pending" badges correctly (no raw translation keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)