### PR TITLE
:bug: Fix: replace Web Share API with clipboard copy for mosaic

### DIFF
--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -10,7 +10,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { ActionIcon, Button, CopyButton, Group, Loader, Select, SegmentedControl, Stack, Text, Tooltip } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
-import { IconArrowsExchange, IconCopy, IconShare } from '@tabler/icons-react';
+import { IconArrowsExchange, IconCheck, IconCopy, IconShare } from '@tabler/icons-react';
 import { initCardHover } from '../shared/card-hover';
 import CardImageModal, { type FlatCard } from './CardImageModal';
 import CardMosaicGrid from './CardMosaicGrid';
@@ -496,6 +496,8 @@ export default function ArchetypeVariantSelector({ variants, labels, archetypeSl
     const [viewMode, setViewMode] = useState<ViewMode>('mosaic');
     const [cardModalOpen, setCardModalOpen] = useState(false);
     const [cardModalIndex, setCardModalIndex] = useState(0);
+    const [mosaicCopied, setMosaicCopied] = useState(false);
+    const mosaicCopyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     /**
      * @see docs/features.md F2.25 — Archetype variant URL anchors & enhanced archetype tags
@@ -555,29 +557,15 @@ export default function ArchetypeVariantSelector({ variants, labels, archetypeSl
         const mosaicUrl = selectedVariant?.mosaicUrl;
         if (!mosaicUrl) return;
 
-        if (navigator.share) {
-            try {
-                const response = await fetch(mosaicUrl);
-                const blob = await response.blob();
-                const file = new File([blob], 'deck-mosaic.png', { type: 'image/png' });
-                await navigator.share({ files: [file] });
+        await navigator.clipboard.writeText(window.location.origin + mosaicUrl);
+        setMosaicCopied(true);
 
-                return;
-            } catch {
-                // Share cancelled or not supported with files
-            }
-
-            try {
-                await navigator.share({ title: labels.mosaicAlt, url: mosaicUrl });
-
-                return;
-            } catch {
-                // Share cancelled — fall back to clipboard
-            }
+        if (mosaicCopyTimeout.current) {
+            clearTimeout(mosaicCopyTimeout.current);
         }
 
-        await navigator.clipboard.writeText(window.location.origin + mosaicUrl);
-    }, [selectedVariant?.mosaicUrl, labels.mosaicAlt]);
+        mosaicCopyTimeout.current = setTimeout(() => setMosaicCopied(false), 2000);
+    }, [selectedVariant?.mosaicUrl]);
 
     // Re-initialize card hover after every render — description HTML contains
     // .card-hover elements from [[card:...]] tags, and they get recreated on
@@ -664,9 +652,9 @@ export default function ArchetypeVariantSelector({ variants, labels, archetypeSl
                                 </CopyButton>
                             )}
                             {selectedVariant.mosaicUrl && (
-                                <Tooltip label={labels.shareMosaic}>
-                                    <ActionIcon variant="subtle" color="gray" size="lg" onClick={handleShareMosaic}>
-                                        <IconShare size={18} />
+                                <Tooltip label={mosaicCopied ? labels.copied : labels.shareMosaic}>
+                                    <ActionIcon variant="subtle" color={mosaicCopied ? 'teal' : 'gray'} size="lg" onClick={handleShareMosaic}>
+                                        {mosaicCopied ? <IconCheck size={18} /> : <IconShare size={18} />}
                                     </ActionIcon>
                                 </Tooltip>
                             )}

--- a/assets/components/DeckCardList.tsx
+++ b/assets/components/DeckCardList.tsx
@@ -293,35 +293,6 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
             return;
         }
 
-        // Try Web Share API with the image file
-        if (navigator.share) {
-            try {
-                const response = await fetch(activeMosaicUrl);
-                const blob = await response.blob();
-                const file = new File([blob], 'deck-mosaic.png', { type: 'image/png' });
-
-                await navigator.share({
-                    files: [file],
-                });
-
-                return;
-            } catch {
-                // Share cancelled or not supported with files — fall back to URL share
-            }
-
-            try {
-                await navigator.share({
-                    title: labels.mosaicAlt,
-                    url: activeMosaicUrl,
-                });
-
-                return;
-            } catch {
-                // Share cancelled — fall back to clipboard
-            }
-        }
-
-        // Fallback: copy mosaic URL to clipboard
         await navigator.clipboard.writeText(window.location.origin + activeMosaicUrl);
         setCopied(true);
 
@@ -330,7 +301,7 @@ export const DeckCardList: React.FC<DeckCardListProps> = ({
         }
 
         copyTimeout.current = setTimeout(() => setCopied(false), 2000);
-    }, [activeMosaicUrl, labels.mosaicAlt]);
+    }, [activeMosaicUrl]);
 
     return (
         <>


### PR DESCRIPTION
## Summary
- Replace `navigator.share()` with `navigator.clipboard.writeText()` for the mosaic share button on both deck and archetype pages
- Fixes Safari macOS triggering the native share sheet (AirDrop, Mail, etc.) instead of copying to clipboard
- Add missing copy confirmation feedback (teal icon + tooltip) to the archetype variant selector share button, fixing the silent copy on Firefox

## Test plan
- [ ] Safari macOS: click share mosaic button on a deck page — should copy URL to clipboard, no share sheet
- [ ] Safari macOS: click share mosaic button on an archetype page — same behavior
- [ ] Firefox: click share mosaic button on an archetype page — should show teal checkmark confirmation
- [ ] Chrome: verify both pages still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)