### PR TITLE
:bug: Fix: localized energy enrichment and canonical card names

### DIFF
--- a/src/Service/Tcgdex/CardEnricher.php
+++ b/src/Service/Tcgdex/CardEnricher.php
@@ -92,6 +92,19 @@ class CardEnricher
         'MEE|8' => 'https://assets.pokemon.com/static-assets/content-assets/cms2/img/cards/web/MEE/MEE_EN_8.png',
     ];
 
+    /** English basic energy names — canonical names used by TCGdex. */
+    private const array ENGLISH_ENERGY_NAMES = [
+        'Grass Energy',
+        'Fire Energy',
+        'Water Energy',
+        'Lightning Energy',
+        'Psychic Energy',
+        'Fighting Energy',
+        'Darkness Energy',
+        'Metal Energy',
+        'Fairy Energy',
+    ];
+
     /**
      * Fallback image URLs for basic energy cards when no TCGdex printing exists.
      *
@@ -195,6 +208,7 @@ class CardEnricher
                 // Basic energy: detect by name (regardless of set code)
                 if ($this->isBasicEnergy($card)) {
                     $this->enrichBasicEnergy($card);
+                    $this->resolveDisplayName($card);
                     $this->resolveCardType($card, 'Energy');
                     ++$enrichedCount;
 
@@ -211,6 +225,7 @@ class CardEnricher
                     if (null !== $tcgdexCard) {
                         $printing = $this->identityResolver->resolveFromTcgdexCard($tcgdexCard);
                         $card->setCardPrinting($printing);
+                        $this->resolveDisplayName($card);
                         $this->resolveCardType($card, $tcgdexCard->category);
                         $this->resolveImageUrl($printing, $tcgdexCard, $card->getCardName());
                         $this->applyImageOverride($printing, $card->getSetCode(), $card->getCardNumber());
@@ -238,6 +253,7 @@ class CardEnricher
 
                 $printing = $this->identityResolver->resolveFromTcgdexCard($tcgdexCard);
                 $card->setCardPrinting($printing);
+                $this->resolveDisplayName($card);
                 $this->resolveCardType($card, $tcgdexCard->category);
                 $this->resolveImageUrl($printing, $tcgdexCard, $card->getCardName());
                 $this->applyImageOverride($printing, $card->getSetCode(), $card->getCardNumber());
@@ -290,15 +306,40 @@ class CardEnricher
         $energySetKey = $setCode.'|'.$normalizedNumber;
 
         if (isset(self::ENERGY_SET_IMAGES[$energySetKey])) {
-            // Static energy image — no CardPrinting (energy-only sets aren't in TCGdex)
-            // Try to find a printing anyway for enrichment completeness
+            // Static energy image — energy-only sets aren't in TCGdex.
+            // Try to find a printing for enrichment completeness.
+            // Localized names (e.g. "Énergie Obscurité") won't match TCGdex — try English fallback.
             $tcgdexCard = $this->findSimplestBasicEnergyByName($card->getCardName());
+
+            if (null === $tcgdexCard) {
+                $englishName = self::resolveEnglishEnergyName($card->getCardName());
+
+                if (null !== $englishName) {
+                    $tcgdexCard = $this->findSimplestBasicEnergyByName($englishName);
+                }
+            }
 
             if (null !== $tcgdexCard) {
                 $printing = $this->identityResolver->resolveFromTcgdexCard($tcgdexCard);
                 $printing->setImageUrl(self::ENERGY_SET_IMAGES[$energySetKey]);
                 $card->setCardPrinting($printing);
+
+                return;
             }
+
+            // Synthetic fallback with English name for a consistent CardIdentity
+            $englishName = self::resolveEnglishEnergyName($card->getCardName()) ?? $card->getCardName();
+            $syntheticDto = new TcgdexCard(
+                id: \sprintf('energy-%s', strtolower(str_replace(' ', '-', $englishName))),
+                name: $englishName,
+                category: 'Energy',
+                trainerType: null,
+                imageUrl: self::ENERGY_SET_IMAGES[$energySetKey],
+                isExpandedLegal: true,
+            );
+            $printing = $this->identityResolver->resolveFromTcgdexCard($syntheticDto);
+            $printing->setImageUrl(self::ENERGY_SET_IMAGES[$energySetKey]);
+            $card->setCardPrinting($printing);
 
             return;
         }
@@ -503,6 +544,52 @@ class CardEnricher
         $pokemontcgSetId = str_replace('.', '', $setId);
 
         return \sprintf('https://images.pokemontcg.io/%s/%s_hires.png', $pokemontcgSetId, $localId);
+    }
+
+    /**
+     * Updates DeckCard.cardName with the canonical name from CardIdentity.
+     *
+     * When the deck list is pasted in a non-English locale (e.g. "Ordres du Boss"),
+     * this replaces the player input with the matched English name ("Boss's Orders")
+     * so all display contexts (table, mosaic, export) show the canonical name.
+     */
+    private function resolveDisplayName(DeckCard $card): void
+    {
+        $printing = $card->getCardPrinting();
+
+        if (null === $printing) {
+            return;
+        }
+
+        $canonicalName = $printing->getCardIdentity()->getName();
+
+        if ('' !== $canonicalName) {
+            $card->setCardName($canonicalName);
+        }
+    }
+
+    /**
+     * Resolves the English basic energy name from a localized name.
+     *
+     * Uses BASIC_ENERGY_IMAGES as the authority: all localized names that share the
+     * same image URL correspond to the same energy type. Returns null if the name
+     * is not a known localized energy name, or the name itself if already English.
+     */
+    private static function resolveEnglishEnergyName(string $localizedName): ?string
+    {
+        $targetUrl = self::BASIC_ENERGY_IMAGES[$localizedName] ?? null;
+
+        if (null === $targetUrl) {
+            return null;
+        }
+
+        foreach (self::ENGLISH_ENERGY_NAMES as $englishName) {
+            if (self::BASIC_ENERGY_IMAGES[$englishName] === $targetUrl) {
+                return $englishName;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Service/Tcgdex/CardEnricherTest.php
+++ b/tests/Service/Tcgdex/CardEnricherTest.php
@@ -1156,6 +1156,121 @@ class CardEnricherTest extends TestCase
     }
 
     /**
+     * Covers enrichBasicEnergy() with a French energy name: "Énergie Obscurité"
+     * is not in TCGdex but should resolve to "Darkness Energy" via English fallback.
+     *
+     * @see docs/features.md F6.9 — Improved energy card enrichment
+     */
+    public function testEnrichBasicEnergyResolvesLocalizedFrenchName(): void
+    {
+        $card = new DeckCard();
+        $card->setCardName('Énergie Obscurité');
+        $card->setSetCode('MEE');
+        $card->setCardNumber('7');
+        $card->setCardType('energy');
+        $card->setQuantity(8);
+
+        $version = $this->createVersionWithCards([$card]);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        // French name returns empty, English name returns a printing
+        $apiClient->method('findAllPrintingsByName')->willReturnCallback(
+            static function (string $name): array {
+                if ('Darkness Energy' === $name) {
+                    return [
+                        new TcgdexCard(
+                            id: 'sm1-darkness',
+                            name: 'Darkness Energy',
+                            category: 'Energy',
+                            trainerType: null,
+                            imageUrl: 'https://example.com/darkness.webp',
+                            isExpandedLegal: true,
+                            rarity: 'Common',
+                        ),
+                    ];
+                }
+
+                return [];
+            },
+        );
+
+        $enricher = new CardEnricher($apiClient, $this->identityResolver, $this->em);
+        $report = $enricher->enrichVersion($version);
+
+        self::assertSame(1, $report->enrichedCount);
+        self::assertNotNull($card->getCardPrinting());
+        // Image should come from the static MEE|7 energy set image
+        self::assertStringContainsString('MEE_EN_7', (string) $card->getCardPrinting()->getImageUrl());
+    }
+
+    /**
+     * Covers enrichBasicEnergy() synthetic fallback: when TCGdex has no printing
+     * for the English energy name either, a synthetic printing is created with
+     * the English name (not the localized name) for a consistent CardIdentity.
+     *
+     * @see docs/features.md F6.9 — Improved energy card enrichment
+     */
+    public function testEnrichBasicEnergySyntheticFallbackUsesEnglishName(): void
+    {
+        $card = new DeckCard();
+        $card->setCardName('Énergie Obscurité');
+        $card->setSetCode('MEE');
+        $card->setCardNumber('7');
+        $card->setCardType('energy');
+        $card->setQuantity(4);
+
+        $version = $this->createVersionWithCards([$card]);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        // All name lookups return empty — force synthetic fallback
+        $apiClient->method('findAllPrintingsByName')->willReturn([]);
+
+        $enricher = new CardEnricher($apiClient, $this->identityResolver, $this->em);
+        $report = $enricher->enrichVersion($version);
+
+        self::assertSame(1, $report->enrichedCount);
+        self::assertNotNull($card->getCardPrinting());
+        // CardIdentity should use English name, not French
+        self::assertSame('Darkness Energy', $card->getCardPrinting()->getCardIdentity()->getName());
+        self::assertStringContainsString('MEE_EN_7', (string) $card->getCardPrinting()->getImageUrl());
+    }
+
+    /**
+     * Covers resolveDisplayName(): after enrichment, the card name should be updated
+     * to the canonical name from CardIdentity (not the player's raw input).
+     *
+     * @see docs/features.md F6.2 — TCGdex card data enrichment
+     */
+    public function testEnrichVersionUpdatesCardNameToCanonicalName(): void
+    {
+        $card = new DeckCard();
+        $card->setCardName('Ordres du Boss');
+        $card->setSetCode('MEG');
+        $card->setCardNumber('114');
+        $card->setCardType('trainer');
+        $card->setQuantity(2);
+
+        $version = $this->createVersionWithCards([$card]);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')
+            ->willReturn(new TcgdexCard(
+                id: 'me01-114',
+                name: "Boss's Orders",
+                category: 'Trainer',
+                trainerType: 'Supporter',
+                imageUrl: 'https://assets.tcgdex.net/en/me/me01/114/high.webp',
+                isExpandedLegal: true,
+            ));
+
+        $enricher = new CardEnricher($apiClient, $this->identityResolver, $this->em);
+        $enricher->enrichVersion($version);
+
+        // Card name should be updated to the canonical English name from TCGdex
+        self::assertSame("Boss's Orders", $card->getCardName());
+    }
+
+    /**
      * @param list<DeckCard> $cards
      */
     private function createVersionWithCards(array $cards): DeckVersion


### PR DESCRIPTION
## Summary

- **Resolve localized basic energy names**: French names like "Énergie Obscurité" failed TCGdex lookup (English-only). `enrichBasicEnergy()` now tries the English equivalent ("Darkness Energy") via `resolveEnglishEnergyName()` which maps localized names to English using the `BASIC_ENERGY_IMAGES` URL as a grouping key. When TCGdex has no printing at all, the synthetic fallback uses the English name for a consistent `CardIdentity`.
- **Display canonical card names**: After enrichment, `resolveDisplayName()` updates `DeckCard.cardName` with the matched name from `CardIdentity` so tables show "Boss's Orders" instead of the player's raw French input "Ordres du Boss".

## Test plan
- [ ] Import the French deck list from the issue — verify "Énergie Obscurité MEE 7" is enriched with MEE image and "Darkness Energy" identity
- [ ] Verify all card names in the table show canonical English names after enrichment (not French input)
- [ ] Re-enrich an existing English deck — verify card names remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)