### PR TITLE
:wrench: Chore: add dependency vulnerability scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,3 +182,35 @@ jobs:
 
       - name: Encore production build
         run: npx encore production
+
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: intl, zip
+          coverage: none
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Composer audit
+        run: composer audit
+
+      - name: npm audit
+        run: npm audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,7 @@ make phpstan       # Static analysis
 make lint-i18n     # Validate translation files (syntax + content)
 make lint-yaml     # Validate YAML configuration files
 make lint-container # Validate Symfony DI container
+make audit         # Dependency vulnerability audit (PHP + JS)
 make test          # Run test suite
 ```
 
@@ -278,6 +279,9 @@ When creating new features or backlog items, create a GitHub issue with the feat
 | `make lint-i18n`       | Validate translation files (syntax + content)    | Before every commit (translation changes)|
 | `make lint-yaml`       | Validate YAML configuration files                | Before every commit (config changes)     |
 | `make lint-container`  | Validate Symfony DI container                    | Before every commit                      |
+| `make audit`           | Run dependency vulnerability audit (PHP + JS)    | Before every commit                      |
+| `make audit.php`       | Run PHP dependency vulnerability audit            | When checking PHP deps only              |
+| `make audit.js`        | Run JS dependency vulnerability audit             | When checking JS deps only               |
 
 ### Messenger Workers
 

--- a/Makefile
+++ b/Makefile
@@ -173,3 +173,18 @@ stylelint: ## Lint SCSS and CSS files
 .PHONY: stylelint-fix
 stylelint-fix: ## Fix SCSS and CSS style issues
 	npx stylelint "assets/**/*.scss" --fix
+
+## —— Security —————————————————————————————————————————————————————————
+
+.PHONY: audit
+audit: ## Run dependency vulnerability audit (PHP + JS)
+	symfony composer audit
+	npm audit
+
+.PHONY: audit.php
+audit.php: ## Run PHP dependency vulnerability audit
+	symfony composer audit
+
+.PHONY: audit.js
+audit.js: ## Run JS dependency vulnerability audit
+	npm audit

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "bump-after-update": true,
         "sort-packages": true,
         "audit": {
-            "block-insecure": false
+            "block-insecure": true
         }
     },
     "autoload": {


### PR DESCRIPTION
Closes #438

## Summary
- Enable `composer audit` blocking (`block-insecure: true` in `composer.json`) so installs/updates fail on known CVEs
- Add `make audit`, `make audit.php`, and `make audit.js` Makefile targets under a new Security section
- Add `security-audit` CI job that runs both `composer audit` and `npm audit` in parallel with existing jobs
- Configure GitHub Dependabot (`.github/dependabot.yml`) for weekly vulnerability checks on both `composer` and `npm` ecosystems, targeting `develop`
- Document new make targets in `CLAUDE.md` (pre-commit checklist + commands table)

## Test plan
- [ ] `make audit` runs both PHP and JS audits
- [ ] `make audit.php` and `make audit.js` work independently
- [ ] CI `security-audit` job runs successfully
- [ ] Dependabot picks up the config after merge (may take a few minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)