### PR TITLE
:sparkles: Feature: interactive card mosaic grid

### DIFF
--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -11,6 +11,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button, CopyButton, Group, Select, SegmentedControl, Stack } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { initCardHover } from '../shared/card-hover';
+import CardMosaicGrid from './CardMosaicGrid';
 
 /**
  * @see docs/features.md F18.16 — Archetype detail: variant selector
@@ -244,9 +245,7 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
     const [selectedIndex, setSelectedIndex] = useState(canonicalIndex >= 0 ? canonicalIndex : 0);
     const containerRef = useRef<HTMLDivElement>(null);
     const isMobile = useMediaQuery('(max-width: 767.98px)');
-    const [viewMode, setViewMode] = useState<ViewMode>(
-        () => window.matchMedia('(max-width: 767.98px)').matches ? 'table' : 'mosaic',
-    );
+    const [viewMode, setViewMode] = useState<ViewMode>('mosaic');
 
     // Re-initialize card hover after every render — description HTML contains
     // .card-hover elements from [[card:...]] tags, and they get recreated on
@@ -316,18 +315,11 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                         <CardTable groupedCards={selectedVariant.groupedCards} labels={labels} />
                     )}
 
-                    {viewMode === 'mosaic' && selectedVariant.mosaicUrl && (
-                        <div className="text-center">
-                            <img
-                                src={selectedVariant.mosaicUrl}
-                                alt={`${labels.mosaicAlt} \u2014 ${selectedVariant.name}`}
-                                className="img-fluid rounded shadow-sm"
-                            />
-                        </div>
-                    )}
-
-                    {viewMode === 'mosaic' && !selectedVariant.mosaicUrl && (
-                        <p className="text-muted text-center">Mosaic not yet generated.</p>
+                    {viewMode === 'mosaic' && (
+                        <CardMosaicGrid
+                            groupedCards={selectedVariant.groupedCards}
+                            mosaicAltLabel={`${labels.mosaicAlt} \u2014 ${selectedVariant.name}`}
+                        />
                     )}
                 </Stack>
             )}

--- a/assets/components/CardMosaicGrid.tsx
+++ b/assets/components/CardMosaicGrid.tsx
@@ -203,7 +203,9 @@ export default function CardMosaicGrid({ groupedCards, mosaicAltLabel }: CardMos
                             alt={card.cardName}
                             loading="lazy"
                         />
-                        <span className="card-mosaic-qty">{card.quantity}</span>
+                        <span className="card-mosaic-qty">
+                            <span className="card-mosaic-qty-inner">{card.quantity}</span>
+                        </span>
                     </button>
                 ))}
             </div>

--- a/assets/components/CardMosaicGrid.tsx
+++ b/assets/components/CardMosaicGrid.tsx
@@ -1,0 +1,220 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @see docs/features.md F2.23 — Interactive card mosaic with responsive grid and image modal
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CloseButton, Modal, Text, UnstyledButton } from '@mantine/core';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+
+interface CardData {
+    cardName: string;
+    quantity: number;
+    setCode: string;
+    cardNumber: string;
+    cardType: string;
+    trainerSubtype: string | null;
+    imageUrl: string | null;
+}
+
+interface CardMosaicGridProps {
+    groupedCards: Record<string, CardData[]>;
+    mosaicAltLabel: string;
+}
+
+interface FlatCard {
+    cardName: string;
+    quantity: number;
+    imageUrl: string;
+    lowResUrl: string;
+}
+
+const SECTION_ORDER = ['pokemon', 'trainer', 'energy'];
+
+/**
+ * Derive the low-resolution thumbnail URL from the stored high-resolution URL.
+ *
+ * TCGdex CDN serves both resolutions at the same path — swap the suffix.
+ * For non-TCGdex URLs (PokemonTCG.io, etc.), return the original URL as-is.
+ */
+function toLowRes(imageUrl: string): string {
+    if (imageUrl.includes('/high.webp')) {
+        return imageUrl.replace('/high.webp', '/low.webp');
+    }
+
+    return imageUrl;
+}
+
+/**
+ * Card image gallery modal — swipeable viewer with prev/next navigation.
+ */
+const CardImageModal: React.FC<{
+    opened: boolean;
+    cards: FlatCard[];
+    currentIndex: number;
+    onClose: () => void;
+    onNavigate: (index: number) => void;
+}> = ({ opened, cards, currentIndex, onClose, onNavigate }) => {
+    const touchStartX = useRef(0);
+    const touchStartY = useRef(0);
+
+    const card = cards[currentIndex];
+
+    const navigate = useCallback((direction: number) => {
+        onNavigate((currentIndex + direction + cards.length) % cards.length);
+    }, [currentIndex, cards.length, onNavigate]);
+
+    useEffect(() => {
+        if (!opened) return;
+
+        const handleKeyDown = (event: KeyboardEvent): void => {
+            if (event.key === 'ArrowLeft') navigate(-1);
+            if (event.key === 'ArrowRight') navigate(1);
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [opened, navigate]);
+
+    if (!card) return null;
+
+    const title = `${card.quantity} \u00d7 ${card.cardName}`;
+
+    return (
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            withCloseButton={false}
+            centered
+            size="sm"
+            padding={0}
+            styles={{
+                body: { padding: 0 },
+                content: { overflow: 'hidden' },
+            }}
+        >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px' }}>
+                <Text size="sm" fw={500} style={{ flex: 1 }}>{title}</Text>
+                <Text size="xs" c="dimmed" style={{ marginRight: 8 }}>
+                    {currentIndex + 1} / {cards.length}
+                </Text>
+                <CloseButton onClick={onClose} />
+            </div>
+            <div
+                style={{ position: 'relative', textAlign: 'center', padding: '0 8px 8px' }}
+                onTouchStart={(event) => {
+                    touchStartX.current = event.touches[0].clientX;
+                    touchStartY.current = event.touches[0].clientY;
+                }}
+                onTouchMove={(event) => {
+                    const deltaX = Math.abs(event.touches[0].clientX - touchStartX.current);
+                    const deltaY = Math.abs(event.touches[0].clientY - touchStartY.current);
+                    if (deltaY > deltaX) {
+                        event.preventDefault();
+                    }
+                }}
+                onTouchEnd={(event) => {
+                    const deltaX = event.changedTouches[0].clientX - touchStartX.current;
+                    if (Math.abs(deltaX) > 50) {
+                        navigate(deltaX < 0 ? 1 : -1);
+                    }
+                }}
+            >
+                <UnstyledButton
+                    onClick={() => navigate(-1)}
+                    style={{ position: 'absolute', left: 4, top: '50%', transform: 'translateY(-50%)', zIndex: 1 }}
+                >
+                    <IconChevronLeft size={28} />
+                </UnstyledButton>
+                <img
+                    src={card.imageUrl}
+                    alt={card.cardName}
+                    style={{ maxWidth: '100%', borderRadius: 4 }}
+                />
+                <UnstyledButton
+                    onClick={() => navigate(1)}
+                    style={{ position: 'absolute', right: 4, top: '50%', transform: 'translateY(-50%)', zIndex: 1 }}
+                >
+                    <IconChevronRight size={28} />
+                </UnstyledButton>
+            </div>
+        </Modal>
+    );
+};
+
+/**
+ * Interactive card mosaic grid — responsive 6-col (desktop) / 3-col (mobile)
+ * grid of low-res card thumbnails with quantity badges and click-to-zoom modal.
+ */
+export default function CardMosaicGrid({ groupedCards, mosaicAltLabel }: CardMosaicGridProps) {
+    const [modalOpen, setModalOpen] = useState(false);
+    const [modalIndex, setModalIndex] = useState(0);
+
+    const flatCards: FlatCard[] = useMemo(() => {
+        const entries: FlatCard[] = [];
+
+        for (const section of SECTION_ORDER) {
+            for (const card of groupedCards[section] ?? []) {
+                if (card.imageUrl) {
+                    entries.push({
+                        cardName: card.cardName,
+                        quantity: card.quantity,
+                        imageUrl: card.imageUrl,
+                        lowResUrl: toLowRes(card.imageUrl),
+                    });
+                }
+            }
+        }
+
+        return entries;
+    }, [groupedCards]);
+
+    const handleCardClick = useCallback((index: number) => {
+        setModalIndex(index);
+        setModalOpen(true);
+    }, []);
+
+    if (flatCards.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            <div className="card-mosaic-grid" role="grid" aria-label={mosaicAltLabel}>
+                {flatCards.map((card, index) => (
+                    <button
+                        key={`${card.cardName}-${index}`}
+                        type="button"
+                        className="card-mosaic-cell"
+                        onClick={() => handleCardClick(index)}
+                        aria-label={`${card.quantity} \u00d7 ${card.cardName}`}
+                    >
+                        <img
+                            src={card.lowResUrl}
+                            alt={card.cardName}
+                            loading="lazy"
+                        />
+                        <span className="card-mosaic-qty">{card.quantity}</span>
+                    </button>
+                ))}
+            </div>
+
+            <CardImageModal
+                opened={modalOpen}
+                cards={flatCards}
+                currentIndex={modalIndex}
+                onClose={() => setModalOpen(false)}
+                onNavigate={setModalIndex}
+            />
+        </>
+    );
+}

--- a/assets/components/DeckCardList.tsx
+++ b/assets/components/DeckCardList.tsx
@@ -13,6 +13,7 @@
  * @see docs/features.md F6.8 — Minified deck list export
  * @see docs/features.md F6.6b — Minified mosaic
  * @see docs/features.md F6.11 — Export deck list for Cardmarket wishlist
+ * @see docs/features.md F2.23 — Interactive card mosaic with responsive grid
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -30,6 +31,7 @@ import {
 } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { IconCopy, IconCheck, IconShare, IconShoppingCart, IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import CardMosaicGrid from './CardMosaicGrid';
 
 interface CardData {
     cardName: string;
@@ -359,15 +361,12 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
     labels,
 }) => {
     const hasMinifiedData = Object.keys(minifiedCards).length > 0 || minifiedList !== null;
-    const hasMosaic = mosaicUrl !== null;
     const hasMinifiedMosaic = minifiedMosaicUrl !== null;
-    const isMobile = useMediaQuery('(max-width: 767px)');
 
     const [variant, setVariant] = useState<Variant>(hasMinifiedData ? 'minified' : 'original');
-    const [viewMode, setViewMode] = useState<ViewMode>(hasMosaic ? 'mosaic' : 'table');
+    const [viewMode, setViewMode] = useState<ViewMode>('mosaic');
     const [copied, setCopied] = useState(false);
     const [cardmarketCopied, setCardmarketCopied] = useState(false);
-    const [mosaicModalOpen, setMosaicModalOpen] = useState(false);
     const [cardModalOpen, setCardModalOpen] = useState(false);
     const [cardModalIndex, setCardModalIndex] = useState(0);
     const copyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -387,7 +386,9 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
         return mosaicUrl;
     }, [variant, mosaicUrl, minifiedMosaicUrl, hasMinifiedMosaic]);
 
-    const isMosaicPending = viewMode === 'mosaic' && activeMosaicUrl === null;
+    const hasInteractiveCards = Object.values(activeCards).some(
+        (cards) => cards.some((card) => card.imageUrl !== null),
+    );
 
     const activeList = variant === 'minified' && minifiedList !== null
         ? minifiedList
@@ -488,14 +489,6 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
         copyTimeout.current = setTimeout(() => setCopied(false), 2000);
     }, [activeMosaicUrl, labels.mosaicAlt]);
 
-    const handleMosaicClick = useCallback(() => {
-        if (isMobile) {
-            setMosaicModalOpen(true);
-        } else {
-            setViewMode('mosaic');
-        }
-    }, [isMobile]);
-
     return (
         <>
             {/* Top bar: Variant toggle (left) + Copy (center) + View toggle (right) */}
@@ -556,14 +549,8 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
 
                 <SegmentedControl
                     size="xs"
-                    value={isMobile ? 'table' : viewMode}
-                    onChange={(value) => {
-                        if (value === 'mosaic') {
-                            handleMosaicClick();
-                        } else {
-                            setViewMode('table');
-                        }
-                    }}
+                    value={viewMode}
+                    onChange={(value) => setViewMode(value as ViewMode)}
                     data={[
                         { label: labels.viewTable, value: 'table' },
                         { label: labels.viewMosaic, value: 'mosaic' },
@@ -577,27 +564,21 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
             )}
 
             {/* Table view */}
-            {!isMinifiedPending && (viewMode === 'table' || isMobile) && (
+            {!isMinifiedPending && viewMode === 'table' && (
                 <CardTable groupedCards={activeCards} labels={labels} onCardTap={handleCardTap} />
             )}
 
-            {/* Mosaic view (desktop inline) */}
-            {viewMode === 'mosaic' && !isMobile && activeMosaicUrl && (
-                <div className="text-center">
-                    <img
-                        src={activeMosaicUrl}
-                        alt={labels.mosaicAlt}
-                        className="img-fluid rounded shadow-sm"
-                    />
-                </div>
+            {/* Interactive mosaic grid view */}
+            {viewMode === 'mosaic' && !isMinifiedPending && hasInteractiveCards && (
+                <CardMosaicGrid groupedCards={activeCards} mosaicAltLabel={labels.mosaicAlt} />
             )}
 
-            {/* Mosaic view pending (desktop inline) */}
-            {isMosaicPending && !isMobile && !isMinifiedPending && (
+            {/* Mosaic view pending (no card data yet) */}
+            {viewMode === 'mosaic' && !hasInteractiveCards && !isMinifiedPending && (
                 <GeneratingPlaceholder message={labels.mosaicGenerating} />
             )}
 
-            {/* Card image gallery modal (mobile tap-to-view with swipe) */}
+            {/* Card image gallery modal (mobile tap-to-view from table) */}
             <CardImageModal
                 opened={cardModalOpen}
                 cards={flatCards}
@@ -605,39 +586,6 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
                 onClose={() => setCardModalOpen(false)}
                 onNavigate={setCardModalIndex}
             />
-
-            {/* Mosaic fullscreen modal (mobile) */}
-            <Modal
-                opened={mosaicModalOpen}
-                onClose={() => setMosaicModalOpen(false)}
-                fullScreen
-                title={labels.mosaicAlt}
-                styles={{
-                    body: {
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        padding: 8,
-                        overflow: 'auto',
-                    },
-                    header: { backgroundColor: '#213568', color: 'white' },
-                    content: { backgroundColor: '#213568' },
-                }}
-            >
-                {activeMosaicUrl ? (
-                    <img
-                        src={activeMosaicUrl}
-                        alt={labels.mosaicAlt}
-                        className="img-fluid"
-                        style={{ maxHeight: '90vh' }}
-                    />
-                ) : (
-                    <div className="text-center py-5">
-                        <Loader size="sm" className="mb-2" color="white" />
-                        <Text size="sm" c="white">{labels.mosaicGenerating}</Text>
-                    </div>
-                )}
-            </Modal>
         </>
     );
 };

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -536,6 +536,62 @@ footer {
     }
 }
 
+// --- Interactive card mosaic grid ---
+// Responsive grid of card thumbnails with quantity badges.
+// @see docs/features.md F2.23
+
+.card-mosaic-grid {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 8px;
+
+    @include media-breakpoint-down(md) {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+.card-mosaic-cell {
+    position: relative;
+    cursor: pointer;
+    border: 0;
+    padding: 0;
+    background: none;
+    border-radius: 6px;
+    overflow: hidden;
+    transition: transform .15s ease;
+
+    &:hover {
+        transform: scale(1.03);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--bs-primary);
+        outline-offset: 2px;
+    }
+
+    img {
+        width: 100%;
+        height: auto;
+        display: block;
+    }
+}
+
+.card-mosaic-qty {
+    position: absolute;
+    bottom: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: $danger;
+    color: #fff;
+    font-weight: 700;
+    font-size: .7rem;
+    line-height: 1;
+    padding: 3px 8px;
+    border-radius: 10px;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+    pointer-events: none;
+}
+
 // --- Deck mosaic hover overlay (desktop only) ---
 // Shows the mosaic image on hover over deck cards in list views.
 .deck-mosaic-hover {

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -602,7 +602,7 @@ footer {
     background: #e83a45;
     color: #fff;
     font-weight: 700;
-    font-size: .75rem;
+    font-size: .9rem;
     line-height: 1;
     clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
 }

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -588,23 +588,14 @@ footer {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: $danger;
+    background: #e83a45; // bright red matching the GD badge (0xCC2936 lightened for screen)
     color: #fff;
     font-weight: 700;
     font-size: .75rem;
     line-height: 1;
     clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+    filter: drop-shadow(2px 2px 2px rgb(0 0 0 / 50%));
     pointer-events: none;
-
-    // Shadow layer behind the hexagon
-    &::before {
-        content: "";
-        position: absolute;
-        inset: -2px;
-        background: rgb(102 17 22); // matches GD shadow color 0x661116
-        clip-path: inherit;
-        z-index: -1;
-    }
 }
 
 // --- Deck mosaic hover overlay (desktop only) ---

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -590,20 +590,21 @@ footer {
     pointer-events: none;
 }
 
-// Flat-top hexagon (wider than tall) matching the server-generated GD badge.
-// aspect-ratio is √3/2 ≈ 0.866 (height / width for a flat-top regular hexagon).
+// Regular hexagon (all six sides equal, pointy-top).
+// A pointy-top regular hexagon inscribed in a rectangle has
+// width:height = √3 : 2 ≈ 0.866 : 1, so aspect-ratio = 0.866.
 .card-mosaic-qty-inner {
     display: flex;
     align-items: center;
     justify-content: center;
     width: 100%;
-    aspect-ratio: 1 / .866;
+    aspect-ratio: .866;
     background: #e83a45;
     color: #fff;
     font-weight: 700;
     font-size: .75rem;
     line-height: 1;
-    clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
 }
 
 // --- Deck mosaic hover overlay (desktop only) ---

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -586,22 +586,24 @@ footer {
     left: 50%;
     transform: translateX(-50%);
     width: 20%;
-    filter: drop-shadow(2px 2px 2px rgb(0 0 0 / 50%));
+    filter: drop-shadow(2px 3px 3px rgb(0 0 0 / 60%));
     pointer-events: none;
 }
 
+// Flat-top hexagon (wider than tall) matching the server-generated GD badge.
+// aspect-ratio is √3/2 ≈ 0.866 (height / width for a flat-top regular hexagon).
 .card-mosaic-qty-inner {
     display: flex;
     align-items: center;
     justify-content: center;
     width: 100%;
-    aspect-ratio: 1.1547; // regular hexagon width:height ratio (2 / √3)
+    aspect-ratio: 1 / .866;
     background: #e83a45;
     color: #fff;
     font-weight: 700;
     font-size: .75rem;
     line-height: 1;
-    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+    clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
 }
 
 // --- Deck mosaic hover overlay (desktop only) ---

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -576,20 +576,35 @@ footer {
     }
 }
 
+// Badge sized at ~20% of card width to match the server-generated mosaic
+// (50 px badge on a 245 px card). Hexagonal shape via clip-path.
 .card-mosaic-qty {
     position: absolute;
-    bottom: 6px;
+    bottom: 6%;
     left: 50%;
     transform: translateX(-50%);
+    width: 20%;
+    aspect-ratio: 1.1547; // regular hexagon width:height ratio (2 / √3)
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: $danger;
     color: #fff;
     font-weight: 700;
-    font-size: .7rem;
+    font-size: .75rem;
     line-height: 1;
-    padding: 3px 8px;
-    border-radius: 10px;
-    box-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
     pointer-events: none;
+
+    // Shadow layer behind the hexagon
+    &::before {
+        content: "";
+        position: absolute;
+        inset: -2px;
+        background: rgb(102 17 22); // matches GD shadow color 0x661116
+        clip-path: inherit;
+        z-index: -1;
+    }
 }
 
 // --- Deck mosaic hover overlay (desktop only) ---

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -578,24 +578,30 @@ footer {
 
 // Badge sized at ~20% of card width to match the server-generated mosaic
 // (50 px badge on a 245 px card). Hexagonal shape via clip-path.
+// Shadow lives on the outer wrapper so Firefox renders it correctly
+// (filter + clip-path on the same element is unreliable in Gecko).
 .card-mosaic-qty {
     position: absolute;
     bottom: 6%;
     left: 50%;
     transform: translateX(-50%);
     width: 20%;
-    aspect-ratio: 1.1547; // regular hexagon width:height ratio (2 / √3)
+    filter: drop-shadow(2px 2px 2px rgb(0 0 0 / 50%));
+    pointer-events: none;
+}
+
+.card-mosaic-qty-inner {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #e83a45; // bright red matching the GD badge (0xCC2936 lightened for screen)
+    width: 100%;
+    aspect-ratio: 1.1547; // regular hexagon width:height ratio (2 / √3)
+    background: #e83a45;
     color: #fff;
     font-weight: 700;
     font-size: .75rem;
     line-height: 1;
     clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
-    filter: drop-shadow(2px 2px 2px rgb(0 0 0 / 50%));
-    pointer-events: none;
 }
 
 // --- Deck mosaic hover overlay (desktop only) ---


### PR DESCRIPTION
## Summary

- **New `CardMosaicGrid` shared component** — responsive 6-col (desktop) / 3-col (mobile) CSS Grid of `low.webp` card thumbnails. Clicking a card opens a `high.webp` modal with swipe/keyboard navigation and quantity display.
- **Deck detail page** (`DeckCardList`) — replaced static server-generated PNG mosaic with the interactive grid. Removed the mobile fullscreen mosaic modal — the grid works identically on all screen sizes.
- **Archetype variant view** (`ArchetypeVariantSelector`) — replaced static mosaic image with the same interactive grid. Default view mode is now always `mosaic`.
- **Hexagonal quantity badges** — regular hexagon (all sides equal) via CSS `clip-path`, bright red (`#e83a45`), with `drop-shadow` on a wrapper element for Firefox compatibility.
- **Server-side mosaic generation preserved** — the generated PNG is still produced and used for the Web Share API / social preview share button.

## Test plan

- [ ] Open a deck detail page → verify the mosaic view shows a 6-col interactive grid
- [ ] Verify the red hexagonal quantity badges are visible and properly proportioned
- [ ] Click a card → verify the modal opens with high-res image, quantity, and prev/next navigation
- [ ] On mobile (or narrow viewport) → verify the grid adapts to 3 columns
- [ ] Switch between Original / Minified variants → verify the grid updates
- [ ] Open an archetype page with variants → verify the mosaic view uses the interactive grid
- [ ] Use the share button → verify it still shares the server-generated mosaic PNG
- [ ] Verify table view still works with card hover previews on both pages
- [ ] Test on Firefox → verify the hexagon shadow renders correctly

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)