### PR TITLE
:recycle: Refactor: click-to-modal for card names in table views

### DIFF
--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -7,10 +7,11 @@
  * file that was distributed with this source code.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Button, CopyButton, Group, Select, SegmentedControl, Stack } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { initCardHover } from '../shared/card-hover';
+import CardImageModal, { type FlatCard } from './CardImageModal';
 import CardMosaicGrid from './CardMosaicGrid';
 
 /**
@@ -83,7 +84,12 @@ function SpriteList({ slugs, height = 20 }: { slugs: string[]; height?: number }
     );
 }
 
-function CardSection({ title, cards, labels }: { title: string; cards: CardData[]; labels: Labels }) {
+function CardSection({ title, cards, labels, onCardClick }: {
+    title: string;
+    cards: CardData[];
+    labels: Labels;
+    onCardClick?: (card: CardData) => void;
+}) {
     return (
         <div className="mb-3">
             <h6 className="text-muted text-uppercase small fw-bold">{title}</h6>
@@ -101,15 +107,14 @@ function CardSection({ title, cards, labels }: { title: string; cards: CardData[
                         <tr key={index}>
                             <td>{card.quantity}</td>
                             <td>
-                                {card.imageUrl ? (
-                                    <span className="card-hover" data-quantity={card.quantity} data-card-hover-group="variant-decklist">
+                                {card.imageUrl && onCardClick ? (
+                                    <span className="card-name-link" role="button" tabIndex={0} onClick={() => onCardClick(card)} onKeyDown={(event) => {
+                                        if (event.key === 'Enter' || event.key === ' ') {
+                                            event.preventDefault();
+                                            onCardClick(card);
+                                        }
+                                    }}>
                                         {card.cardName}
-                                        <img
-                                            className="card-hover-img"
-                                            src={card.imageUrl}
-                                            alt={card.cardName}
-                                            loading="lazy"
-                                        />
                                     </span>
                                 ) : (
                                     card.cardName
@@ -125,7 +130,11 @@ function CardSection({ title, cards, labels }: { title: string; cards: CardData[
     );
 }
 
-function CardTable({ groupedCards, labels }: { groupedCards: Record<string, CardData[]>; labels: Labels }) {
+function CardTable({ groupedCards, labels, onCardClick }: {
+    groupedCards: Record<string, CardData[]>;
+    labels: Labels;
+    onCardClick?: (card: CardData) => void;
+}) {
     const sections = Object.entries(groupedCards);
 
     if (sections.length === 0) {
@@ -140,12 +149,12 @@ function CardTable({ groupedCards, labels }: { groupedCards: Record<string, Card
         <div className="row">
             <div className="col-md-6">
                 {leftSections.map(([type, cards]) => (
-                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} />
+                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} onCardClick={onCardClick} />
                 ))}
             </div>
             <div className="col-md-6">
                 {rightSections.map(([type, cards]) => (
-                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} />
+                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} onCardClick={onCardClick} />
                 ))}
             </div>
         </div>
@@ -246,6 +255,34 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
     const containerRef = useRef<HTMLDivElement>(null);
     const isMobile = useMediaQuery('(max-width: 767.98px)');
     const [viewMode, setViewMode] = useState<ViewMode>('mosaic');
+    const [cardModalOpen, setCardModalOpen] = useState(false);
+    const [cardModalIndex, setCardModalIndex] = useState(0);
+
+    const selectedVariant = variants[selectedIndex];
+    const groupedCards = selectedVariant?.groupedCards;
+
+    const flatCards: FlatCard[] = useMemo(() => {
+        const entries: FlatCard[] = [];
+        const order = ['pokemon', 'trainer', 'energy'];
+
+        for (const section of order) {
+            for (const card of groupedCards?.[section] ?? []) {
+                if (card.imageUrl) {
+                    entries.push({ imageUrl: card.imageUrl, cardName: card.cardName, quantity: card.quantity });
+                }
+            }
+        }
+
+        return entries;
+    }, [groupedCards]);
+
+    const handleCardClick = (card: CardData): void => {
+        const index = flatCards.findIndex((entry) => entry.imageUrl === card.imageUrl && entry.cardName === card.cardName);
+        if (index >= 0) {
+            setCardModalIndex(index);
+            setCardModalOpen(true);
+        }
+    };
 
     // Re-initialize card hover after every render — description HTML contains
     // .card-hover elements from [[card:...]] tags, and they get recreated on
@@ -261,8 +298,7 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
         return null;
     }
 
-    const selectedVariant = variants[selectedIndex];
-    const hasCards = Object.keys(selectedVariant.groupedCards).length > 0;
+    const hasCards = Object.keys(selectedVariant?.groupedCards ?? {}).length > 0;
 
     return (
         <div ref={containerRef}>
@@ -312,7 +348,7 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                     </Group>
 
                     {viewMode === 'table' && (
-                        <CardTable groupedCards={selectedVariant.groupedCards} labels={labels} />
+                        <CardTable groupedCards={selectedVariant.groupedCards} labels={labels} onCardClick={handleCardClick} />
                     )}
 
                     {viewMode === 'mosaic' && (
@@ -323,6 +359,14 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                     )}
                 </Stack>
             )}
+
+            <CardImageModal
+                opened={cardModalOpen}
+                cards={flatCards}
+                currentIndex={cardModalIndex}
+                onClose={() => setCardModalOpen(false)}
+                onNavigate={setCardModalIndex}
+            />
         </div>
     );
 }

--- a/assets/components/CardImageModal.tsx
+++ b/assets/components/CardImageModal.tsx
@@ -1,0 +1,123 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Shared card image gallery modal — swipeable viewer with prev/next navigation.
+ *
+ * @see docs/features.md F2.23 — Interactive card mosaic with responsive grid and image modal
+ */
+
+import React, { useCallback, useEffect, useRef } from 'react';
+import { CloseButton, Modal, Text, UnstyledButton } from '@mantine/core';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+
+export interface FlatCard {
+    cardName: string;
+    quantity: number;
+    imageUrl: string;
+}
+
+interface CardImageModalProps {
+    opened: boolean;
+    cards: FlatCard[];
+    currentIndex: number;
+    onClose: () => void;
+    onNavigate: (index: number) => void;
+}
+
+const CardImageModal: React.FC<CardImageModalProps> = ({ opened, cards, currentIndex, onClose, onNavigate }) => {
+    const touchStartX = useRef(0);
+    const touchStartY = useRef(0);
+
+    const card = cards[currentIndex];
+
+    const navigate = useCallback((direction: number) => {
+        onNavigate((currentIndex + direction + cards.length) % cards.length);
+    }, [currentIndex, cards.length, onNavigate]);
+
+    useEffect(() => {
+        if (!opened) return;
+
+        const handleKeyDown = (event: KeyboardEvent): void => {
+            if (event.key === 'ArrowLeft') navigate(-1);
+            if (event.key === 'ArrowRight') navigate(1);
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [opened, navigate]);
+
+    if (!card) return null;
+
+    const title = `${card.quantity} \u00d7 ${card.cardName}`;
+
+    return (
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            withCloseButton={false}
+            centered
+            size="sm"
+            padding={0}
+            styles={{
+                body: { padding: 0 },
+                content: { overflow: 'hidden' },
+            }}
+        >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px' }}>
+                <Text size="sm" fw={500} style={{ flex: 1 }}>{title}</Text>
+                <Text size="xs" c="dimmed" style={{ marginRight: 8 }}>
+                    {currentIndex + 1} / {cards.length}
+                </Text>
+                <CloseButton onClick={onClose} />
+            </div>
+            <div
+                style={{ position: 'relative', textAlign: 'center', padding: '0 8px 8px' }}
+                onTouchStart={(event) => {
+                    touchStartX.current = event.touches[0].clientX;
+                    touchStartY.current = event.touches[0].clientY;
+                }}
+                onTouchMove={(event) => {
+                    const deltaX = Math.abs(event.touches[0].clientX - touchStartX.current);
+                    const deltaY = Math.abs(event.touches[0].clientY - touchStartY.current);
+                    if (deltaY > deltaX) {
+                        event.preventDefault();
+                    }
+                }}
+                onTouchEnd={(event) => {
+                    const deltaX = event.changedTouches[0].clientX - touchStartX.current;
+                    if (Math.abs(deltaX) > 50) {
+                        navigate(deltaX < 0 ? 1 : -1);
+                    }
+                }}
+            >
+                <UnstyledButton
+                    onClick={() => navigate(-1)}
+                    style={{ position: 'absolute', left: 4, top: '50%', transform: 'translateY(-50%)', zIndex: 1 }}
+                >
+                    <IconChevronLeft size={28} />
+                </UnstyledButton>
+                <img
+                    src={card.imageUrl}
+                    alt={card.cardName}
+                    style={{ maxWidth: '100%', borderRadius: 4 }}
+                />
+                <UnstyledButton
+                    onClick={() => navigate(1)}
+                    style={{ position: 'absolute', right: 4, top: '50%', transform: 'translateY(-50%)', zIndex: 1 }}
+                >
+                    <IconChevronRight size={28} />
+                </UnstyledButton>
+            </div>
+        </Modal>
+    );
+};
+
+export default CardImageModal;

--- a/assets/components/CardImageModal.tsx
+++ b/assets/components/CardImageModal.tsx
@@ -64,11 +64,16 @@ const CardImageModal: React.FC<CardImageModalProps> = ({ opened, cards, currentI
             onClose={onClose}
             withCloseButton={false}
             centered
-            size="sm"
             padding={0}
+            size="auto"
             styles={{
                 body: { padding: 0 },
-                content: { overflow: 'hidden' },
+                content: {
+                    overflow: 'hidden',
+                    // Fit viewport, cap at TCGdex native resolution (600×825)
+                    maxWidth: 'min(600px, 90vw)',
+                    maxHeight: 'min(865px, 95dvh)', // 825px image + ~40px header
+                },
             }}
         >
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px' }}>
@@ -107,7 +112,12 @@ const CardImageModal: React.FC<CardImageModalProps> = ({ opened, cards, currentI
                 <img
                     src={card.imageUrl}
                     alt={card.cardName}
-                    style={{ maxWidth: '100%', borderRadius: 4 }}
+                    style={{
+                        maxWidth: '100%',
+                        maxHeight: 'calc(min(865px, 95dvh) - 48px)', // viewport cap minus header
+                        objectFit: 'contain',
+                        borderRadius: 4,
+                    }}
                 />
                 <UnstyledButton
                     onClick={() => navigate(1)}

--- a/assets/components/CardMosaicGrid.tsx
+++ b/assets/components/CardMosaicGrid.tsx
@@ -11,9 +11,8 @@
  * @see docs/features.md F2.23 — Interactive card mosaic with responsive grid and image modal
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { CloseButton, Modal, Text, UnstyledButton } from '@mantine/core';
-import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import React, { useCallback, useMemo, useState } from 'react';
+import CardImageModal, { type FlatCard } from './CardImageModal';
 
 interface CardData {
     cardName: string;
@@ -30,10 +29,7 @@ interface CardMosaicGridProps {
     mosaicAltLabel: string;
 }
 
-interface FlatCard {
-    cardName: string;
-    quantity: number;
-    imageUrl: string;
+interface MosaicCard extends FlatCard {
     lowResUrl: string;
 }
 
@@ -54,104 +50,6 @@ function toLowRes(imageUrl: string): string {
 }
 
 /**
- * Card image gallery modal — swipeable viewer with prev/next navigation.
- */
-const CardImageModal: React.FC<{
-    opened: boolean;
-    cards: FlatCard[];
-    currentIndex: number;
-    onClose: () => void;
-    onNavigate: (index: number) => void;
-}> = ({ opened, cards, currentIndex, onClose, onNavigate }) => {
-    const touchStartX = useRef(0);
-    const touchStartY = useRef(0);
-
-    const card = cards[currentIndex];
-
-    const navigate = useCallback((direction: number) => {
-        onNavigate((currentIndex + direction + cards.length) % cards.length);
-    }, [currentIndex, cards.length, onNavigate]);
-
-    useEffect(() => {
-        if (!opened) return;
-
-        const handleKeyDown = (event: KeyboardEvent): void => {
-            if (event.key === 'ArrowLeft') navigate(-1);
-            if (event.key === 'ArrowRight') navigate(1);
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [opened, navigate]);
-
-    if (!card) return null;
-
-    const title = `${card.quantity} \u00d7 ${card.cardName}`;
-
-    return (
-        <Modal
-            opened={opened}
-            onClose={onClose}
-            withCloseButton={false}
-            centered
-            size="sm"
-            padding={0}
-            styles={{
-                body: { padding: 0 },
-                content: { overflow: 'hidden' },
-            }}
-        >
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px' }}>
-                <Text size="sm" fw={500} style={{ flex: 1 }}>{title}</Text>
-                <Text size="xs" c="dimmed" style={{ marginRight: 8 }}>
-                    {currentIndex + 1} / {cards.length}
-                </Text>
-                <CloseButton onClick={onClose} />
-            </div>
-            <div
-                style={{ position: 'relative', textAlign: 'center', padding: '0 8px 8px' }}
-                onTouchStart={(event) => {
-                    touchStartX.current = event.touches[0].clientX;
-                    touchStartY.current = event.touches[0].clientY;
-                }}
-                onTouchMove={(event) => {
-                    const deltaX = Math.abs(event.touches[0].clientX - touchStartX.current);
-                    const deltaY = Math.abs(event.touches[0].clientY - touchStartY.current);
-                    if (deltaY > deltaX) {
-                        event.preventDefault();
-                    }
-                }}
-                onTouchEnd={(event) => {
-                    const deltaX = event.changedTouches[0].clientX - touchStartX.current;
-                    if (Math.abs(deltaX) > 50) {
-                        navigate(deltaX < 0 ? 1 : -1);
-                    }
-                }}
-            >
-                <UnstyledButton
-                    onClick={() => navigate(-1)}
-                    style={{ position: 'absolute', left: 4, top: '50%', transform: 'translateY(-50%)', zIndex: 1 }}
-                >
-                    <IconChevronLeft size={28} />
-                </UnstyledButton>
-                <img
-                    src={card.imageUrl}
-                    alt={card.cardName}
-                    style={{ maxWidth: '100%', borderRadius: 4 }}
-                />
-                <UnstyledButton
-                    onClick={() => navigate(1)}
-                    style={{ position: 'absolute', right: 4, top: '50%', transform: 'translateY(-50%)', zIndex: 1 }}
-                >
-                    <IconChevronRight size={28} />
-                </UnstyledButton>
-            </div>
-        </Modal>
-    );
-};
-
-/**
  * Interactive card mosaic grid — responsive 6-col (desktop) / 3-col (mobile)
  * grid of low-res card thumbnails with quantity badges and click-to-zoom modal.
  */
@@ -159,8 +57,8 @@ export default function CardMosaicGrid({ groupedCards, mosaicAltLabel }: CardMos
     const [modalOpen, setModalOpen] = useState(false);
     const [modalIndex, setModalIndex] = useState(0);
 
-    const flatCards: FlatCard[] = useMemo(() => {
-        const entries: FlatCard[] = [];
+    const flatCards: MosaicCard[] = useMemo(() => {
+        const entries: MosaicCard[] = [];
 
         for (const section of SECTION_ORDER) {
             for (const card of groupedCards[section] ?? []) {

--- a/assets/components/DeckCardList.tsx
+++ b/assets/components/DeckCardList.tsx
@@ -16,21 +16,18 @@
  * @see docs/features.md F2.23 — Interactive card mosaic with responsive grid
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
     ActionIcon,
-    CloseButton,
     Group,
     Loader,
-    Modal,
     SegmentedControl,
     Table,
     Text,
     Tooltip,
-    UnstyledButton,
 } from '@mantine/core';
-import { useMediaQuery } from '@mantine/hooks';
-import { IconCopy, IconCheck, IconShare, IconShoppingCart, IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import { IconCopy, IconCheck, IconShare, IconShoppingCart } from '@tabler/icons-react';
+import CardImageModal, { type FlatCard } from './CardImageModal';
 import CardMosaicGrid from './CardMosaicGrid';
 
 interface CardData {
@@ -82,175 +79,21 @@ type Variant = 'original' | 'minified';
 type ViewMode = 'table' | 'mosaic';
 
 /**
- * Card image gallery modal — mobile swipeable viewer with prev/next navigation.
- *
- * @see docs/features.md F6.2 — TCGdex card data enrichment
+ * Clickable card name — opens the card image modal on click.
  */
-const CardImageModal: React.FC<{
-    opened: boolean;
-    cards: CardEntry[];
-    currentIndex: number;
-    onClose: () => void;
-    onNavigate: (index: number) => void;
-}> = ({ opened, cards, currentIndex, onClose, onNavigate }) => {
-    const touchStartX = useRef(0);
-    const touchStartY = useRef(0);
-
-    const card = cards[currentIndex];
-
-    const navigate = useCallback((direction: number) => {
-        onNavigate((currentIndex + direction + cards.length) % cards.length);
-    }, [currentIndex, cards.length, onNavigate]);
-
-    useEffect(() => {
-        if (!opened) return;
-
-        const handleKeyDown = (event: KeyboardEvent): void => {
-            if (event.key === 'ArrowLeft') navigate(-1);
-            if (event.key === 'ArrowRight') navigate(1);
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [opened, navigate]);
-
-    if (!card) return null;
-
-    const title = `${card.quantity} \u00d7 ${card.name}`;
-
-    return (
-        <Modal
-            opened={opened}
-            onClose={onClose}
-            withCloseButton={false}
-            centered
-            size="sm"
-            padding={0}
-            styles={{
-                body: { padding: 0 },
-                content: { overflow: 'hidden' },
-            }}
-        >
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px' }}>
-                <Text size="sm" fw={500} style={{ flex: 1 }}>{title}</Text>
-                <Text size="xs" c="dimmed" style={{ marginRight: 8 }}>
-                    {currentIndex + 1} / {cards.length}
-                </Text>
-                <CloseButton onClick={onClose} />
-            </div>
-            <div
-                style={{ position: 'relative', textAlign: 'center', padding: '0 8px 8px' }}
-                onTouchStart={(event) => {
-                    touchStartX.current = event.touches[0].clientX;
-                    touchStartY.current = event.touches[0].clientY;
-                }}
-                onTouchMove={(event) => {
-                    const deltaX = Math.abs(event.touches[0].clientX - touchStartX.current);
-                    const deltaY = Math.abs(event.touches[0].clientY - touchStartY.current);
-                    if (deltaY > deltaX) {
-                        event.preventDefault();
-                    }
-                }}
-                onTouchEnd={(event) => {
-                    const deltaX = event.changedTouches[0].clientX - touchStartX.current;
-                    if (Math.abs(deltaX) > 50) {
-                        navigate(deltaX < 0 ? 1 : -1);
-                    }
-                }}
-            >
-                <UnstyledButton
-                    onClick={() => navigate(-1)}
-                    style={{ position: 'absolute', left: 4, top: '50%', transform: 'translateY(-50%)', zIndex: 1 }}
-                >
-                    <IconChevronLeft size={28} />
-                </UnstyledButton>
-                <img
-                    src={card.imageUrl}
-                    alt={card.name}
-                    style={{ maxWidth: '100%', borderRadius: 4 }}
-                />
-                <UnstyledButton
-                    onClick={() => navigate(1)}
-                    style={{ position: 'absolute', right: 4, top: '50%', transform: 'translateY(-50%)', zIndex: 1 }}
-                >
-                    <IconChevronRight size={28} />
-                </UnstyledButton>
-            </div>
-        </Modal>
-    );
-};
-
-interface CardEntry {
-    imageUrl: string;
-    name: string;
-    quantity: number;
-}
-
-/**
- * Card hover preview — shows card image on mouse hover (desktop) or tap (mobile modal).
- */
-const CardName: React.FC<{ card: CardData; onMobileTap?: () => void }> = ({ card, onMobileTap }) => {
-    const [showPreview, setShowPreview] = useState(false);
-    const spanRef = useRef<HTMLSpanElement>(null);
-    const imgRef = useRef<HTMLImageElement>(null);
-    const isMobile = useMediaQuery('(max-width: 767px)');
-
-    const handleMouseEnter = useCallback(() => {
-        if (!spanRef.current || !imgRef.current) return;
-
-        const rect = spanRef.current.getBoundingClientRect();
-        const imgHeight = Math.min(Math.max(280, window.innerHeight / 3), 672);
-        const imgWidth = imgHeight / 1.4;
-
-        let top: number;
-        if (rect.top >= imgHeight + 8) {
-            top = rect.top - imgHeight;
-        } else {
-            top = rect.bottom + 4;
-        }
-
-        top = Math.max(4, Math.min(top, window.innerHeight - imgHeight - 4));
-
-        let left = rect.left;
-        if (left + imgWidth > window.innerWidth - 4) {
-            left = window.innerWidth - imgWidth - 4;
-        }
-        left = Math.max(4, left);
-
-        // Set position imperatively before showing to avoid flicker
-        imgRef.current.style.top = `${top}px`;
-        imgRef.current.style.left = `${left}px`;
-
-        setShowPreview(true);
-    }, []);
-
-    if (!card.imageUrl) {
+const CardName: React.FC<{ card: CardData; onClick?: () => void }> = ({ card, onClick }) => {
+    if (!card.imageUrl || !onClick) {
         return <>{card.cardName}</>;
     }
 
     return (
-        <span
-            ref={spanRef}
-            className="card-hover"
-            data-quantity={card.quantity}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={() => setShowPreview(false)}
-            onClick={(event) => {
-                if (isMobile && onMobileTap) {
-                    event.preventDefault();
-                    onMobileTap();
-                }
-            }}
-        >
+        <span className="card-name-link" role="button" tabIndex={0} onClick={onClick} onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onClick();
+            }
+        }}>
             {card.cardName}
-            <img
-                ref={imgRef}
-                className="card-hover-img"
-                src={card.imageUrl}
-                alt={card.cardName}
-                style={{ display: showPreview ? 'block' : undefined }}
-            />
         </span>
     );
 };
@@ -262,8 +105,8 @@ const CardSection: React.FC<{
     label: string;
     cards: CardData[];
     tableLabels: { qty: string; card: string; set: string };
-    onCardTap?: (card: CardData) => void;
-}> = ({ label, cards, tableLabels, onCardTap }) => (
+    onCardClick?: (card: CardData) => void;
+}> = ({ label, cards, tableLabels, onCardClick }) => (
     <div className="card shadow-sm">
         <div className="card-header card-header-themed">
             <h5 className="mb-0">{label}</h5>
@@ -283,7 +126,7 @@ const CardSection: React.FC<{
                         <Table.Tr key={`${card.cardName}-${card.setCode}-${card.cardNumber}-${index}`}>
                             <Table.Td>{card.quantity}</Table.Td>
                             <Table.Td>
-                                <CardName card={card} onMobileTap={onCardTap ? () => onCardTap(card) : undefined} />
+                                <CardName card={card} onClick={onCardClick ? () => onCardClick(card) : undefined} />
                             </Table.Td>
                             <Table.Td><code>{card.setCode}</code></Table.Td>
                             <Table.Td>{card.cardNumber}</Table.Td>
@@ -301,8 +144,8 @@ const CardSection: React.FC<{
 const CardTable: React.FC<{
     groupedCards: Record<string, CardData[]>;
     labels: Labels;
-    onCardTap?: (card: CardData) => void;
-}> = ({ groupedCards, labels, onCardTap }) => {
+    onCardClick?: (card: CardData) => void;
+}> = ({ groupedCards, labels, onCardClick }) => {
     const pokemonCards = groupedCards.pokemon ?? [];
     const trainerCards = groupedCards.trainer ?? [];
     const energyCards = groupedCards.energy ?? [];
@@ -314,21 +157,21 @@ const CardTable: React.FC<{
         <div className="row">
             <div className="col-md-6 mb-3">
                 {pokemonCards.length > 0 && (
-                    <CardSection label={labels.sectionPokemon} cards={pokemonCards} tableLabels={tableLabels} onCardTap={onCardTap} />
+                    <CardSection label={labels.sectionPokemon} cards={pokemonCards} tableLabels={tableLabels} onCardClick={onCardClick} />
                 )}
                 {energyInLeft && energyCards.length > 0 && (
                     <div className="mt-3">
-                        <CardSection label={labels.sectionEnergy} cards={energyCards} tableLabels={tableLabels} onCardTap={onCardTap} />
+                        <CardSection label={labels.sectionEnergy} cards={energyCards} tableLabels={tableLabels} onCardClick={onCardClick} />
                     </div>
                 )}
             </div>
             <div className="col-md-6 mb-3">
                 {trainerCards.length > 0 && (
-                    <CardSection label={labels.sectionTrainer} cards={trainerCards} tableLabels={tableLabels} onCardTap={onCardTap} />
+                    <CardSection label={labels.sectionTrainer} cards={trainerCards} tableLabels={tableLabels} onCardClick={onCardClick} />
                 )}
                 {!energyInLeft && energyCards.length > 0 && (
                     <div className="mt-3">
-                        <CardSection label={labels.sectionEnergy} cards={energyCards} tableLabels={tableLabels} onCardTap={onCardTap} />
+                        <CardSection label={labels.sectionEnergy} cards={energyCards} tableLabels={tableLabels} onCardClick={onCardClick} />
                     </div>
                 )}
             </div>
@@ -394,14 +237,14 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
         ? minifiedList
         : rawList;
 
-    const flatCards: CardEntry[] = useMemo(() => {
-        const entries: CardEntry[] = [];
+    const flatCards: FlatCard[] = useMemo(() => {
+        const entries: FlatCard[] = [];
         const order = ['pokemon', 'trainer', 'energy'];
 
         for (const section of order) {
             for (const card of activeCards[section] ?? []) {
                 if (card.imageUrl) {
-                    entries.push({ imageUrl: card.imageUrl, name: card.cardName, quantity: card.quantity });
+                    entries.push({ imageUrl: card.imageUrl, cardName: card.cardName, quantity: card.quantity });
                 }
             }
         }
@@ -409,8 +252,8 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
         return entries;
     }, [activeCards]);
 
-    const handleCardTap = useCallback((card: CardData) => {
-        const index = flatCards.findIndex((entry) => entry.imageUrl === card.imageUrl && entry.name === card.cardName);
+    const handleCardClick = useCallback((card: CardData) => {
+        const index = flatCards.findIndex((entry) => entry.imageUrl === card.imageUrl && entry.cardName === card.cardName);
         if (index >= 0) {
             setCardModalIndex(index);
             setCardModalOpen(true);
@@ -565,7 +408,7 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
 
             {/* Table view */}
             {!isMinifiedPending && viewMode === 'table' && (
-                <CardTable groupedCards={activeCards} labels={labels} onCardTap={handleCardTap} />
+                <CardTable groupedCards={activeCards} labels={labels} onCardClick={handleCardClick} />
             )}
 
             {/* Interactive mosaic grid view */}

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -536,6 +536,28 @@ footer {
     }
 }
 
+// --- Clickable card name in table views ---
+// Subtle hover hint to indicate the card name opens the image modal.
+.card-name-link {
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-underline-offset: 2px;
+    transition: text-decoration-color .15s ease, color .15s ease;
+
+    &:hover,
+    &:focus-visible {
+        text-decoration-color: currentcolor;
+        color: var(--bs-primary);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--bs-primary);
+        outline-offset: 2px;
+        border-radius: 2px;
+    }
+}
+
 // --- Interactive card mosaic grid ---
 // Responsive grid of card thumbnails with quantity badges.
 // @see docs/features.md F2.23


### PR DESCRIPTION
## Summary

- **Extracted `CardImageModal` to a shared component** — deduplicated the modal from `DeckCardList`, `CardMosaicGrid`, and added it to `ArchetypeVariantSelector`. All three now import from `CardImageModal.tsx`.
- **Replaced hover preview with click-to-modal** — card names in table views (both deck detail and archetype variant) now open the image modal on click instead of showing a floating hover preview. Works consistently on desktop and mobile.
- **Subtle hover hint** — `.card-name-link` class with transparent-to-visible underline transition on hover signals clickability without looking like a hyperlink at rest.
- **Responsive modal sizing** — modal uses `size="auto"` with `maxWidth: min(600px, 90vw)` and `maxHeight: min(865px, 95dvh)`, capped at the TCGdex native resolution (600×825px). Image fills available space with `object-fit: contain` — no cropping on any device.
- **Removed legacy card-hover dependency** from the archetype variant table view (still used for `[[card:...]]` tags in server-rendered description HTML).

## Test plan

- [ ] Open a deck detail page in table view → click a card name → verify modal opens with high-res image
- [ ] Verify hover on card names shows a subtle underline hint (desktop)
- [ ] Verify keyboard navigation works (Enter to open, arrows to navigate, Escape to close)
- [ ] On mobile → tap a card name → verify modal opens and fits the screen
- [ ] On a large desktop monitor → verify modal caps at 600×825 and doesn't stretch beyond
- [ ] Open an archetype page → table view → click a card name → verify modal opens
- [ ] Verify mosaic grid click-to-modal still works on both pages
- [ ] Verify `[[card:...]]` tags in archetype descriptions still show hover preview (legacy card-hover.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)