### PR TITLE
:sparkles: Feature: mosaic 8 columns with transparent background

### DIFF
--- a/assets/components/CardMosaicGrid.tsx
+++ b/assets/components/CardMosaicGrid.tsx
@@ -50,7 +50,7 @@ function toLowRes(imageUrl: string): string {
 }
 
 /**
- * Interactive card mosaic grid — responsive 6-col (desktop) / 3-col (mobile)
+ * Interactive card mosaic grid — responsive 8-col (desktop) / 4-col (mobile)
  * grid of low-res card thumbnails with quantity badges and click-to-zoom modal.
  */
 export default function CardMosaicGrid({ groupedCards, mosaicAltLabel }: CardMosaicGridProps) {

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -564,11 +564,11 @@ footer {
 
 .card-mosaic-grid {
     display: grid;
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(8, 1fr);
     gap: 8px;
 
     @include media-breakpoint-down(md) {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(4, 1fr);
     }
 }
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -68,7 +68,6 @@ services:
     App\Service\Mosaic\MosaicGenerator:
         arguments:
             $mosaicStorage: '@mosaic.storage'
-            $projectDir: '%kernel.project_dir%'
 
     App\Controller\MosaicController:
         arguments:

--- a/docs/technicalities/mosaic.md
+++ b/docs/technicalities/mosaic.md
@@ -18,7 +18,7 @@ The mosaic is a **server-generated composite image** of a deck's card list, foll
 
 - **Grid:** fixed-width, 8 cards per row
 - **Card order:** Pokemon → Trainer → Energy (no section headers, continuous flow); within each type: quantity descending, then name ascending
-- **Background:** site background (`#f5f5f7` with tiled `bg_fairy_quincunx.png` texture, 96×80px repeat)
+- **Background:** transparent (PNG alpha channel)
 - **Quantity badge:** red hexagonal badge centered at the bottom of each tile, white text
 - **Placeholder:** cards without an `imageUrl` render as a grey tile with the card name
 
@@ -58,7 +58,7 @@ A `MosaicRedispatchService` finds deck versions that are fully enriched but have
 - **Input:** ordered list of `DeckCard` entities with `imageUrl` and `quantity`
 - **Process:**
   1. Download card images from TCGdex (webp format, `/high.webp` URLs)
-  2. Create canvas with tiled background texture
+  2. Create canvas with transparent background
   3. Place card images in grid cells
   4. Overlay quantity badges (red hexagon, white text, centered bottom)
   5. Export as PNG or WebP

--- a/docs/technicalities/mosaic.md
+++ b/docs/technicalities/mosaic.md
@@ -16,7 +16,7 @@ The mosaic is a **server-generated composite image** of a deck's card list, foll
 
 ## Layout
 
-- **Grid:** fixed-width, 8–9 cards per row
+- **Grid:** fixed-width, 8 cards per row
 - **Card order:** Pokemon → Trainer → Energy (no section headers, continuous flow); within each type: quantity descending, then name ascending
 - **Background:** site background (`#f5f5f7` with tiled `bg_fairy_quincunx.png` texture, 96×80px repeat)
 - **Quantity badge:** red hexagonal badge centered at the bottom of each tile, white text

--- a/src/Service/Mosaic/MosaicGenerator.php
+++ b/src/Service/Mosaic/MosaicGenerator.php
@@ -36,15 +36,10 @@ class MosaicGenerator
     private const int SHADOW_OFFSET_X = 3;
     private const int SHADOW_OFFSET_Y = 3;
 
-    /** Background tile dimensions matching app.scss (96px x 80px). */
-    private const int TILE_WIDTH = 96;
-    private const int TILE_HEIGHT = 80;
-
     public function __construct(
         private readonly FilesystemOperator $mosaicStorage,
         private readonly LoggerInterface $logger,
         private readonly CardImageResolver $cardImageResolver,
-        private readonly string $projectDir,
     ) {
     }
 
@@ -207,31 +202,8 @@ class MosaicGenerator
         $offsetX = (int) (($canvasWidth - $lastRowWidth) / 2);
         $lastRowY = self::PADDING + ($rows - 1) * (self::CARD_HEIGHT + self::PADDING);
 
-        $backgroundColor = imagecolorallocate($canvas, 0xF5, 0xF5, 0xF7);
-
-        if (false !== $backgroundColor) {
-            imagefilledrectangle($canvas, 0, $lastRowY, $canvasWidth - 1, $lastRowY + self::CARD_HEIGHT + self::PADDING - 1, $backgroundColor);
-        }
-
-        $tilePath = $this->projectDir.'/assets/images/bg_fairy_quincunx.png';
-
-        if (file_exists($tilePath)) {
-            $bgTile = imagecreatefrompng($tilePath);
-
-            if (false !== $bgTile) {
-                for ($tileY = $lastRowY; $tileY < $lastRowY + self::CARD_HEIGHT + self::PADDING; $tileY += self::TILE_HEIGHT) {
-                    for ($tileX = 0; $tileX < $canvasWidth; $tileX += self::TILE_WIDTH) {
-                        $copyWidth = min(self::TILE_WIDTH, $canvasWidth - $tileX);
-                        $copyHeight = min(self::TILE_HEIGHT, $lastRowY + self::CARD_HEIGHT + self::PADDING - $tileY);
-
-                        if ($copyHeight > 0 && $copyWidth > 0) {
-                            $sourceTileY = $tileY % self::TILE_HEIGHT;
-                            imagecopy($canvas, $bgTile, $tileX, $tileY, $tileX % self::TILE_WIDTH, $sourceTileY, $copyWidth, min($copyHeight, self::TILE_HEIGHT - $sourceTileY));
-                        }
-                    }
-                }
-            }
-        }
+        // Clear last row area to transparent before redrawing centered
+        $this->clearRegionToTransparent($canvas, 0, $lastRowY, $canvasWidth - 1, $lastRowY + self::CARD_HEIGHT + self::PADDING - 1);
 
         $lastRowStartIndex = (int) (($rows - 1) * self::CARDS_PER_ROW);
 
@@ -284,9 +256,8 @@ class MosaicGenerator
     }
 
     /**
-     * Create the canvas with the site background texture tiled.
-     */
-    /**
+     * Create the canvas with a transparent background.
+     *
      * @param int<1, max> $width
      * @param int<1, max> $height
      */
@@ -298,31 +269,17 @@ class MosaicGenerator
             throw new \RuntimeException('Failed to create GD canvas.');
         }
 
-        // Fill with site background color #f5f5f7
-        $backgroundColor = imagecolorallocate($canvas, 0xF5, 0xF5, 0xF7);
+        imagesavealpha($canvas, true);
+        imagealphablending($canvas, false);
 
-        if (false === $backgroundColor) {
-            throw new \RuntimeException('Failed to allocate background color.');
+        $transparent = imagecolorallocatealpha($canvas, 0, 0, 0, 127);
+
+        if (false === $transparent) {
+            throw new \RuntimeException('Failed to allocate transparent color.');
         }
 
-        imagefill($canvas, 0, 0, $backgroundColor);
-
-        // Tile the background texture
-        $tilePath = $this->projectDir.'/assets/images/bg_fairy_quincunx.png';
-
-        if (file_exists($tilePath)) {
-            $tile = imagecreatefrompng($tilePath);
-
-            if (false !== $tile) {
-                for ($tileY = 0; $tileY < $height; $tileY += self::TILE_HEIGHT) {
-                    for ($tileX = 0; $tileX < $width; $tileX += self::TILE_WIDTH) {
-                        $copyWidth = min(self::TILE_WIDTH, $width - $tileX);
-                        $copyHeight = min(self::TILE_HEIGHT, $height - $tileY);
-                        imagecopy($canvas, $tile, $tileX, $tileY, 0, 0, $copyWidth, $copyHeight);
-                    }
-                }
-            }
-        }
+        imagefill($canvas, 0, 0, $transparent);
+        imagealphablending($canvas, true);
 
         return $canvas;
     }
@@ -461,36 +418,9 @@ class MosaicGenerator
         $offsetX = (int) (($canvasWidth - $lastRowWidth) / 2);
         $lastRowY = self::PADDING + ($rows - 1) * (self::CARD_HEIGHT + self::PADDING);
 
-        // Clear last row area first (redraw background)
-        $backgroundColor = imagecolorallocate($canvas, 0xF5, 0xF5, 0xF7);
+        // Clear last row area to transparent before redrawing centered
+        $this->clearRegionToTransparent($canvas, 0, $lastRowY, $canvasWidth - 1, $lastRowY + self::CARD_HEIGHT + self::PADDING - 1);
 
-        if (false !== $backgroundColor) {
-            imagefilledrectangle($canvas, 0, $lastRowY, $canvasWidth - 1, $lastRowY + self::CARD_HEIGHT + self::PADDING - 1, $backgroundColor);
-        }
-
-        // Re-tile background for last row
-        $tilePath = $this->projectDir.'/assets/images/bg_fairy_quincunx.png';
-
-        if (file_exists($tilePath)) {
-            $tile = imagecreatefrompng($tilePath);
-
-            if (false !== $tile) {
-                for ($tileY = $lastRowY; $tileY < $lastRowY + self::CARD_HEIGHT + self::PADDING; $tileY += self::TILE_HEIGHT) {
-                    for ($tileX = 0; $tileX < $canvasWidth; $tileX += self::TILE_WIDTH) {
-                        $copyWidth = min(self::TILE_WIDTH, $canvasWidth - $tileX);
-                        $copyHeight = min(self::TILE_HEIGHT, $lastRowY + self::CARD_HEIGHT + self::PADDING - $tileY);
-
-                        if ($copyHeight > 0 && $copyWidth > 0) {
-                            // Use tile offset to maintain seamless pattern
-                            $sourceTileY = $tileY % self::TILE_HEIGHT;
-                            imagecopy($canvas, $tile, $tileX, $tileY, $tileX % self::TILE_WIDTH, $sourceTileY, $copyWidth, min($copyHeight, self::TILE_HEIGHT - $sourceTileY));
-                        }
-                    }
-                }
-            }
-        }
-
-        // Redraw cards centered
         $lastRowStartIndex = (int) (($rows - 1) * self::CARDS_PER_ROW);
 
         for ($i = 0; $i < $columnsInLastRow; ++$i) {
@@ -498,6 +428,22 @@ class MosaicGenerator
             $x = $offsetX + $i * (self::CARD_WIDTH + self::PADDING);
             $this->drawCard($canvas, $card, $x, $lastRowY, $imageUrlOverrides);
         }
+    }
+
+    /**
+     * Clear a rectangular region to fully transparent by temporarily disabling alpha blending.
+     */
+    private function clearRegionToTransparent(\GdImage $canvas, int $x1, int $y1, int $x2, int $y2): void
+    {
+        imagealphablending($canvas, false);
+
+        $transparent = imagecolorallocatealpha($canvas, 0, 0, 0, 127);
+
+        if (false !== $transparent) {
+            imagefilledrectangle($canvas, $x1, $y1, $x2, $y2, $transparent);
+        }
+
+        imagealphablending($canvas, true);
     }
 
     private function buildStoragePath(DeckVersion $version, string $variant = ''): string

--- a/src/Service/Mosaic/MosaicGenerator.php
+++ b/src/Service/Mosaic/MosaicGenerator.php
@@ -27,7 +27,7 @@ use Psr\Log\LoggerInterface;
  */
 class MosaicGenerator
 {
-    private const int CARDS_PER_ROW = 6;
+    private const int CARDS_PER_ROW = 8;
     private const int CARD_WIDTH = 245;
     private const int CARD_HEIGHT = 342;
     private const int PADDING = 12;

--- a/tests/Service/Mosaic/MosaicGeneratorTest.php
+++ b/tests/Service/Mosaic/MosaicGeneratorTest.php
@@ -40,7 +40,6 @@ final class MosaicGeneratorTest extends TestCase
             $this->storage,
             new NullLogger(),
             $this->createStub(CardImageResolver::class),
-            \dirname(__DIR__, 3), // project root
         );
     }
 
@@ -56,7 +55,7 @@ final class MosaicGeneratorTest extends TestCase
     public function testGenerateWritesPngToStorage(): void
     {
         $storage = $this->createMock(FilesystemOperator::class);
-        $generator = new MosaicGenerator($storage, new NullLogger(), $this->createStub(CardImageResolver::class), \dirname(__DIR__, 3));
+        $generator = new MosaicGenerator($storage, new NullLogger(), $this->createStub(CardImageResolver::class));
 
         $version = $this->createVersion(1, 1);
         $this->addCard($version, 'Pikachu', 'pokemon', null, 4);
@@ -181,7 +180,7 @@ final class MosaicGeneratorTest extends TestCase
             ->willReturn($fakePngData);
 
         $storage = $this->createStub(FilesystemOperator::class);
-        $generator = new MosaicGenerator($storage, new NullLogger(), $resolver, \dirname(__DIR__, 3));
+        $generator = new MosaicGenerator($storage, new NullLogger(), $resolver);
 
         $version = $this->createVersion(10, 20);
 
@@ -203,7 +202,7 @@ final class MosaicGeneratorTest extends TestCase
         $resolver->expects(self::never())->method('downloadImage');
 
         $storage = $this->createStub(FilesystemOperator::class);
-        $generator = new MosaicGenerator($storage, new NullLogger(), $resolver, \dirname(__DIR__, 3));
+        $generator = new MosaicGenerator($storage, new NullLogger(), $resolver);
 
         $version = $this->createVersion(11, 21);
 

--- a/tests/Service/Mosaic/MosaicGeneratorTest.php
+++ b/tests/Service/Mosaic/MosaicGeneratorTest.php
@@ -144,6 +144,15 @@ final class MosaicGeneratorTest extends TestCase
         self::assertTrue(str_starts_with($writtenData, "\x89PNG"));
     }
 
+    public function testGenerateFromTilesReturnsEmptyStringOnEmptyTiles(): void
+    {
+        $version = $this->createVersion(9, 9);
+
+        $result = $this->generator->generateFromTiles($version, []);
+
+        self::assertSame('', $result);
+    }
+
     public function testGenerateFromTilesUsesCardImageResolverWhenPrintingPresent(): void
     {
         $printing = new CardPrinting();
@@ -185,6 +194,30 @@ final class MosaicGeneratorTest extends TestCase
         $version = $this->createVersion(10, 20);
 
         $generator->generateFromTiles($version, [$tile], 'minified');
+    }
+
+    public function testGenerateFromTilesCentersIncompleteLastRow(): void
+    {
+        // 9 tiles = 8 in first row + 1 centered in second row (CARDS_PER_ROW = 8)
+        $tiles = [];
+
+        for ($i = 1; $i <= 9; ++$i) {
+            $tiles[] = new MosaicTile('Tile '.$i, $i, null, 'pokemon', null);
+        }
+
+        $writtenData = '';
+        $this->storage->method('write')->willReturnCallback(
+            static function (string $path, string $data) use (&$writtenData): void {
+                $writtenData = $data;
+            },
+        );
+
+        $version = $this->createVersion(12, 22);
+
+        $this->generator->generateFromTiles($version, $tiles, 'minified');
+
+        self::assertNotEmpty($writtenData);
+        self::assertTrue(str_starts_with($writtenData, "\x89PNG"));
     }
 
     public function testGenerateFromTilesFallsBackToRawUrlWhenNoPrinting(): void


### PR DESCRIPTION
## Summary
- Increase mosaic grid width from 6 to 8 cards per row in both the server-side GD image (`MosaicGenerator::CARDS_PER_ROW`) and the client-side HTML grid (CSS `grid-template-columns`)
- Update mobile breakpoint from 3 to 4 columns
- Replace tiled `bg_fairy_quincunx.png` background with full PNG alpha transparency
- Remove unused `$projectDir` constructor dependency and tile-related constants from `MosaicGenerator`
- Update `docs/technicalities/mosaic.md` to reflect new layout and transparent background

## Post-deploy
- Trigger **MosaicRedispatchService** from the admin panel to regenerate existing PNG mosaics

## Test plan
- [ ] Visually verify mosaic on a deck page (HTML grid shows 8 columns on desktop, 4 on mobile)
- [ ] Regenerate a PNG mosaic and verify it renders with 8 columns and transparent background
- [ ] Check card sizing is comfortable at 8 columns on various screen widths
- [ ] Verify mosaic PNG looks correct when pasted on colored backgrounds (e.g. Discord, social media)

🤖 Generated with [Claude Code](https://claude.com/claude-code)