### PR TITLE
:rocket: Release: 1.8.0

### DIFF
--- a/assets/archetype-variants.tsx
+++ b/assets/archetype-variants.tsx
@@ -20,6 +20,8 @@ import ArchetypeVariantSelector from './components/ArchetypeVariantSelector';
 const root = document.getElementById('archetype-variant-selector-root');
 if (root) {
     const variants = JSON.parse(root.dataset.variants ?? '[]');
+    const archetypeSlug = root.dataset.archetypeSlug ?? '';
+    const canCopyTag = root.dataset.canCopyTag === 'true';
     const labels = {
         viewTable: root.dataset.labelViewTable ?? 'Table',
         viewMosaic: root.dataset.labelViewMosaic ?? 'Mosaic',
@@ -38,11 +40,14 @@ if (root) {
         groupOutdated: root.dataset.labelGroupOutdated ?? 'Outdated',
         shareMosaic: root.dataset.labelShareMosaic ?? 'Share mosaic',
         enrichmentPending: root.dataset.labelEnrichmentPending ?? 'Card data is being generated…',
+        copyTag: root.dataset.labelCopyTag ?? 'Copy reference tag',
+        copyTagCopied: root.dataset.labelCopyTagCopied ?? 'Copied!',
+        copyCardTag: root.dataset.labelCopyCardTag ?? 'Copy card reference',
     };
 
     createRoot(root).render(
         <MantineProvider>
-            <ArchetypeVariantSelector variants={variants} labels={labels} />
+            <ArchetypeVariantSelector variants={variants} labels={labels} archetypeSlug={archetypeSlug} canCopyTag={canCopyTag} />
         </MantineProvider>,
     );
 }

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -10,7 +10,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { ActionIcon, Button, CopyButton, Group, Loader, Select, SegmentedControl, Stack, Text, Tooltip } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
-import { IconShare } from '@tabler/icons-react';
+import { IconCopy, IconShare } from '@tabler/icons-react';
 import { initCardHover } from '../shared/card-hover';
 import CardImageModal, { type FlatCard } from './CardImageModal';
 import CardMosaicGrid from './CardMosaicGrid';
@@ -31,6 +31,7 @@ interface CardData {
 
 interface VariantData {
     id: number;
+    shortTag: string;
     name: string;
     canonical: boolean;
     outdated: boolean;
@@ -62,11 +63,16 @@ interface Labels {
     groupOutdated: string;
     shareMosaic: string;
     enrichmentPending: string;
+    copyTag: string;
+    copyTagCopied: string;
+    copyCardTag: string;
 }
 
 interface ArchetypeVariantSelectorProps {
     variants: VariantData[];
     labels: Labels;
+    archetypeSlug: string;
+    canCopyTag: boolean;
 }
 
 type ViewMode = 'table' | 'mosaic';
@@ -95,11 +101,12 @@ function SpriteList({ slugs, height = 20 }: { slugs: string[]; height?: number }
     );
 }
 
-function CardSection({ title, cards, labels, onCardClick }: {
+function CardSection({ title, cards, labels, onCardClick, canCopyTag }: {
     title: string;
     cards: CardData[];
     labels: Labels;
     onCardClick?: (card: CardData) => void;
+    canCopyTag: boolean;
 }) {
     return (
         <div className="mb-3">
@@ -111,6 +118,7 @@ function CardSection({ title, cards, labels, onCardClick }: {
                         <th>{labels.tableCard}</th>
                         <th style={{ width: '60px' }}>{labels.tableSet}</th>
                         <th style={{ width: '40px' }}>#</th>
+                        {canCopyTag && <th style={{ width: '32px' }} />}
                     </tr>
                 </thead>
                 <tbody>
@@ -133,6 +141,19 @@ function CardSection({ title, cards, labels, onCardClick }: {
                             </td>
                             <td><span className="badge bg-secondary">{card.setCode}</span></td>
                             <td>{card.cardNumber}</td>
+                            {canCopyTag && (
+                                <td>
+                                    <CopyButton value={`[[card:${card.setCode}-${card.cardNumber}]]`} timeout={2000}>
+                                        {({ copied, copy }) => (
+                                            <Tooltip label={copied ? labels.copyTagCopied : labels.copyCardTag} withArrow>
+                                                <ActionIcon variant="subtle" color={copied ? 'teal' : 'gray'} size="xs" onClick={copy}>
+                                                    <IconCopy size={14} />
+                                                </ActionIcon>
+                                            </Tooltip>
+                                        )}
+                                    </CopyButton>
+                                </td>
+                            )}
                         </tr>
                     ))}
                 </tbody>
@@ -141,10 +162,11 @@ function CardSection({ title, cards, labels, onCardClick }: {
     );
 }
 
-function CardTable({ groupedCards, labels, onCardClick }: {
+function CardTable({ groupedCards, labels, onCardClick, canCopyTag }: {
     groupedCards: Record<string, CardData[]>;
     labels: Labels;
     onCardClick?: (card: CardData) => void;
+    canCopyTag: boolean;
 }) {
     const sections = Object.entries(groupedCards);
 
@@ -160,12 +182,12 @@ function CardTable({ groupedCards, labels, onCardClick }: {
         <div className="row">
             <div className="col-md-6">
                 {leftSections.map(([type, cards]) => (
-                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} onCardClick={onCardClick} />
+                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} onCardClick={onCardClick} canCopyTag={canCopyTag} />
                 ))}
             </div>
             <div className="col-md-6">
                 {rightSections.map(([type, cards]) => (
-                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} onCardClick={onCardClick} />
+                    <CardSection key={type} title={labels[SECTION_LABELS[type]] ?? type} cards={cards} labels={labels} onCardClick={onCardClick} canCopyTag={canCopyTag} />
                 ))}
             </div>
         </div>
@@ -447,14 +469,60 @@ function MobileSelector({ variants, selectedIndex, onSelect, labels }: {
     );
 }
 
-export default function ArchetypeVariantSelector({ variants, labels }: ArchetypeVariantSelectorProps) {
+/**
+ * Resolve the initial variant index from the URL hash, falling back to the canonical variant.
+ *
+ * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
+ */
+function resolveInitialIndex(variants: VariantData[]): number {
+    const hash = window.location.hash.slice(1);
+    if (hash) {
+        const hashIndex = variants.findIndex((variant) => variant.shortTag === hash);
+        if (hashIndex >= 0) {
+            return hashIndex;
+        }
+    }
+
     const canonicalIndex = variants.findIndex((variant) => variant.canonical);
-    const [selectedIndex, setSelectedIndex] = useState(canonicalIndex >= 0 ? canonicalIndex : 0);
+
+    return canonicalIndex >= 0 ? canonicalIndex : 0;
+}
+
+export default function ArchetypeVariantSelector({ variants, labels, archetypeSlug, canCopyTag }: ArchetypeVariantSelectorProps) {
+    const [selectedIndex, setSelectedIndex] = useState(() => resolveInitialIndex(variants));
     const containerRef = useRef<HTMLDivElement>(null);
     const isMobile = useMediaQuery('(max-width: 767.98px)');
     const [viewMode, setViewMode] = useState<ViewMode>('mosaic');
     const [cardModalOpen, setCardModalOpen] = useState(false);
     const [cardModalIndex, setCardModalIndex] = useState(0);
+
+    /**
+     * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
+     */
+    const handleSelectVariant = useCallback((index: number) => {
+        setSelectedIndex(index);
+        const shortTag = variants[index]?.shortTag;
+        if (shortTag) {
+            history.replaceState(null, '', `#${shortTag}`);
+        }
+    }, [variants]);
+
+    // Sync variant selection when the URL hash changes (browser back/forward).
+    useEffect(() => {
+        const handleHashChange = () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const hashIndex = variants.findIndex((variant) => variant.shortTag === hash);
+                if (hashIndex >= 0) {
+                    setSelectedIndex(hashIndex);
+                }
+            }
+        };
+
+        window.addEventListener('hashchange', handleHashChange);
+
+        return () => window.removeEventListener('hashchange', handleHashChange);
+    }, [variants]);
 
     const selectedVariant = variants[selectedIndex];
     const groupedCards = selectedVariant?.groupedCards;
@@ -532,9 +600,9 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
             {variants.length > 1 && (
                 <div className="mb-3">
                     {isMobile ? (
-                        <MobileSelector variants={variants} selectedIndex={selectedIndex} onSelect={setSelectedIndex} labels={labels} />
+                        <MobileSelector variants={variants} selectedIndex={selectedIndex} onSelect={handleSelectVariant} labels={labels} />
                     ) : (
-                        <DesktopSelector variants={variants} selectedIndex={selectedIndex} onSelect={setSelectedIndex} labels={labels} />
+                        <DesktopSelector variants={variants} selectedIndex={selectedIndex} onSelect={handleSelectVariant} labels={labels} />
                     )}
                 </div>
             )}
@@ -583,6 +651,17 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                                     )}
                                 </CopyButton>
                             )}
+                            {canCopyTag && selectedVariant.shortTag && (
+                                <CopyButton value={`[[archetype:${archetypeSlug}:${selectedVariant.shortTag}]]`} timeout={2000}>
+                                    {({ copied, copy }) => (
+                                        <Tooltip label={copied ? labels.copyTagCopied : labels.copyTag}>
+                                            <ActionIcon variant="subtle" color={copied ? 'teal' : 'gray'} size="lg" onClick={copy}>
+                                                <IconCopy size={18} />
+                                            </ActionIcon>
+                                        </Tooltip>
+                                    )}
+                                </CopyButton>
+                            )}
                             {selectedVariant.mosaicUrl && (
                                 <Tooltip label={labels.shareMosaic}>
                                     <ActionIcon variant="subtle" color="gray" size="lg" onClick={handleShareMosaic}>
@@ -603,7 +682,7 @@ export default function ArchetypeVariantSelector({ variants, labels }: Archetype
                     )}
 
                     {!selectedVariant.enrichmentPending && viewMode === 'table' && (
-                        <CardTable groupedCards={selectedVariant.groupedCards} labels={labels} onCardClick={handleCardClick} />
+                        <CardTable groupedCards={selectedVariant.groupedCards} labels={labels} onCardClick={handleCardClick} canCopyTag={canCopyTag} />
                     )}
 
                     {!selectedVariant.enrichmentPending && viewMode === 'mosaic' && (

--- a/assets/components/InsertReferenceButton.tsx
+++ b/assets/components/InsertReferenceButton.tsx
@@ -24,6 +24,7 @@ interface InsertReferenceButtonProps {
     validate: (value: string) => boolean;
     nodeType: string;
     attrName: string;
+    getAttributes?: (value: string) => Record<string, string | null>;
 }
 
 export default function InsertReferenceButton({
@@ -34,6 +35,7 @@ export default function InsertReferenceButton({
     validate,
     nodeType,
     attrName,
+    getAttributes,
 }: InsertReferenceButtonProps) {
     const [opened, setOpened] = useState(false);
     const [value, setValue] = useState('');
@@ -47,16 +49,18 @@ export default function InsertReferenceButton({
             return;
         }
 
+        const attrs = getAttributes ? getAttributes(trimmed) : { [attrName]: trimmed };
+
         editor
             .chain()
             .focus()
-            .insertContent({ type: nodeType, attrs: { [attrName]: trimmed } })
+            .insertContent({ type: nodeType, attrs })
             .run();
 
         setValue('');
         setError(false);
         setOpened(false);
-    }, [value, validate, editor, nodeType, attrName]);
+    }, [value, validate, editor, nodeType, attrName, getAttributes]);
 
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent) => {

--- a/assets/components/MarkdownEditor.tsx
+++ b/assets/components/MarkdownEditor.tsx
@@ -109,7 +109,7 @@ interface MarkdownEditorProps {
 type EditorMode = 'rte' | 'markdown';
 
 const CARD_PATTERN = /^[A-Za-z0-9-]+$/;
-const ARCHETYPE_PATTERN = /^[a-z0-9-]+$/;
+const ARCHETYPE_PATTERN = /^[a-z0-9-]+(:[A-HJ-NP-Z0-9]{6})?$/;
 const DECK_PATTERN = /^[A-HJ-NP-Z0-9]{6}$/;
 
 const validateCardReference = (value: string) => CARD_PATTERN.test(value);
@@ -295,10 +295,15 @@ export default function MarkdownEditor({ textareaSelector, initialContent, place
                                 editor={editor}
                                 icon={<IconSword size={16} />}
                                 label="Insert archetype reference"
-                                placeholder="slug"
+                                placeholder="slug or slug:SHORTTAG"
                                 validate={validateArchetypeSlug}
                                 nodeType="archetypeReference"
                                 attrName="slug"
+                                getAttributes={(value) => {
+                                    const parts = value.split(':');
+
+                                    return { slug: parts[0], shortTag: parts[1] ?? null };
+                                }}
                             />
                             <InsertReferenceButton
                                 editor={editor}

--- a/assets/extensions/ArchetypeReference.ts
+++ b/assets/extensions/ArchetypeReference.ts
@@ -7,16 +7,17 @@
  * file that was distributed with this source code.
  */
 
-import { mergeAttributes, Node } from '@tiptap/core';
+import { mergeAttributes, Node, nodePasteRule } from '@tiptap/core';
 
 /**
  * @see docs/features.md F17.3 — Custom Tiptap extension for [[archetype:slug]] tags
+ * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
  */
 
-const ARCHETYPE_TAG_PATTERN = /\[\[archetype:([a-z0-9-]+)\]\]/;
+const ARCHETYPE_TAG_PATTERN = /\[\[archetype:([a-z0-9-]+)(?::([A-HJ-NP-Z0-9]{6}))?\]\]/;
 
 /**
- * markdown-it inline rule that matches `[[archetype:slug]]` tokens.
+ * markdown-it inline rule that matches `[[archetype:slug]]` and `[[archetype:slug:shortTag]]` tokens.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function archetypeReferenceRule(state: any, silent: boolean): boolean {
@@ -30,6 +31,7 @@ function archetypeReferenceRule(state: any, silent: boolean): boolean {
     if (!silent) {
         const token = state.push('archetype_reference', '', 0);
         token.content = match[1];
+        token.meta = { shortTag: match[2] ?? null };
     }
 
     state.pos += match[0].length;
@@ -52,6 +54,17 @@ const ArchetypeReference = Node.create({
                     'data-archetype-slug': attributes.slug,
                 }),
             },
+            shortTag: {
+                default: null,
+                parseHTML: (element: HTMLElement) => element.getAttribute('data-archetype-short-tag'),
+                renderHTML: (attributes: Record<string, string | null>) => {
+                    if (!attributes.shortTag) {
+                        return {};
+                    }
+
+                    return { 'data-archetype-short-tag': attributes.shortTag };
+                },
+            },
         };
     },
 
@@ -60,10 +73,27 @@ const ArchetypeReference = Node.create({
     },
 
     renderHTML({ HTMLAttributes }) {
+        const slug = HTMLAttributes['data-archetype-slug'] ?? '';
+        const shortTag = HTMLAttributes['data-archetype-short-tag'];
+        const display = shortTag ? `${slug}:${shortTag}` : slug;
+
         return [
             'span',
             mergeAttributes(HTMLAttributes, { class: 'archetype-reference-badge' }),
-            HTMLAttributes['data-archetype-slug'] ?? '',
+            display,
+        ];
+    },
+
+    addPasteRules() {
+        return [
+            nodePasteRule({
+                find: /\[\[archetype:([a-z0-9-]+)(?::([A-HJ-NP-Z0-9]{6}))?\]\]/g,
+                type: this.type,
+                getAttributes: (match) => ({
+                    slug: match[1],
+                    shortTag: match[2] ?? null,
+                }),
+            }),
         ];
     },
 
@@ -72,7 +102,9 @@ const ArchetypeReference = Node.create({
             markdown: {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 serialize(state: any, node: any) {
-                    state.write(`[[archetype:${node.attrs.slug}]]`);
+                    const { slug, shortTag } = node.attrs;
+                    const tag = shortTag ? `[[archetype:${slug}:${shortTag}]]` : `[[archetype:${slug}]]`;
+                    state.write(tag);
                 },
                 parse: {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,6 +117,11 @@ const ArchetypeReference = Node.create({
                             index: number,
                         ) => {
                             const slug = tokens[index].content;
+                            const shortTag = tokens[index].meta?.shortTag;
+
+                            if (shortTag) {
+                                return `<span data-archetype-slug="${slug}" data-archetype-short-tag="${shortTag}">${slug}:${shortTag}</span>`;
+                            }
 
                             return `<span data-archetype-slug="${slug}">${slug}</span>`;
                         };

--- a/assets/extensions/CardReference.ts
+++ b/assets/extensions/CardReference.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { mergeAttributes, Node } from '@tiptap/core';
+import { mergeAttributes, Node, nodePasteRule } from '@tiptap/core';
 
 /**
  * @see docs/features.md F17.2 — Custom Tiptap extension for [[card:SET-NUM]] tags
@@ -64,6 +64,18 @@ const CardReference = Node.create({
             'span',
             mergeAttributes(HTMLAttributes, { class: 'card-reference-badge' }),
             HTMLAttributes['data-card-reference'] ?? '',
+        ];
+    },
+
+    addPasteRules() {
+        return [
+            nodePasteRule({
+                find: /\[\[card:([A-Za-z0-9-]+)\]\]/g,
+                type: this.type,
+                getAttributes: (match) => ({
+                    reference: match[1],
+                }),
+            }),
         ];
     },
 

--- a/assets/extensions/DeckReference.ts
+++ b/assets/extensions/DeckReference.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { mergeAttributes, Node } from '@tiptap/core';
+import { mergeAttributes, Node, nodePasteRule } from '@tiptap/core';
 
 /**
  * @see docs/features.md F17.2 — Custom Tiptap extension for [[deck:SHORT_TAG]] tags
@@ -64,6 +64,18 @@ const DeckReference = Node.create({
             'span',
             mergeAttributes(HTMLAttributes, { class: 'deck-reference-badge' }),
             HTMLAttributes['data-deck-short-tag'] ?? '',
+        ];
+    },
+
+    addPasteRules() {
+        return [
+            nodePasteRule({
+                find: /\[\[deck:([A-HJ-NP-Z0-9]{6})\]\]/g,
+                type: this.type,
+                getAttributes: (match) => ({
+                    shortTag: match[1],
+                }),
+            }),
         ];
     },
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,25 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.8.0] — 2026-04-17
+
+Archetype variant deep-linking, extended reference tags, and editor copy helpers.
+
+### Features
+
+- **Variant URL anchors** — archetype page URLs now accept a `#shortTag` hash that auto-selects the corresponding variant on load. Selecting a variant updates the URL hash via `history.replaceState`, making variant links shareable. Browser back/forward navigation is supported via `hashchange` listener. ([F2.25](https://github.com/jbourdin/expandedDecks/issues/402))
+- **Extended `[[archetype:slug:shortTag]]` tag** — the existing `[[archetype:slug]]` custom tag now supports an optional third segment with a variant's short tag. When present, the rendered link uses the variant's name and sprites instead of the archetype's, and points to `/archetypes/{slug}#shortTag`. Two-part tags remain unchanged (backward compatible). ([F2.25](https://github.com/jbourdin/expandedDecks/issues/402))
+- **Copy-tag button for editors** — users with `ROLE_ARCHETYPE_EDITOR` or `ROLE_ADMIN` see a copy icon on each variant that puts `[[archetype:slug:shortTag]]` in the clipboard. ([F2.25](https://github.com/jbourdin/expandedDecks/issues/402))
+- **Copy card reference in table view** — editors see a copy icon on each card row in the variant table view that copies `[[card:SET-NUMBER]]` to the clipboard for quick content referencing. ([F2.25](https://github.com/jbourdin/expandedDecks/issues/402))
+- **RTE paste detection** — pasting `[[archetype:...]]`, `[[card:...]]`, or `[[deck:...]]` tags as plain text in the Tiptap editor now auto-converts them to their respective custom nodes via `addPasteRules()`. ([F2.25](https://github.com/jbourdin/expandedDecks/issues/402))
+- **InsertReferenceButton multi-field input** — the archetype reference toolbar button now accepts `slug:SHORTTAG` format via a new `getAttributes` prop that parses the input into separate `slug` and `shortTag` attributes. ([F2.25](https://github.com/jbourdin/expandedDecks/issues/402))
+
+### Testing & Quality
+
+- **Variant tag expansion tests** — three new unit tests covering the `[[archetype:slug:shortTag]]` three-part tag: valid variant rendering, archetype-mismatch fallback, and unknown variant fallback.
+
+---
+
 ## [1.7.7] — 2026-04-17
 
 Variant selector grouped layout with dynamic overflow, and CI/test performance improvements.

--- a/src/Controller/ArchetypeDetailController.php
+++ b/src/Controller/ArchetypeDetailController.php
@@ -79,10 +79,11 @@ class ArchetypeDetailController extends AbstractController
      * Build serializable variant data for the React variant selector.
      *
      * @see docs/features.md F18.16 — Archetype detail: variant selector
+     * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
      *
      * @param list<Deck> $variants
      *
-     * @return list<array{id: int, name: string, canonical: bool, description: string|null, mosaicUrl: string|null, groupedCards: array<string, list<array{cardName: string, quantity: int, setCode: string, cardNumber: string, cardType: string, trainerSubtype: string|null, imageUrl: string|null}>>}>
+     * @return list<array{id: int, shortTag: string, name: string, canonical: bool, description: string|null, mosaicUrl: string|null, groupedCards: array<string, list<array{cardName: string, quantity: int, setCode: string, cardNumber: string, cardType: string, trainerSubtype: string|null, imageUrl: string|null}>>}>
      */
     private function buildVariantsData(array $variants, ArchetypeDescriptionRenderer $descriptionRenderer, string $locale): array
     {
@@ -153,6 +154,7 @@ class ArchetypeDetailController extends AbstractController
 
             $data[] = [
                 'id' => $variantId,
+                'shortTag' => $variant->getShortTag(),
                 'name' => $variant->getName(),
                 'canonical' => $variant->isCanonical(),
                 'outdated' => $variant->isOutdated(),

--- a/src/Service/ArchetypeDescriptionRenderer.php
+++ b/src/Service/ArchetypeDescriptionRenderer.php
@@ -15,6 +15,7 @@ namespace App\Service;
 
 use App\Repository\ArchetypeRepository;
 use App\Repository\DeckCardRepository;
+use App\Repository\DeckRepository;
 use App\Service\Tcgdex\TcgdexApiClient;
 use App\Twig\Runtime\ArchetypeSpriteRuntime;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -25,11 +26,13 @@ use Symfony\Contracts\Cache\ItemInterface;
  * Renders archetype descriptions: Markdown → HTML with custom tag expansion.
  *
  * Supported custom tags:
- * - [[archetype:slug]]   → link to archetype detail page with sprites
- * - [[deck:SHORTTAG]]    → link to deck show page with short tag badge
- * - [[card:SET-NUMBER]]  → card name with hover image preview
+ * - [[archetype:slug]]            → link to archetype detail page with sprites
+ * - [[archetype:slug:shortTag]]  → link to archetype variant with variant sprites and name
+ * - [[deck:SHORTTAG]]            → link to deck show page with short tag badge
+ * - [[card:SET-NUMBER]]          → card name with hover image preview
  *
  * @see docs/features.md F2.10 — Archetype detail page
+ * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
  */
 class ArchetypeDescriptionRenderer
 {
@@ -37,6 +40,7 @@ class ArchetypeDescriptionRenderer
         private readonly MarkdownRenderer $markdownRenderer,
         private readonly ArchetypeRepository $archetypeRepository,
         private readonly DeckCardRepository $deckCardRepository,
+        private readonly DeckRepository $deckRepository,
         private readonly TcgdexApiClient $tcgdexApiClient,
         private readonly ArchetypeSpriteRuntime $spriteRuntime,
         private readonly UrlGeneratorInterface $urlGenerator,
@@ -73,27 +77,48 @@ class ArchetypeDescriptionRenderer
 
     /**
      * @see docs/features.md F9.6 — Archetype localization
+     * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
      */
     private function expandArchetypeTags(string $html, string $locale): string
     {
         return (string) preg_replace_callback(
-            '/\[\[archetype:([a-z0-9-]+)\]\]/',
+            '/\[\[archetype:([a-z0-9-]+)(?::([A-HJ-NP-Z0-9]{6}))?\]\]/',
             function (array $matches) use ($locale): string {
                 $slug = $matches[1];
+                $variantShortTag = $matches[2] ?? null;
                 $archetype = $this->archetypeRepository->findOneBy(['slug' => $slug]);
 
                 if (null === $archetype) {
                     return htmlspecialchars($matches[0], \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
                 }
 
-                $sprites = $this->spriteRuntime->renderSprites($archetype);
-                $name = htmlspecialchars($archetype->getLocalizedName($locale), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+                // Resolve variant-specific display when a shortTag is provided.
+                $variant = null;
+                if (null !== $variantShortTag) {
+                    $variant = $this->deckRepository->findOneBy(['shortTag' => $variantShortTag]);
+
+                    // Ignore the variant if it doesn't belong to this archetype.
+                    if (null !== $variant && $variant->getArchetype() !== $archetype) {
+                        $variant = null;
+                    }
+                }
+
+                if (null !== $variant) {
+                    $sprites = $this->spriteRuntime->renderDeckSprites($variant);
+                    $name = htmlspecialchars($variant->getName(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+                } else {
+                    $sprites = $this->spriteRuntime->renderSprites($archetype);
+                    $name = htmlspecialchars($archetype->getLocalizedName($locale), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+                }
 
                 if (!$archetype->isPublished()) {
                     return \sprintf('%s %s', $sprites, $name);
                 }
 
                 $url = $this->urlGenerator->generate('app_archetype_show', ['slug' => $slug]);
+                if (null !== $variant && null !== $variantShortTag) {
+                    $url .= '#'.urlencode($variantShortTag);
+                }
 
                 return \sprintf('<a href="%s">%s %s</a>', htmlspecialchars($url, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'), $sprites, $name);
             },

--- a/templates/archetype/show.html.twig
+++ b/templates/archetype/show.html.twig
@@ -67,6 +67,11 @@
                 <div class="card-body">
                     <div id="archetype-variant-selector-root"
                          data-variants="{{ variantsData|json_encode|e('html_attr') }}"
+                         data-archetype-slug="{{ archetype.slug }}"
+                         data-can-copy-tag="{{ is_granted('ROLE_ARCHETYPE_EDITOR') or is_granted('ROLE_ADMIN') ? 'true' : 'false' }}"
+                         data-label-copy-tag="{{ 'app.archetype.variant.copy_tag'|trans }}"
+                         data-label-copy-tag-copied="{{ 'app.archetype.variant.copy_tag_copied'|trans }}"
+                         data-label-copy-card-tag="{{ 'app.archetype.variant.copy_card_tag'|trans }}"
                          data-label-view-table="{{ 'app.deck.view_table'|trans }}"
                          data-label-view-mosaic="{{ 'app.deck.view_mosaic'|trans }}"
                          data-label-mosaic-alt="{{ 'app.deck.mosaic_alt'|trans({'%name%': archetype.localizedName(app.request.locale)}) }}"

--- a/tests/Service/ArchetypeDescriptionRendererTest.php
+++ b/tests/Service/ArchetypeDescriptionRendererTest.php
@@ -15,6 +15,7 @@ namespace App\Tests\Service;
 
 use App\Entity\Archetype;
 use App\Entity\ArchetypeTranslation;
+use App\Entity\Deck;
 use App\Entity\DeckCard;
 use App\Repository\ArchetypeRepository;
 use App\Repository\DeckCardRepository;
@@ -262,5 +263,99 @@ class ArchetypeDescriptionRendererTest extends TestCase
 
         self::assertStringContainsString('Professor Research', $result);
         self::assertStringContainsString('card-hover', $result);
+    }
+
+    /**
+     * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
+     */
+    public function testExpandsThreePartArchetypeTagWithVariant(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setName('Lugia VSTAR');
+        $archetype->setPokemonSlugs(['lugia']);
+        $archetype->setIsPublished(true);
+
+        $variant = new Deck();
+        $variant->setName('Turbo Lugia');
+        $variant->setPokemonSlugs(['lugia', 'archeops']);
+        $variant->setArchetype($archetype);
+
+        $this->archetypeRepository->method('findOneBy')
+            ->willReturnCallback(static fn (array $criteria): ?Archetype => 'lugia-vstar' === ($criteria['slug'] ?? null) ? $archetype : null);
+
+        $this->deckRepository->method('findOneBy')
+            ->willReturnCallback(static fn (array $criteria): ?Deck => 'ABC123' === ($criteria['shortTag'] ?? null) ? $variant : null);
+
+        $this->urlGenerator->method('generate')
+            ->willReturnCallback(static fn (string $route, array $parameters): string => 'app_archetype_show' === $route && 'lugia-vstar' === ($parameters['slug'] ?? null) ? '/archetypes/lugia-vstar' : '');
+
+        $result = $this->renderer->render('See [[archetype:lugia-vstar:ABC123]].');
+
+        self::assertStringContainsString('<a href="/archetypes/lugia-vstar#ABC123">', $result);
+        self::assertStringContainsString('Turbo Lugia', $result);
+        self::assertStringContainsString('archeops', $result);
+        self::assertStringNotContainsString('[[archetype:', $result);
+    }
+
+    /**
+     * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
+     */
+    public function testThreePartTagFallsBackWhenVariantBelongsToDifferentArchetype(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setName('Kyurem');
+        $archetype->setPokemonSlugs(['kyurem']);
+        $archetype->setIsPublished(true);
+
+        $otherArchetype = new Archetype();
+        $otherArchetype->setName('Lugia VSTAR');
+
+        $variant = new Deck();
+        $variant->setName('Turbo Lugia');
+        $variant->setArchetype($otherArchetype);
+
+        $this->archetypeRepository->method('findOneBy')
+            ->willReturnCallback(static fn (array $criteria): ?Archetype => 'kyurem' === ($criteria['slug'] ?? null) ? $archetype : null);
+
+        $this->deckRepository->method('findOneBy')
+            ->willReturnCallback(static fn (array $criteria): ?Deck => 'XYZ789' === ($criteria['shortTag'] ?? null) ? $variant : null);
+
+        $this->urlGenerator->method('generate')
+            ->willReturnCallback(static fn (string $route, array $parameters): string => 'app_archetype_show' === $route && 'kyurem' === ($parameters['slug'] ?? null) ? '/archetypes/kyurem' : '');
+
+        $result = $this->renderer->render('See [[archetype:kyurem:XYZ789]].');
+
+        // Falls back to archetype rendering (no hash, archetype name)
+        self::assertStringContainsString('<a href="/archetypes/kyurem">', $result);
+        self::assertStringContainsString('Kyurem', $result);
+        self::assertStringNotContainsString('#XYZ789', $result);
+        self::assertStringNotContainsString('Turbo Lugia', $result);
+    }
+
+    /**
+     * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
+     */
+    public function testThreePartTagFallsBackWhenVariantNotFound(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setName('Kyurem');
+        $archetype->setPokemonSlugs(['kyurem']);
+        $archetype->setIsPublished(true);
+
+        $this->archetypeRepository->method('findOneBy')
+            ->willReturnCallback(static fn (array $criteria): ?Archetype => 'kyurem' === ($criteria['slug'] ?? null) ? $archetype : null);
+
+        $this->deckRepository->method('findOneBy')
+            ->willReturn(null);
+
+        $this->urlGenerator->method('generate')
+            ->willReturnCallback(static fn (string $route, array $parameters): string => 'app_archetype_show' === $route && 'kyurem' === ($parameters['slug'] ?? null) ? '/archetypes/kyurem' : '');
+
+        $result = $this->renderer->render('See [[archetype:kyurem:NHE5T3]].');
+
+        // Falls back to archetype rendering (no hash, archetype name)
+        self::assertStringContainsString('<a href="/archetypes/kyurem">', $result);
+        self::assertStringContainsString('Kyurem', $result);
+        self::assertStringNotContainsString('#NHE5T3', $result);
     }
 }

--- a/tests/Service/ArchetypeDescriptionRendererTest.php
+++ b/tests/Service/ArchetypeDescriptionRendererTest.php
@@ -18,6 +18,7 @@ use App\Entity\ArchetypeTranslation;
 use App\Entity\DeckCard;
 use App\Repository\ArchetypeRepository;
 use App\Repository\DeckCardRepository;
+use App\Repository\DeckRepository;
 use App\Service\ArchetypeDescriptionRenderer;
 use App\Service\MarkdownRenderer;
 use App\Service\Tcgdex\TcgdexApiClient;
@@ -36,6 +37,7 @@ class ArchetypeDescriptionRendererTest extends TestCase
     private ArchetypeDescriptionRenderer $renderer;
     private ArchetypeRepository&Stub $archetypeRepository;
     private DeckCardRepository&Stub $deckCardRepository;
+    private DeckRepository&Stub $deckRepository;
     private TcgdexApiClient&Stub $tcgdexApiClient;
     private UrlGeneratorInterface&Stub $urlGenerator;
 
@@ -43,6 +45,7 @@ class ArchetypeDescriptionRendererTest extends TestCase
     {
         $this->archetypeRepository = $this->createStub(ArchetypeRepository::class);
         $this->deckCardRepository = $this->createStub(DeckCardRepository::class);
+        $this->deckRepository = $this->createStub(DeckRepository::class);
         $this->tcgdexApiClient = $this->createStub(TcgdexApiClient::class);
         $this->urlGenerator = $this->createStub(UrlGeneratorInterface::class);
 
@@ -50,6 +53,7 @@ class ArchetypeDescriptionRendererTest extends TestCase
             new MarkdownRenderer(),
             $this->archetypeRepository,
             $this->deckCardRepository,
+            $this->deckRepository,
             $this->tcgdexApiClient,
             new ArchetypeSpriteRuntime(),
             $this->urlGenerator,

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -3695,6 +3695,21 @@
                 <target>Are you sure you want to delete this variant?</target>
                 <note>Confirmation dialog for variant deletion</note>
             </trans-unit>
+            <trans-unit id="app.archetype.variant.copy_tag">
+                <source>app.archetype.variant.copy_tag</source>
+                <target>Copy reference tag</target>
+                <note>Tooltip for copy-tag button on archetype variant selector (F2.25)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.copy_tag_copied">
+                <source>app.archetype.variant.copy_tag_copied</source>
+                <target>Copied!</target>
+                <note>Tooltip shown after reference tag has been copied to clipboard (F2.25)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.copy_card_tag">
+                <source>app.archetype.variant.copy_card_tag</source>
+                <target>Copy card reference</target>
+                <note>Tooltip for copy card reference button on card table rows (F2.25)</note>
+            </trans-unit>
 
             <!-- Admin: User management -->
             <trans-unit id="app.admin.user.list_title">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -3685,6 +3685,21 @@
                 <target>Voulez-vous vraiment supprimer cette variante ?</target>
                 <note>Confirmation dialog for variant deletion</note>
             </trans-unit>
+            <trans-unit id="app.archetype.variant.copy_tag">
+                <source>app.archetype.variant.copy_tag</source>
+                <target>Copier la balise de référence</target>
+                <note>Tooltip for copy-tag button on archetype variant selector (F2.25)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.copy_tag_copied">
+                <source>app.archetype.variant.copy_tag_copied</source>
+                <target>Copié !</target>
+                <note>Tooltip shown after reference tag has been copied to clipboard (F2.25)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.variant.copy_card_tag">
+                <source>app.archetype.variant.copy_card_tag</source>
+                <target>Copier la référence carte</target>
+                <note>Tooltip for copy card reference button on card table rows (F2.25)</note>
+            </trans-unit>
 
             <!-- Admin: User management -->
             <trans-unit id="app.admin.user.list_title">


### PR DESCRIPTION
## Summary
- Release 1.8.0 — Archetype variant deep-linking, extended reference tags, and editor copy helpers. See docs/changelog.md for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)