### PR TITLE
:sparkles: Feature: expansion set boundary & outdated variant flag

### DIFF
--- a/assets/archetype-variants.tsx
+++ b/assets/archetype-variants.tsx
@@ -33,6 +33,8 @@ if (root) {
         moreVariants: root.dataset.labelMoreVariants ?? 'More variants\u2026',
         copyList: root.dataset.labelCopyList ?? 'Copy list',
         copied: root.dataset.labelCopied ?? 'Copied!',
+        outdatedBadge: root.dataset.labelOutdatedBadge ?? 'Outdated variant',
+        shareMosaic: root.dataset.labelShareMosaic ?? 'Share mosaic',
     };
 
     createRoot(root).render(

--- a/assets/archetype-variants.tsx
+++ b/assets/archetype-variants.tsx
@@ -35,6 +35,7 @@ if (root) {
         copied: root.dataset.labelCopied ?? 'Copied!',
         outdatedBadge: root.dataset.labelOutdatedBadge ?? 'Outdated variant',
         shareMosaic: root.dataset.labelShareMosaic ?? 'Share mosaic',
+        enrichmentPending: root.dataset.labelEnrichmentPending ?? 'Card data is being generated…',
     };
 
     createRoot(root).render(

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -7,9 +7,10 @@
  * file that was distributed with this source code.
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Button, CopyButton, Group, Select, SegmentedControl, Stack } from '@mantine/core';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ActionIcon, Button, CopyButton, Group, Select, SegmentedControl, Stack, Tooltip } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
+import { IconShare } from '@tabler/icons-react';
 import { initCardHover } from '../shared/card-hover';
 import CardImageModal, { type FlatCard } from './CardImageModal';
 import CardMosaicGrid from './CardMosaicGrid';
@@ -32,6 +33,9 @@ interface VariantData {
     id: number;
     name: string;
     canonical: boolean;
+    outdated: boolean;
+    latestSetCode: string | null;
+    latestSetName: string | null;
     sprites: string[];
     description: string | null;
     mosaicUrl: string | null;
@@ -52,6 +56,8 @@ interface Labels {
     moreVariants: string;
     copyList: string;
     copied: string;
+    outdatedBadge: string;
+    shareMosaic: string;
 }
 
 interface ArchetypeVariantSelectorProps {
@@ -182,15 +188,21 @@ function DesktopSelector({ variants, selectedIndex, onSelect }: {
                     radius="xl"
                     onClick={() => onSelect(index)}
                     leftSection={variant.sprites.length > 0 ? <SpriteList slugs={variant.sprites} height={22} /> : undefined}
+                    opacity={variant.outdated && index !== selectedIndex ? 0.5 : 1}
                 >
-                    {variant.name}
+                    {variant.outdated && variant.latestSetCode && (
+                        <span className="badge bg-secondary" style={{ marginRight: 6, fontStyle: 'normal', fontSize: '0.7em' }}>{variant.latestSetCode}</span>
+                    )}
+                    <span style={variant.outdated ? { fontStyle: 'italic' } : undefined}>{variant.name}</span>
                 </Button>
             ))}
             {dropdownVariants.length > 0 && (
                 <Select
                     data={dropdownVariants.map((variant, index) => ({
                         value: String(MAX_BUTTONS + index),
-                        label: variant.name,
+                        label: variant.outdated && variant.latestSetCode
+                            ? `${variant.latestSetCode} ${variant.name}`
+                            : variant.name,
                     }))}
                     value={selectedIndex >= MAX_BUTTONS ? String(selectedIndex) : null}
                     onChange={(value) => {
@@ -219,7 +231,9 @@ function MobileSelector({ variants, selectedIndex, onSelect }: {
         <Select
             data={variants.map((variant, index) => ({
                 value: String(index),
-                label: variant.name,
+                label: variant.outdated && variant.latestSetCode
+                    ? `${variant.latestSetCode} ${variant.name}`
+                    : variant.name,
             }))}
             value={String(selectedIndex)}
             onChange={(value) => {
@@ -284,6 +298,34 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
         }
     };
 
+    const handleShareMosaic = useCallback(async () => {
+        const mosaicUrl = selectedVariant?.mosaicUrl;
+        if (!mosaicUrl) return;
+
+        if (navigator.share) {
+            try {
+                const response = await fetch(mosaicUrl);
+                const blob = await response.blob();
+                const file = new File([blob], 'deck-mosaic.png', { type: 'image/png' });
+                await navigator.share({ files: [file] });
+
+                return;
+            } catch {
+                // Share cancelled or not supported with files
+            }
+
+            try {
+                await navigator.share({ title: labels.mosaicAlt, url: mosaicUrl });
+
+                return;
+            } catch {
+                // Share cancelled — fall back to clipboard
+            }
+        }
+
+        await navigator.clipboard.writeText(window.location.origin + mosaicUrl);
+    }, [selectedVariant?.mosaicUrl, labels.mosaicAlt]);
+
     // Re-initialize card hover after every render — description HTML contains
     // .card-hover elements from [[card:...]] tags, and they get recreated on
     // variant switch via dangerouslySetInnerHTML. Use requestAnimationFrame
@@ -313,6 +355,17 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                 </div>
             )}
 
+            {/* Outdated badge */}
+            {selectedVariant.outdated && selectedVariant.latestSetCode && (
+                <div className="alert alert-secondary py-2 px-3 mb-3 d-flex align-items-center gap-2" role="status">
+                    <span className="badge bg-secondary">{selectedVariant.latestSetCode}</span>
+                    <span className="text-muted small">
+                        {selectedVariant.latestSetName && <>{selectedVariant.latestSetName} — </>}
+                        {labels.outdatedBadge}
+                    </span>
+                </div>
+            )}
+
             {/* Description */}
             {selectedVariant.description && (
                 <div className="cms-content mb-3" dangerouslySetInnerHTML={{ __html: selectedVariant.description }} />
@@ -331,20 +384,29 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                             ]}
                             size="xs"
                         />
-                        {selectedVariant.rawList && (
-                            <CopyButton value={selectedVariant.rawList} timeout={2000}>
-                                {({ copied, copy }) => (
-                                    <Button
-                                        variant={copied ? 'filled' : 'outline'}
-                                        color={copied ? 'teal' : 'gray'}
-                                        size="sm"
-                                        onClick={copy}
-                                    >
-                                        {copied ? labels.copied : labels.copyList}
-                                    </Button>
-                                )}
-                            </CopyButton>
-                        )}
+                        <Group gap="xs">
+                            {selectedVariant.rawList && (
+                                <CopyButton value={selectedVariant.rawList} timeout={2000}>
+                                    {({ copied, copy }) => (
+                                        <Button
+                                            variant={copied ? 'filled' : 'outline'}
+                                            color={copied ? 'teal' : 'gray'}
+                                            size="sm"
+                                            onClick={copy}
+                                        >
+                                            {copied ? labels.copied : labels.copyList}
+                                        </Button>
+                                    )}
+                                </CopyButton>
+                            )}
+                            {selectedVariant.mosaicUrl && (
+                                <Tooltip label={labels.shareMosaic}>
+                                    <ActionIcon variant="subtle" color="gray" size="lg" onClick={handleShareMosaic}>
+                                        <IconShare size={18} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                        </Group>
                     </Group>
 
                     {viewMode === 'table' && (

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActionIcon, Button, CopyButton, Group, Select, SegmentedControl, Stack, Tooltip } from '@mantine/core';
+import { ActionIcon, Button, CopyButton, Group, Loader, Select, SegmentedControl, Stack, Text, Tooltip } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { IconShare } from '@tabler/icons-react';
 import { initCardHover } from '../shared/card-hover';
@@ -36,6 +36,7 @@ interface VariantData {
     outdated: boolean;
     latestSetCode: string | null;
     latestSetName: string | null;
+    enrichmentPending: boolean;
     sprites: string[];
     description: string | null;
     mosaicUrl: string | null;
@@ -58,6 +59,7 @@ interface Labels {
     copied: string;
     outdatedBadge: string;
     shareMosaic: string;
+    enrichmentPending: string;
 }
 
 interface ArchetypeVariantSelectorProps {
@@ -409,11 +411,20 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                         </Group>
                     </Group>
 
-                    {viewMode === 'table' && (
+                    {selectedVariant.enrichmentPending && (
+                        <div className="card shadow-sm">
+                            <div className="card-body text-center py-5">
+                                <Loader size="sm" className="mb-2" />
+                                <Text size="sm" c="dimmed">{labels.enrichmentPending}</Text>
+                            </div>
+                        </div>
+                    )}
+
+                    {!selectedVariant.enrichmentPending && viewMode === 'table' && (
                         <CardTable groupedCards={selectedVariant.groupedCards} labels={labels} onCardClick={handleCardClick} />
                     )}
 
-                    {viewMode === 'mosaic' && (
+                    {!selectedVariant.enrichmentPending && viewMode === 'mosaic' && (
                         <CardMosaicGrid
                             groupedCards={selectedVariant.groupedCards}
                             mosaicAltLabel={`${labels.mosaicAlt} \u2014 ${selectedVariant.name}`}

--- a/migrations/Version20260415203227.php
+++ b/migrations/Version20260415203227.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add latest_set_id foreign key on deck table.
+ *
+ * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+ */
+final class Version20260415203227 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add latest_set_id (ManyToOne → tcgdex_set) on deck table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE deck ADD latest_set_id VARCHAR(20) DEFAULT NULL');
+        $this->addSql('ALTER TABLE deck ADD CONSTRAINT FK_4FAC3637C46FBE9A FOREIGN KEY (latest_set_id) REFERENCES tcgdex_set (id)');
+        $this->addSql('CREATE INDEX IDX_4FAC3637C46FBE9A ON deck (latest_set_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE deck DROP FOREIGN KEY FK_4FAC3637C46FBE9A');
+        $this->addSql('DROP INDEX IDX_4FAC3637C46FBE9A ON deck');
+        $this->addSql('ALTER TABLE deck DROP latest_set_id');
+    }
+}

--- a/src/Controller/AdminArchetypeController.php
+++ b/src/Controller/AdminArchetypeController.php
@@ -18,6 +18,7 @@ use App\Entity\ArchetypeTranslation;
 use App\Entity\Deck;
 use App\Entity\DeckCard;
 use App\Entity\DeckVersion;
+use App\Enum\DeckStatus;
 use App\Form\ArchetypeFormType;
 use App\Form\ArchetypeTranslationFormType;
 use App\Form\ArchetypeVariantFormType;
@@ -277,6 +278,7 @@ class AdminArchetypeController extends AbstractAppController
         if ($form->isSubmitted() && $form->isValid()) {
             $this->handleVariantPokemonSlugs($form, $deck);
             $this->handleCanonicalToggle($deck, $archetype);
+            $this->handleOutdatedToggle($form, $deck);
             $this->em->persist($deck);
             $this->em->flush();
 
@@ -319,11 +321,16 @@ class AdminArchetypeController extends AbstractAppController
                 'deckId' => $deckId,
             ]),
         ]);
+
+        // Pre-fill the unmapped outdated checkbox from the entity status
+        $form->get('outdated')->setData($deck->isOutdated());
+
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->handleVariantPokemonSlugs($form, $deck);
             $this->handleCanonicalToggle($deck, $archetype);
+            $this->handleOutdatedToggle($form, $deck);
             $this->em->flush();
 
             $this->handleVariantRawList($form, $deck, $parser, $versionRepository, $messageBus);
@@ -364,6 +371,82 @@ class AdminArchetypeController extends AbstractAppController
         $this->addFlash('success', 'app.archetype.variant.deleted', ['%name%' => $deck->getName()]);
 
         return $this->redirectToRoute('app_admin_archetype_edit', ['id' => $archetype->getId()]);
+    }
+
+    /**
+     * Duplicate an archetype variant: copies name (prefixed), notes, sprites,
+     * latest set, and re-parses the raw list to create a fresh DeckVersion.
+     *
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    #[Route('/{id}/variants/{deckId}/duplicate', name: 'app_admin_archetype_variant_duplicate', methods: ['POST'], requirements: ['id' => '\d+', 'deckId' => '\d+'])]
+    public function duplicateVariant(
+        Request $request,
+        Archetype $archetype,
+        int $deckId,
+        DeckRepository $deckRepository,
+        DeckListParser $parser,
+        DeckVersionRepository $versionRepository,
+        MessageBusInterface $messageBus,
+    ): Response {
+        $source = $deckRepository->find($deckId);
+        if (!$source instanceof Deck || !$source->isArchetypeVariant() || $source->getArchetype()?->getId() !== $archetype->getId()) {
+            throw $this->createNotFoundException();
+        }
+
+        if (!$this->isCsrfTokenValid('variant-duplicate-'.$deckId, $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_archetype_edit', ['id' => $archetype->getId()]);
+        }
+
+        $copy = new Deck();
+        $copy->setArchetype($archetype);
+        $copy->setFormat($source->getFormat());
+        $copy->setName($this->translator->trans('app.archetype.variant.copy_prefix', ['%name%' => $source->getName()]));
+        $copy->setNotes($source->getNotes());
+        $copy->setPokemonSlugs($source->getPokemonSlugs());
+        $copy->setLatestSet($source->getLatestSet());
+
+        $this->em->persist($copy);
+        $this->em->flush();
+
+        // Re-parse the raw list to create a fresh DeckVersion with enrichment
+        $rawList = $source->getCurrentVersion()?->getRawList();
+        if (null !== $rawList && '' !== trim($rawList)) {
+            $nextVersion = $versionRepository->findMaxVersionNumber($copy) + 1;
+            $result = $parser->parse($rawList);
+
+            $version = new DeckVersion();
+            $version->setDeck($copy);
+            $version->setVersionNumber($nextVersion);
+            $version->setRawList($rawList);
+
+            foreach ($result->cards as $parsedCard) {
+                $card = new DeckCard();
+                $card->setCardName($parsedCard->cardName);
+                $card->setSetCode($parsedCard->setCode);
+                $card->setCardNumber($parsedCard->cardNumber);
+                $card->setQuantity($parsedCard->quantity);
+                $card->setCardType($parsedCard->cardType);
+                $version->addCard($card);
+            }
+
+            $this->em->persist($version);
+            $copy->setCurrentVersion($version);
+            $this->em->flush();
+
+            /** @var int $versionId */
+            $versionId = $version->getId();
+            $messageBus->dispatch(new EnrichDeckVersionMessage($versionId));
+        }
+
+        $this->addFlash('success', 'app.archetype.variant.duplicated', ['%name%' => $copy->getName()]);
+
+        return $this->redirectToRoute('app_admin_archetype_variant_edit', [
+            'id' => $archetype->getId(),
+            'deckId' => $copy->getId(),
+        ]);
     }
 
     /**
@@ -410,6 +493,24 @@ class AdminArchetypeController extends AbstractAppController
         }
 
         $queryBuilder->getQuery()->execute();
+    }
+
+    /**
+     * Sync the unmapped "outdated" checkbox with DeckStatus.
+     *
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     *
+     * @param FormInterface<Deck> $form
+     */
+    private function handleOutdatedToggle(FormInterface $form, Deck $deck): void
+    {
+        $isOutdated = (bool) $form->get('outdated')->getData();
+
+        if ($isOutdated) {
+            $deck->setStatus(DeckStatus::Outdated);
+        } elseif ($deck->isOutdated()) {
+            $deck->setStatus(DeckStatus::Available);
+        }
     }
 
     /**

--- a/src/Controller/AdminArchetypeController.php
+++ b/src/Controller/AdminArchetypeController.php
@@ -374,6 +374,73 @@ class AdminArchetypeController extends AbstractAppController
     }
 
     /**
+     * Re-parse and re-enrich a variant's current deck version.
+     */
+    #[Route('/{id}/variants/{deckId}/reenrich', name: 'app_admin_archetype_variant_reenrich', methods: ['POST'], requirements: ['id' => '\d+', 'deckId' => '\d+'])]
+    #[IsGranted('ROLE_TECHNICAL_ADMIN')]
+    public function reenrichVariant(
+        Request $request,
+        Archetype $archetype,
+        int $deckId,
+        DeckRepository $deckRepository,
+        DeckListParser $parser,
+        MessageBusInterface $messageBus,
+    ): Response {
+        $deck = $deckRepository->find($deckId);
+        if (!$deck instanceof Deck || !$deck->isArchetypeVariant() || $deck->getArchetype()?->getId() !== $archetype->getId()) {
+            throw $this->createNotFoundException();
+        }
+
+        if (!$this->isCsrfTokenValid('variant-reenrich-'.$deckId, $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_archetype_variant_edit', ['id' => $archetype->getId(), 'deckId' => $deckId]);
+        }
+
+        $version = $deck->getCurrentVersion();
+        if (null === $version || null === $version->getRawList() || '' === trim($version->getRawList())) {
+            $this->addFlash('warning', 'app.deck.reenrich.no_raw_list');
+
+            return $this->redirectToRoute('app_admin_archetype_variant_edit', ['id' => $archetype->getId(), 'deckId' => $deckId]);
+        }
+
+        foreach ($version->getCards() as $card) {
+            $version->removeCard($card);
+            $this->em->remove($card);
+        }
+
+        $this->em->flush();
+
+        $result = $parser->parse($version->getRawList());
+
+        foreach ($result->cards as $parsedCard) {
+            $card = new DeckCard();
+            $card->setCardName($parsedCard->cardName);
+            $card->setSetCode($parsedCard->setCode);
+            $card->setCardNumber($parsedCard->cardNumber);
+            $card->setQuantity($parsedCard->quantity);
+            $card->setCardType($parsedCard->cardType);
+            $version->addCard($card);
+        }
+
+        $version->setEnrichmentStatus('pending');
+        $version->setMosaicImageUrl(null);
+        $version->setMinifiedList(null);
+        $version->setMinifiedCardViews(null);
+        $version->setMinifiedMosaicImageUrl(null);
+
+        $this->em->flush();
+
+        /** @var int $versionId */
+        $versionId = $version->getId();
+        $messageBus->dispatch(new EnrichDeckVersionMessage($versionId));
+
+        $this->addFlash('success', 'app.deck.reenrich.dispatched');
+
+        return $this->redirectToRoute('app_admin_archetype_variant_edit', ['id' => $archetype->getId(), 'deckId' => $deckId]);
+    }
+
+    /**
      * Duplicate an archetype variant: copies name (prefixed), notes, sprites,
      * latest set, and re-parses the raw list to create a fresh DeckVersion.
      *

--- a/src/Controller/ArchetypeDetailController.php
+++ b/src/Controller/ArchetypeDetailController.php
@@ -149,10 +149,15 @@ class ArchetypeDetailController extends AbstractController
             /** @var int $variantId */
             $variantId = $variant->getId();
 
+            $latestSet = $variant->getLatestSet();
+
             $data[] = [
                 'id' => $variantId,
                 'name' => $variant->getName(),
                 'canonical' => $variant->isCanonical(),
+                'outdated' => $variant->isOutdated(),
+                'latestSetCode' => $latestSet?->getPtcgCode(),
+                'latestSetName' => $latestSet?->getLocalizedName($locale),
                 'sprites' => $variant->getPokemonSlugs(),
                 'description' => $htmlDescription,
                 'mosaicUrl' => $mosaicUrl,
@@ -160,6 +165,9 @@ class ArchetypeDetailController extends AbstractController
                 'groupedCards' => $orderedGroups,
             ];
         }
+
+        // Sort outdated variants after current ones, preserving relative order within each group.
+        usort($data, static fn (array $variantA, array $variantB): int => (int) $variantA['outdated'] <=> (int) $variantB['outdated']);
 
         return $data;
     }

--- a/src/Controller/ArchetypeDetailController.php
+++ b/src/Controller/ArchetypeDetailController.php
@@ -160,6 +160,7 @@ class ArchetypeDetailController extends AbstractController
                 'latestSetName' => $latestSet?->getLocalizedName($locale),
                 'sprites' => $variant->getPokemonSlugs(),
                 'description' => $htmlDescription,
+                'enrichmentPending' => null !== $version && 'done' !== $version->getEnrichmentStatus(),
                 'mosaicUrl' => $mosaicUrl,
                 'rawList' => $version?->getRawList(),
                 'groupedCards' => $orderedGroups,

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -66,6 +66,16 @@ class Deck
     private ?Archetype $archetype = null;
 
     /**
+     * The latest expansion set that defines the format boundary for this deck.
+     * E.g. SV08 means the deck is built with cards up to and including SV08.
+     *
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    #[ORM\ManyToOne(targetEntity: TcgdexSet::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?TcgdexSet $latestSet = null;
+
+    /**
      * Marks the primary/reference variant for an archetype.
      * Only meaningful for archetype variant decks (owner = null).
      *
@@ -318,6 +328,26 @@ class Deck
         $this->status = $status;
 
         return $this;
+    }
+
+    public function getLatestSet(): ?TcgdexSet
+    {
+        return $this->latestSet;
+    }
+
+    public function setLatestSet(?TcgdexSet $latestSet): static
+    {
+        $this->latestSet = $latestSet;
+
+        return $this;
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function isOutdated(): bool
+    {
+        return DeckStatus::Outdated === $this->status;
     }
 
     public function getNotes(): ?string

--- a/src/Enum/DeckStatus.php
+++ b/src/Enum/DeckStatus.php
@@ -22,4 +22,12 @@ enum DeckStatus: string
     case Reserved = 'reserved';
     case Lent = 'lent';
     case Retired = 'retired';
+
+    /**
+     * Marks an archetype variant as outdated (format rotation).
+     * Only applicable to archetype variants (decks with no owner).
+     *
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    case Outdated = 'outdated';
 }

--- a/src/Form/ArchetypeVariantFormType.php
+++ b/src/Form/ArchetypeVariantFormType.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Entity\Deck;
+use App\Entity\TcgdexSet;
+use App\Repository\TcgdexSetRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -53,6 +56,23 @@ class ArchetypeVariantFormType extends AbstractType
                     'rows' => 10,
                     'placeholder' => 'app.archetype.variant.raw_list_placeholder',
                 ],
+            ])
+            ->add('latestSet', EntityType::class, [
+                'class' => TcgdexSet::class,
+                'label' => 'app.archetype.variant.latest_set',
+                'required' => false,
+                'placeholder' => 'app.archetype.variant.latest_set_placeholder',
+                'query_builder' => static fn (TcgdexSetRepository $repository) => $repository->createExpandedSetsQueryBuilder(),
+                'choice_label' => static fn (TcgdexSet $set): string => \sprintf(
+                    '%s — %s',
+                    $set->getPtcgCode() ?? $set->getId(),
+                    $set->getLocalizedName() ?? $set->getId(),
+                ),
+            ])
+            ->add('outdated', CheckboxType::class, [
+                'label' => 'app.archetype.variant.outdated',
+                'required' => false,
+                'mapped' => false,
             ])
             ->add('notes', TextareaType::class, [
                 'label' => 'app.archetype.variant.description',

--- a/src/Form/DeckFormType.php
+++ b/src/Form/DeckFormType.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Entity\Deck;
+use App\Entity\TcgdexSet;
+use App\Repository\TcgdexSetRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -56,6 +59,18 @@ class DeckFormType extends AbstractType
             ->add('pokemonSlugs', HiddenType::class, [
                 'mapped' => false,
                 'required' => false,
+            ])
+            ->add('latestSet', EntityType::class, [
+                'class' => TcgdexSet::class,
+                'label' => 'app.form.label.latest_set',
+                'required' => false,
+                'placeholder' => 'app.form.placeholder.latest_set',
+                'query_builder' => static fn (TcgdexSetRepository $repository) => $repository->createExpandedSetsQueryBuilder(),
+                'choice_label' => static fn (TcgdexSet $set): string => \sprintf(
+                    '%s — %s',
+                    $set->getPtcgCode() ?? $set->getId(),
+                    $set->getLocalizedName() ?? $set->getId(),
+                ),
             ])
             ->add('public', CheckboxType::class, [
                 'label' => 'app.form.label.public',

--- a/src/Repository/TcgdexSetRepository.php
+++ b/src/Repository/TcgdexSetRepository.php
@@ -15,6 +15,7 @@ namespace App\Repository;
 
 use App\Entity\TcgdexSet;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -33,5 +34,59 @@ class TcgdexSetRepository extends ServiceEntityRepository
         $result = $this->findOneBy(['ptcgCode' => $ptcgCode]);
 
         return $result;
+    }
+
+    /** Series IDs that belong to the Expanded format (Black & White onward). */
+    private const array EXPANDED_SERIES = ['bw', 'xy', 'sm', 'swsh', 'sv', 'me'];
+
+    /**
+     * Base query builder for non-promo expansion sets in the Expanded era,
+     * ordered by release date descending.
+     *
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function createExpandedSetsQueryBuilder(): QueryBuilder
+    {
+        return $this->createQueryBuilder('s')
+            ->innerJoin('s.serie', 'serie')
+            ->where('s.releaseDate IS NOT NULL')
+            ->andWhere('s.ptcgCode IS NOT NULL')
+            ->andWhere('s.ptcgCode NOT LIKE :promoPrefix')
+            ->andWhere('serie.id IN (:expandedSeries)')
+            ->setParameter('promoPrefix', 'PR-%')
+            ->setParameter('expandedSeries', self::EXPANDED_SERIES)
+            ->orderBy('s.releaseDate', 'DESC');
+    }
+
+    /**
+     * Return all non-promo expansion sets from the Expanded era,
+     * ordered by release date descending (most recent first).
+     *
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     *
+     * @return list<TcgdexSet>
+     */
+    public function findExpansionSetsOrderedByReleaseDate(): array
+    {
+        /** @var list<TcgdexSet> $sets */
+        $sets = $this->createExpandedSetsQueryBuilder()
+            ->getQuery()
+            ->getResult();
+
+        return $sets;
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function findLatestExpansionSet(): ?TcgdexSet
+    {
+        /** @var TcgdexSet|null $set */
+        $set = $this->createExpandedSetsQueryBuilder()
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $set;
     }
 }

--- a/src/Service/CardImageResolver.php
+++ b/src/Service/CardImageResolver.php
@@ -46,9 +46,16 @@ class CardImageResolver
      *
      * @return string|false the image data on success, false on failure
      */
-    public function downloadImage(CardPrinting $printing): string|false
+    /**
+     * @param string $resolution 'high' for full resolution, 'low' for thumbnails
+     */
+    public function downloadImage(CardPrinting $printing, string $resolution = 'high'): string|false
     {
         $primaryUrl = $printing->getImageUrl();
+
+        if ('low' === $resolution && null !== $primaryUrl) {
+            $primaryUrl = str_replace('/high.webp', '/low.webp', $primaryUrl);
+        }
         $cardName = $printing->getCardIdentity()->getName();
 
         // Try primary URL

--- a/src/Service/EnrichmentFlushService.php
+++ b/src/Service/EnrichmentFlushService.php
@@ -35,9 +35,9 @@ class EnrichmentFlushService
 
     public function flush(): void
     {
-        // 1. Clear DeckCard enrichment fields and CardPrinting FK
+        // 1. Clear DeckCard → CardPrinting FK (enrichment data lives on CardPrinting)
         $this->connection->executeStatement(
-            'UPDATE deck_card SET tcgdex_id = NULL, image_url = NULL, trainer_subtype = NULL, card_printing_id = NULL',
+            'UPDATE deck_card SET card_printing_id = NULL',
         );
 
         // 2. Reset DeckVersion generated fields

--- a/src/Service/Mosaic/MosaicGenerator.php
+++ b/src/Service/Mosaic/MosaicGenerator.php
@@ -184,7 +184,7 @@ class MosaicGenerator
         // When a CardPrinting is available, use the fallback-aware resolver
         // which also persists working URLs on the printing entity.
         if (null !== $tile->printing) {
-            $imageData = $this->cardImageResolver->downloadImage($tile->printing);
+            $imageData = $this->cardImageResolver->downloadImage($tile->printing, 'low');
         } elseif (null !== $tile->imageUrl && '' !== $tile->imageUrl) {
             $imageData = @file_get_contents($tile->imageUrl);
         }
@@ -339,7 +339,7 @@ class MosaicGenerator
         if (null !== $imageUrlOverrides && null !== $cardId && isset($imageUrlOverrides[$cardId])) {
             $imageData = @file_get_contents($imageUrlOverrides[$cardId]);
         } elseif (null !== $printing) {
-            $imageData = $this->cardImageResolver->downloadImage($printing);
+            $imageData = $this->cardImageResolver->downloadImage($printing, 'low');
         } else {
             $imageData = false;
         }

--- a/src/Service/Mosaic/MosaicGenerator.php
+++ b/src/Service/Mosaic/MosaicGenerator.php
@@ -27,7 +27,7 @@ use Psr\Log\LoggerInterface;
  */
 class MosaicGenerator
 {
-    private const int CARDS_PER_ROW = 8;
+    private const int CARDS_PER_ROW = 6;
     private const int CARD_WIDTH = 245;
     private const int CARD_HEIGHT = 342;
     private const int PADDING = 12;

--- a/templates/admin/archetype/edit.html.twig
+++ b/templates/admin/archetype/edit.html.twig
@@ -134,11 +134,17 @@
                                         {% for slug in variant.effectivePokemonSlugs[:3] %}
                                             <img src="{{ asset('build/sprites/pokemon/' ~ slug ~ '.png') }}" alt="{{ slug }}" class="archetype-sprite" style="height: 24px;">
                                         {% endfor %}
+                                        {% if variant.latestSet %}
+                                            <span class="badge bg-light text-dark border">{{ variant.latestSet.ptcgCode }}</span>
+                                        {% endif %}
                                         {{ variant.name }}
                                     </td>
                                     <td>
                                         {% if variant.canonical %}
                                             <span class="badge bg-success">{{ 'app.archetype.variant.canonical'|trans }}</span>
+                                        {% endif %}
+                                        {% if variant.outdated %}
+                                            <span class="badge bg-secondary">{{ 'app.archetype.variant.outdated'|trans }}</span>
                                         {% endif %}
                                     </td>
                                     <td>
@@ -155,9 +161,15 @@
                                     </td>
                                     <td>{{ variant.createdAt|date('Y-m-d') }}</td>
                                     <td class="text-end">
-                                        <a href="{{ path('app_admin_archetype_variant_edit', {id: archetype.id, deckId: variant.id}) }}" class="btn btn-sm btn-outline-primary">
+                                        <a href="{{ path('app_admin_archetype_variant_edit', {id: archetype.id, deckId: variant.id}) }}" class="btn btn-sm btn-outline-primary" title="{{ 'app.common.edit'|trans }}">
                                             <i class="bi bi-pencil"></i>
                                         </a>
+                                        <form method="post" action="{{ path('app_admin_archetype_variant_duplicate', {id: archetype.id, deckId: variant.id}) }}" class="d-inline">
+                                            <input type="hidden" name="_token" value="{{ csrf_token('variant-duplicate-' ~ variant.id) }}">
+                                            <button type="submit" class="btn btn-sm btn-outline-secondary" title="{{ 'app.archetype.variant.duplicate'|trans }}">
+                                                <i class="bi bi-copy"></i>
+                                            </button>
+                                        </form>
                                         <form method="post" action="{{ path('app_admin_archetype_variant_delete', {id: archetype.id, deckId: variant.id}) }}" class="d-inline" onsubmit="return confirm('{{ 'app.archetype.variant.delete_confirm'|trans|e('js') }}')">
                                             <input type="hidden" name="_token" value="{{ csrf_token('variant-delete-' ~ variant.id) }}">
                                             <button type="submit" class="btn btn-sm btn-outline-danger">

--- a/templates/admin/archetype/variant_form.html.twig
+++ b/templates/admin/archetype/variant_form.html.twig
@@ -57,21 +57,11 @@
                 {{ form_row(form.rawList) }}
 
                 {% if not isNew and deck.currentVersion %}
-                    <div class="alert alert-info mb-3 d-flex justify-content-between align-items-center">
-                        <span>
-                            <strong>{{ 'app.archetype.variant.current_version'|trans }}:</strong>
-                            v{{ deck.currentVersion.versionNumber }}
-                            ({{ deck.currentVersion.enrichmentStatus }})
-                            — {{ 'app.archetype.variant.paste_to_replace'|trans }}
-                        </span>
-                        {% if is_granted('ROLE_TECHNICAL_ADMIN') %}
-                            <form method="post" action="{{ path('app_admin_archetype_variant_reenrich', {id: archetype.id, deckId: deck.id}) }}" class="d-inline ms-2">
-                                <input type="hidden" name="_token" value="{{ csrf_token('variant-reenrich-' ~ deck.id) }}">
-                                <button type="submit" class="btn btn-sm btn-outline-dark" title="{{ 'app.deck.reenrich.button'|trans }}">
-                                    <i class="bi bi-arrow-repeat"></i> {{ 'app.deck.reenrich.button'|trans }}
-                                </button>
-                            </form>
-                        {% endif %}
+                    <div class="alert alert-info mb-3">
+                        <strong>{{ 'app.archetype.variant.current_version'|trans }}:</strong>
+                        v{{ deck.currentVersion.versionNumber }}
+                        ({{ deck.currentVersion.enrichmentStatus }})
+                        — {{ 'app.archetype.variant.paste_to_replace'|trans }}
                     </div>
                 {% endif %}
 
@@ -80,6 +70,16 @@
 
                 <button type="submit" class="btn btn-gold mt-3">{{ 'app.common.save'|trans }}</button>
             {{ form_end(form) }}
+
+            {% if not isNew and deck.currentVersion and is_granted('ROLE_TECHNICAL_ADMIN') %}
+                <hr>
+                <form method="post" action="{{ path('app_admin_archetype_variant_reenrich', {id: archetype.id, deckId: deck.id}) }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('variant-reenrich-' ~ deck.id) }}">
+                    <button type="submit" class="btn btn-sm btn-outline-dark">
+                        <i class="bi bi-arrow-repeat"></i> {{ 'app.deck.reenrich.button'|trans }}
+                    </button>
+                </form>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/templates/admin/archetype/variant_form.html.twig
+++ b/templates/admin/archetype/variant_form.html.twig
@@ -51,6 +51,9 @@
                     {{ form_widget(form.pokemonSlugs) }}
                 </div>
 
+                {{ form_row(form.latestSet) }}
+                {{ form_row(form.outdated) }}
+
                 {{ form_row(form.rawList) }}
 
                 {% if not isNew and deck.currentVersion %}

--- a/templates/admin/archetype/variant_form.html.twig
+++ b/templates/admin/archetype/variant_form.html.twig
@@ -67,7 +67,7 @@
                         {% if is_granted('ROLE_TECHNICAL_ADMIN') %}
                             <form method="post" action="{{ path('app_admin_archetype_variant_reenrich', {id: archetype.id, deckId: deck.id}) }}" class="d-inline ms-2">
                                 <input type="hidden" name="_token" value="{{ csrf_token('variant-reenrich-' ~ deck.id) }}">
-                                <button type="submit" class="btn btn-sm btn-outline-warning" title="{{ 'app.deck.reenrich.button'|trans }}">
+                                <button type="submit" class="btn btn-sm btn-outline-dark" title="{{ 'app.deck.reenrich.button'|trans }}">
                                     <i class="bi bi-arrow-repeat"></i> {{ 'app.deck.reenrich.button'|trans }}
                                 </button>
                             </form>

--- a/templates/admin/archetype/variant_form.html.twig
+++ b/templates/admin/archetype/variant_form.html.twig
@@ -57,11 +57,21 @@
                 {{ form_row(form.rawList) }}
 
                 {% if not isNew and deck.currentVersion %}
-                    <div class="alert alert-info mb-3">
-                        <strong>{{ 'app.archetype.variant.current_version'|trans }}:</strong>
-                        v{{ deck.currentVersion.versionNumber }}
-                        ({{ deck.currentVersion.enrichmentStatus }})
-                        — {{ 'app.archetype.variant.paste_to_replace'|trans }}
+                    <div class="alert alert-info mb-3 d-flex justify-content-between align-items-center">
+                        <span>
+                            <strong>{{ 'app.archetype.variant.current_version'|trans }}:</strong>
+                            v{{ deck.currentVersion.versionNumber }}
+                            ({{ deck.currentVersion.enrichmentStatus }})
+                            — {{ 'app.archetype.variant.paste_to_replace'|trans }}
+                        </span>
+                        {% if is_granted('ROLE_TECHNICAL_ADMIN') %}
+                            <form method="post" action="{{ path('app_admin_archetype_variant_reenrich', {id: archetype.id, deckId: deck.id}) }}" class="d-inline ms-2">
+                                <input type="hidden" name="_token" value="{{ csrf_token('variant-reenrich-' ~ deck.id) }}">
+                                <button type="submit" class="btn btn-sm btn-outline-warning" title="{{ 'app.deck.reenrich.button'|trans }}">
+                                    <i class="bi bi-arrow-repeat"></i> {{ 'app.deck.reenrich.button'|trans }}
+                                </button>
+                            </form>
+                        {% endif %}
                     </div>
                 {% endif %}
 

--- a/templates/archetype/show.html.twig
+++ b/templates/archetype/show.html.twig
@@ -80,7 +80,8 @@
                          data-label-copy-list="{{ 'app.deck.export_copy_button'|trans }}"
                          data-label-copied="{{ 'app.deck.export_copied'|trans }}"
                          data-label-outdated-badge="{{ 'app.archetype.variant.outdated_badge'|trans }}"
-                         data-label-share-mosaic="{{ 'app.deck.share_mosaic'|trans }}">
+                         data-label-share-mosaic="{{ 'app.deck.share_mosaic'|trans }}"
+                         data-label-enrichment-pending="{{ 'app.deck.mosaic_generating'|trans }}">
                     </div>
                 </div>
             </div>

--- a/templates/archetype/show.html.twig
+++ b/templates/archetype/show.html.twig
@@ -78,7 +78,9 @@
                          data-label-table-set="{{ 'app.deck.table_set'|trans }}"
                          data-label-more-variants="{{ 'app.archetype.variant.more'|trans }}"
                          data-label-copy-list="{{ 'app.deck.export_copy_button'|trans }}"
-                         data-label-copied="{{ 'app.deck.export_copied'|trans }}">
+                         data-label-copied="{{ 'app.deck.export_copied'|trans }}"
+                         data-label-outdated-badge="{{ 'app.archetype.variant.outdated_badge'|trans }}"
+                         data-label-share-mosaic="{{ 'app.deck.share_mosaic'|trans }}">
                     </div>
                 </div>
             </div>

--- a/templates/deck/edit.html.twig
+++ b/templates/deck/edit.html.twig
@@ -59,6 +59,8 @@
                             {{ form_widget(form.languages) }}
                         </div>
 
+                        {{ form_row(form.latestSet) }}
+
                         <div class="mb-3">
                             {{ form_row(form.public) }}
                             {% if has_active_registrations is defined and has_active_registrations %}

--- a/tests/Entity/DeckTest.php
+++ b/tests/Entity/DeckTest.php
@@ -344,4 +344,47 @@ class DeckTest extends TestCase
 
         self::assertSame(3, $deck->getPosition());
     }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testIsOutdatedReturnsTrueWhenStatusIsOutdated(): void
+    {
+        $deck = new Deck();
+        $deck->setStatus(DeckStatus::Outdated);
+
+        self::assertTrue($deck->isOutdated());
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testIsOutdatedReturnsFalseForOtherStatuses(): void
+    {
+        $deck = new Deck();
+
+        self::assertFalse($deck->isOutdated());
+
+        $deck->setStatus(DeckStatus::Retired);
+        self::assertFalse($deck->isOutdated());
+
+        $deck->setStatus(DeckStatus::Available);
+        self::assertFalse($deck->isOutdated());
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testLatestSetGetterSetter(): void
+    {
+        $deck = new Deck();
+        self::assertNull($deck->getLatestSet());
+
+        $set = $this->createStub(\App\Entity\TcgdexSet::class);
+        $deck->setLatestSet($set);
+        self::assertSame($set, $deck->getLatestSet());
+
+        $deck->setLatestSet(null);
+        self::assertNull($deck->getLatestSet());
+    }
 }

--- a/tests/Functional/AdminArchetypeControllerTest.php
+++ b/tests/Functional/AdminArchetypeControllerTest.php
@@ -15,6 +15,7 @@ namespace App\Tests\Functional;
 
 use App\Entity\Archetype;
 use App\Entity\Deck;
+use App\Enum\DeckStatus;
 use App\Repository\DeckRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -509,6 +510,170 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
         ], '[1,2,3]');
 
         self::assertResponseStatusCodeSame(403);
+    }
+
+    // ---------------------------------------------------------------
+    // Expansion set boundary & outdated variant (F2.24)
+    // ---------------------------------------------------------------
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testOutdatedToggleSetsStatus(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $variant = $this->getVariantByName('Regidrago', $archetype);
+
+        $crawler = $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/'.$variant->getId());
+
+        $form = $crawler->selectButton('Save')->form();
+        $form['archetype_variant_form[outdated]']->tick();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+
+        $refreshed = $this->getVariantByName('Regidrago', $archetype);
+        self::assertSame(DeckStatus::Outdated, $refreshed->getStatus());
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testUntickOutdatedRevertsToAvailable(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $variant = $this->getVariantByName('Regidrago', $archetype);
+
+        // First set outdated
+        $crawler = $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/'.$variant->getId());
+        $form = $crawler->selectButton('Save')->form();
+        $form['archetype_variant_form[outdated]']->tick();
+        $this->client->submit($form);
+
+        // Now untick it
+        $crawler = $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/'.$variant->getId());
+        $form = $crawler->selectButton('Save')->form();
+        $form['archetype_variant_form[outdated]']->untick();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+
+        $refreshed = $this->getVariantByName('Regidrago', $archetype);
+        self::assertSame(DeckStatus::Available, $refreshed->getStatus());
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testDuplicateVariantCreatesNewDeck(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $variant = $this->getVariantByName('Regidrago', $archetype);
+
+        // Load the edit page to get a valid CSRF session
+        $crawler = $this->client->request('GET', '/admin/archetypes/'.$archetype->getId());
+
+        $duplicateForm = $crawler->filter('form[action*="variants/'.$variant->getId().'/duplicate"]');
+        self::assertGreaterThan(0, $duplicateForm->count(), 'Duplicate form for variant should exist.');
+
+        $form = $duplicateForm->form();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+
+        // Verify the copy exists
+        /** @var DeckRepository $deckRepository */
+        $deckRepository = static::getContainer()->get(DeckRepository::class);
+        $variants = $deckRepository->findVariantsByArchetype($archetype);
+        $copyNames = array_map(static fn (Deck $deck): string => $deck->getName(), $variants);
+        self::assertContains('Copy of Regidrago', $copyNames);
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testDuplicateVariantWithInvalidCsrfFails(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $variant = $this->getVariantByName('Regidrago', $archetype);
+
+        $this->client->request('POST', '/admin/archetypes/'.$archetype->getId().'/variants/'.$variant->getId().'/duplicate', [
+            '_token' => 'invalid-token',
+        ]);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-danger');
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testReenrichVariantRedirectsOnSuccess(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $variant = $this->getVariantByName('Regidrago', $archetype);
+
+        // Load the edit page to establish session + get CSRF
+        $crawler = $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/'.$variant->getId());
+
+        $reenrichForm = $crawler->filter('form[action*="reenrich"]');
+        self::assertGreaterThan(0, $reenrichForm->count(), 'Re-enrich form should exist for technical admin.');
+
+        $form = $reenrichForm->form();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testVariantFormShowsLatestSetField(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/new');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('select[name="archetype_variant_form[latestSet]"]');
+    }
+
+    /**
+     * @see docs/features.md F2.24 — Expansion set boundary & outdated variant flag
+     */
+    public function testVariantFormShowsOutdatedCheckbox(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+        $this->client->request('GET', '/admin/archetypes/'.$archetype->getId().'/variants/new');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('input[name="archetype_variant_form[outdated]"]');
     }
 
     private function getVariantByName(string $name, Archetype $archetype): Deck

--- a/tests/Service/EnrichmentFlushServiceTest.php
+++ b/tests/Service/EnrichmentFlushServiceTest.php
@@ -38,9 +38,6 @@ class EnrichmentFlushServiceTest extends TestCase
 
                 if (0 === $callIndex++) {
                     self::assertStringContainsString('deck_card', $sql);
-                    self::assertStringContainsString('tcgdex_id = NULL', $sql);
-                    self::assertStringContainsString('image_url = NULL', $sql);
-                    self::assertStringContainsString('trainer_subtype = NULL', $sql);
                     self::assertStringContainsString('card_printing_id = NULL', $sql);
                 }
 

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2349,6 +2349,16 @@
                 <target>Notes (optional)</target>
                 <note>Form label for notes textarea</note>
             </trans-unit>
+            <trans-unit id="app.form.label.latest_set">
+                <source>app.form.label.latest_set</source>
+                <target>Latest expansion set</target>
+                <note>Form label for expansion set selector on deck edit form</note>
+            </trans-unit>
+            <trans-unit id="app.form.placeholder.latest_set">
+                <source>app.form.placeholder.latest_set</source>
+                <target>Select an expansion set…</target>
+                <note>Placeholder for expansion set selector on deck edit form</note>
+            </trans-unit>
             <trans-unit id="app.form.label.public">
                 <source>app.form.label.public</source>
                 <target>Public (visible in deck catalog)</target>
@@ -3614,6 +3624,41 @@
                 <source>app.archetype.variant.paste_to_replace</source>
                 <target>Paste a new list above to create a new version</target>
                 <note>Help text for replacing existing decklist</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.latest_set">
+                <source>app.archetype.variant.latest_set</source>
+                <target>Latest expansion set</target>
+                <note>Label for expansion set selector on variant form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.latest_set_placeholder">
+                <source>app.archetype.variant.latest_set_placeholder</source>
+                <target>Select an expansion set…</target>
+                <note>Placeholder for expansion set selector</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.outdated">
+                <source>app.archetype.variant.outdated</source>
+                <target>Outdated</target>
+                <note>Label for outdated checkbox on variant form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.outdated_badge">
+                <source>app.archetype.variant.outdated_badge</source>
+                <target>Outdated variant</target>
+                <note>Badge text shown above the description for outdated variants</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.duplicate">
+                <source>app.archetype.variant.duplicate</source>
+                <target>Duplicate</target>
+                <note>Tooltip for duplicate variant button in admin</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.duplicated">
+                <source>app.archetype.variant.duplicated</source>
+                <target>Variant "%name%" duplicated.</target>
+                <note>Flash message after duplicating variant. %name% = new variant name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.copy_prefix">
+                <source>app.archetype.variant.copy_prefix</source>
+                <target>Copy of %name%</target>
+                <note>Name prefix for duplicated variant. %name% = source variant name</note>
             </trans-unit>
             <trans-unit id="app.archetype.variant.created">
                 <source>app.archetype.variant.created</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -2339,6 +2339,16 @@
                 <target>Notes (optionnel)</target>
                 <note>Form label for notes textarea</note>
             </trans-unit>
+            <trans-unit id="app.form.label.latest_set">
+                <source>app.form.label.latest_set</source>
+                <target>Extension la plus récente</target>
+                <note>Form label for expansion set selector on deck edit form</note>
+            </trans-unit>
+            <trans-unit id="app.form.placeholder.latest_set">
+                <source>app.form.placeholder.latest_set</source>
+                <target>Choisir une extension…</target>
+                <note>Placeholder for expansion set selector on deck edit form</note>
+            </trans-unit>
             <trans-unit id="app.form.label.public">
                 <source>app.form.label.public</source>
                 <target>Public (visible dans le catalogue de decks)</target>
@@ -3604,6 +3614,41 @@
                 <source>app.archetype.variant.paste_to_replace</source>
                 <target>Collez une nouvelle liste ci-dessus pour créer une nouvelle version</target>
                 <note>Help text for replacing existing decklist</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.latest_set">
+                <source>app.archetype.variant.latest_set</source>
+                <target>Extension la plus récente</target>
+                <note>Label for expansion set selector on variant form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.latest_set_placeholder">
+                <source>app.archetype.variant.latest_set_placeholder</source>
+                <target>Choisir une extension…</target>
+                <note>Placeholder for expansion set selector</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.outdated">
+                <source>app.archetype.variant.outdated</source>
+                <target>Obsolète</target>
+                <note>Label for outdated checkbox on variant form</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.outdated_badge">
+                <source>app.archetype.variant.outdated_badge</source>
+                <target>Variante obsolète</target>
+                <note>Badge text shown above the description for outdated variants</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.duplicate">
+                <source>app.archetype.variant.duplicate</source>
+                <target>Dupliquer</target>
+                <note>Tooltip for duplicate variant button in admin</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.duplicated">
+                <source>app.archetype.variant.duplicated</source>
+                <target>Variante « %name% » dupliquée.</target>
+                <note>Flash message after duplicating variant. %name% = new variant name</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.copy_prefix">
+                <source>app.archetype.variant.copy_prefix</source>
+                <target>Copie de %name%</target>
+                <note>Name prefix for duplicated variant. %name% = source variant name</note>
             </trans-unit>
             <trans-unit id="app.archetype.variant.created">
                 <source>app.archetype.variant.created</source>


### PR DESCRIPTION
## Summary

- **New `latestSet` field on Deck** — nullable ManyToOne to `TcgdexSet`, with Doctrine migration. Expansion set dropdown on both deck edit and archetype variant forms.
- **Expanded-era filter** — set dropdown only shows non-promo sets from BW era onward (`bw`, `xy`, `sm`, `swsh`, `sv`, `me` series), via `TcgdexSetRepository::createExpandedSetsQueryBuilder()`.
- **`Outdated` status** — new `DeckStatus` enum case, only applicable to archetype variants. Toggled via unmapped checkbox; controller bridges checkbox ↔ enum.
- **Outdated visual treatment** — outdated variants sort after current ones. Buttons show a `bg-secondary` badge with expansion code + italic title at reduced opacity. Description banner displays expansion name + "Outdated variant" text.
- **Duplicate variant** — admin action that clones name (prefixed "Copy of"), notes, sprites, latest set, and re-parses raw list. Redirects to the copy's edit page.
- **Re-enrich variant** — admin action (ROLE_TECHNICAL_ADMIN) to re-parse and re-enrich a variant's deck version. Button placed outside the main form to avoid nested form issues.
- **Share mosaic button** — added to archetype variant view (Web Share API + clipboard fallback).
- **Enrichment pending state** — spinner placeholder shown when variant cards are not yet enriched.
- **Server mosaic 6-col** — `MosaicGenerator::CARDS_PER_ROW` changed from 8 to 6 to match the interactive grid.
- **Low-res mosaic generation** — mosaic now downloads `low.webp` instead of `high.webp` for faster async generation.
- **Admin variant list** — shows expansion badge and outdated status badge. Duplicate button added.
- **Fix: flush-reenrich SQL** — removed references to `tcgdex_id`, `image_url`, `trainer_subtype` columns that no longer exist on `deck_card`.
- **Tests** — 10 new tests covering outdated toggle, duplicate, reenrich, form fields, and entity methods.

## Test plan

- [ ] Edit a deck → verify expansion set dropdown shows only BW-era onward sets
- [ ] Edit an archetype variant → set latest set + check Outdated → verify faded button with badge + italic title
- [ ] Archetype public page → verify outdated variants sort after current ones, description banner visible
- [ ] Admin variant list → expansion badge + outdated badge visible
- [ ] Duplicate button → creates new variant with "Copy of" prefix
- [ ] Re-enrich button → dispatches enrichment (technical admin only)
- [ ] Share mosaic button → shares/copies mosaic image
- [ ] Enrichment pending → spinner shown before enrichment completes
- [ ] Run migration on dev database

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)