### PR TITLE
:sparkles: Feature: add TcgdexApiThrottle rate limiting service

### DIFF
--- a/.env
+++ b/.env
@@ -105,6 +105,13 @@ SCALEWAY_S3_SECRET_KEY=
 MOSAIC_PUBLIC_URL=
 ###< mosaic storage ###
 
+###> tcgdex sync ###
+# Rate limiting for TCGdex API sync (F6.13)
+TCGDEX_SYNC_DELAY_MS=200
+TCGDEX_SYNC_FAILURE_THRESHOLD=3
+TCGDEX_SYNC_COOLDOWN_SECONDS=300
+###< tcgdex sync ###
+
 ###> editor upload storage ###
 # Editor image upload storage adapter: "local" or "s3"
 EDITOR_UPLOAD_STORAGE_ADAPTER=local

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -18,6 +18,9 @@ framework:
         pools:
             cache.menu_categories:
                 default_lifetime: 3600
+            cache.tcgdex_throttle:
+                adapter: cache.adapter.filesystem
+                default_lifetime: 600
 
 when@prod:
     framework:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -101,6 +101,13 @@ services:
         arguments:
             $projectDir: '%kernel.project_dir%'
 
+    App\Service\Tcgdex\TcgdexApiThrottle:
+        arguments:
+            $cache: '@cache.tcgdex_throttle'
+            $minimumDelayMilliseconds: '%env(int:TCGDEX_SYNC_DELAY_MS)%'
+            $failureThreshold: '%env(int:TCGDEX_SYNC_FAILURE_THRESHOLD)%'
+            $cooldownDurationSeconds: '%env(int:TCGDEX_SYNC_COOLDOWN_SECONDS)%'
+
     App\Service\EnrichmentFlushService:
         arguments:
             $mosaicStorage: '@mosaic.storage'

--- a/src/Service/Tcgdex/TcgdexApiThrottle.php
+++ b/src/Service/Tcgdex/TcgdexApiThrottle.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Tcgdex;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * Rate limiter for TCGdex API calls during incremental sync.
+ *
+ * Enforces a minimum delay between API calls and enters a cooldown period
+ * after consecutive failures. State is stored in a filesystem-backed cache
+ * pool shared across all worker processes.
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+class TcgdexApiThrottle
+{
+    private const string CACHE_KEY_LAST_CALL = 'tcgdex_sync.last_call_at';
+    private const string CACHE_KEY_FAILURES = 'tcgdex_sync.consecutive_failures';
+    private const string CACHE_KEY_COOLDOWN = 'tcgdex_sync.cooldown_until';
+
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly LoggerInterface $logger,
+        private readonly int $minimumDelayMilliseconds = 200,
+        private readonly int $failureThreshold = 3,
+        private readonly int $cooldownDurationSeconds = 300,
+    ) {
+    }
+
+    /**
+     * Wait until the API can be called again.
+     *
+     * If a cooldown is active, sleeps until it expires. Then enforces the
+     * minimum delay since the last API call. Updates the last-call timestamp.
+     */
+    public function waitIfNeeded(): void
+    {
+        // Wait out cooldown if active
+        $cooldownUntil = $this->getCacheFloat(self::CACHE_KEY_COOLDOWN);
+
+        if (null !== $cooldownUntil) {
+            $remaining = $cooldownUntil - microtime(true);
+
+            if ($remaining > 0) {
+                $this->logger->info('TCGdex throttle: cooldown active, sleeping {seconds}s', [
+                    'seconds' => round($remaining, 1),
+                ]);
+                $this->sleepMicroseconds((int) ($remaining * 1_000_000));
+            }
+        }
+
+        // Enforce minimum delay since last call
+        $lastCallAt = $this->getCacheFloat(self::CACHE_KEY_LAST_CALL);
+
+        if (null !== $lastCallAt) {
+            $elapsed = microtime(true) - $lastCallAt;
+            $minimumDelay = $this->minimumDelayMilliseconds / 1000.0;
+            $remaining = $minimumDelay - $elapsed;
+
+            if ($remaining > 0) {
+                $this->sleepMicroseconds((int) ($remaining * 1_000_000));
+            }
+        }
+
+        // Record this call's timestamp
+        $this->setCacheFloat(self::CACHE_KEY_LAST_CALL, microtime(true));
+    }
+
+    /**
+     * Report a successful API call. Resets the consecutive failure counter.
+     */
+    public function reportSuccess(): void
+    {
+        $this->setCacheInt(self::CACHE_KEY_FAILURES, 0);
+    }
+
+    /**
+     * Report a failed API call. Increments the failure counter and activates
+     * cooldown if the threshold is reached.
+     */
+    public function reportFailure(): void
+    {
+        $failures = $this->getConsecutiveFailures() + 1;
+        $this->setCacheInt(self::CACHE_KEY_FAILURES, $failures);
+
+        if ($failures >= $this->failureThreshold) {
+            $cooldownUntil = microtime(true) + $this->cooldownDurationSeconds;
+            $this->setCacheFloat(self::CACHE_KEY_COOLDOWN, $cooldownUntil);
+
+            $this->logger->warning('TCGdex throttle: {failures} consecutive failures, entering {seconds}s cooldown', [
+                'failures' => $failures,
+                'seconds' => $this->cooldownDurationSeconds,
+            ]);
+        }
+    }
+
+    /**
+     * Whether the throttle is currently in cooldown mode.
+     */
+    public function isInCooldown(): bool
+    {
+        $cooldownUntil = $this->getCacheFloat(self::CACHE_KEY_COOLDOWN);
+
+        return null !== $cooldownUntil && $cooldownUntil > microtime(true);
+    }
+
+    /**
+     * Number of consecutive API failures since the last success.
+     */
+    public function getConsecutiveFailures(): int
+    {
+        return $this->getCacheInt(self::CACHE_KEY_FAILURES);
+    }
+
+    /**
+     * @internal visible for testing — allows subclass to override sleep behavior
+     */
+    protected function sleepMicroseconds(int $microseconds): void
+    {
+        usleep($microseconds);
+    }
+
+    private function getCacheFloat(string $key): ?float
+    {
+        /** @var float|null $value */
+        $value = $this->cache->get($key, static function (ItemInterface $item): null {
+            $item->expiresAfter(600);
+
+            return null;
+        });
+
+        return $value;
+    }
+
+    private function setCacheFloat(string $key, float $value): void
+    {
+        $this->cache->delete($key);
+        $this->cache->get($key, static function (ItemInterface $item) use ($value): float {
+            $item->expiresAfter(600);
+
+            return $value;
+        });
+    }
+
+    private function getCacheInt(string $key): int
+    {
+        /** @var int|null $value */
+        $value = $this->cache->get($key, static function (ItemInterface $item): int {
+            $item->expiresAfter(600);
+
+            return 0;
+        });
+
+        return $value ?? 0;
+    }
+
+    private function setCacheInt(string $key, int $value): void
+    {
+        $this->cache->delete($key);
+        $this->cache->get($key, static function (ItemInterface $item) use ($value): int {
+            $item->expiresAfter(600);
+
+            return $value;
+        });
+    }
+}

--- a/tests/Service/Tcgdex/TcgdexApiThrottleTest.php
+++ b/tests/Service/Tcgdex/TcgdexApiThrottleTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\Tcgdex;
+
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+class TcgdexApiThrottleTest extends TestCase
+{
+    private ArrayAdapter $cache;
+    private LoggerInterface $logger;
+
+    /** @var list<int> Microseconds slept during test, captured by the test double */
+    private array $sleeps = [];
+
+    protected function setUp(): void
+    {
+        $this->cache = new ArrayAdapter();
+        $this->logger = $this->createStub(LoggerInterface::class);
+        $this->sleeps = [];
+    }
+
+    public function testWaitIfNeededEnforcesMinimumDelay(): void
+    {
+        $throttle = $this->createThrottle(minimumDelayMilliseconds: 100);
+
+        // First call: no delay (no previous call)
+        $throttle->waitIfNeeded();
+        self::assertSame([], $this->sleeps);
+
+        // Second call immediately: should sleep for ~100ms
+        $throttle->waitIfNeeded();
+        self::assertCount(1, $this->sleeps);
+        self::assertGreaterThan(0, $this->sleeps[0]);
+    }
+
+    public function testReportSuccessResetsFailureCounter(): void
+    {
+        $throttle = $this->createThrottle();
+
+        $throttle->reportFailure();
+        $throttle->reportFailure();
+        self::assertSame(2, $throttle->getConsecutiveFailures());
+
+        $throttle->reportSuccess();
+        self::assertSame(0, $throttle->getConsecutiveFailures());
+    }
+
+    public function testReportFailureIncrementsCounter(): void
+    {
+        $throttle = $this->createThrottle();
+
+        self::assertSame(0, $throttle->getConsecutiveFailures());
+
+        $throttle->reportFailure();
+        self::assertSame(1, $throttle->getConsecutiveFailures());
+
+        $throttle->reportFailure();
+        self::assertSame(2, $throttle->getConsecutiveFailures());
+    }
+
+    public function testCooldownActivatesAfterThreshold(): void
+    {
+        $throttle = $this->createThrottle(failureThreshold: 3);
+
+        $throttle->reportFailure();
+        $throttle->reportFailure();
+        self::assertFalse($throttle->isInCooldown());
+
+        // Third failure triggers cooldown
+        $throttle->reportFailure();
+        self::assertTrue($throttle->isInCooldown());
+    }
+
+    public function testCooldownNotActiveBeforeThreshold(): void
+    {
+        $throttle = $this->createThrottle(failureThreshold: 5);
+
+        $throttle->reportFailure();
+        $throttle->reportFailure();
+        $throttle->reportFailure();
+        $throttle->reportFailure();
+        self::assertFalse($throttle->isInCooldown());
+    }
+
+    public function testWaitIfNeededSleepsDuringCooldown(): void
+    {
+        $throttle = $this->createThrottle(failureThreshold: 1, cooldownDurationSeconds: 60);
+
+        // Trigger cooldown
+        $throttle->reportFailure();
+        self::assertTrue($throttle->isInCooldown());
+
+        // waitIfNeeded should sleep
+        $throttle->waitIfNeeded();
+        self::assertNotEmpty($this->sleeps);
+        // First sleep should be roughly 60s worth of microseconds
+        self::assertGreaterThan(50_000_000, $this->sleeps[0]);
+    }
+
+    public function testSuccessAfterCooldownResetsBoth(): void
+    {
+        $throttle = $this->createThrottle(failureThreshold: 2, cooldownDurationSeconds: 0);
+
+        $throttle->reportFailure();
+        $throttle->reportFailure();
+
+        // Cooldown duration is 0 so it should already have expired
+        $throttle->reportSuccess();
+        self::assertSame(0, $throttle->getConsecutiveFailures());
+        self::assertFalse($throttle->isInCooldown());
+    }
+
+    public function testIsInCooldownReturnsFalseWhenNoCooldown(): void
+    {
+        $throttle = $this->createThrottle();
+        self::assertFalse($throttle->isInCooldown());
+    }
+
+    public function testGetConsecutiveFailuresReturnsZeroInitially(): void
+    {
+        $throttle = $this->createThrottle();
+        self::assertSame(0, $throttle->getConsecutiveFailures());
+    }
+
+    public function testMultipleFailuresBeyondThresholdKeepCooldown(): void
+    {
+        $throttle = $this->createThrottle(failureThreshold: 2, cooldownDurationSeconds: 300);
+
+        $throttle->reportFailure();
+        $throttle->reportFailure();
+        self::assertTrue($throttle->isInCooldown());
+        self::assertSame(2, $throttle->getConsecutiveFailures());
+
+        // Additional failures keep counting and stay in cooldown
+        $throttle->reportFailure();
+        self::assertTrue($throttle->isInCooldown());
+        self::assertSame(3, $throttle->getConsecutiveFailures());
+    }
+
+    private function createThrottle(
+        int $minimumDelayMilliseconds = 200,
+        int $failureThreshold = 3,
+        int $cooldownDurationSeconds = 300,
+    ): TcgdexApiThrottle {
+        $test = $this;
+
+        return new class($this->cache, $this->logger, $minimumDelayMilliseconds, $failureThreshold, $cooldownDurationSeconds, $test) extends TcgdexApiThrottle {
+            /** @var TcgdexApiThrottleTest */
+            private object $testInstance;
+
+            public function __construct(
+                \Symfony\Contracts\Cache\CacheInterface $cache,
+                LoggerInterface $logger,
+                int $minimumDelayMilliseconds,
+                int $failureThreshold,
+                int $cooldownDurationSeconds,
+                object $testInstance,
+            ) {
+                parent::__construct($cache, $logger, $minimumDelayMilliseconds, $failureThreshold, $cooldownDurationSeconds);
+                $this->testInstance = $testInstance;
+            }
+
+            protected function sleepMicroseconds(int $microseconds): void
+            {
+                $this->testInstance->recordSleep($microseconds);
+            }
+        };
+    }
+
+    /**
+     * @internal called by test double to record sleep calls without actually sleeping
+     */
+    public function recordSleep(int $microseconds): void
+    {
+        $this->sleeps[] = $microseconds;
+    }
+}


### PR DESCRIPTION
## Summary

Phase B of incremental TCGdex database sync (#411 / F6.13):

- **`TcgdexApiThrottle`** service with filesystem-backed cache pool (`cache.tcgdex_throttle`) shared across all worker processes
- **Minimum delay** enforcement between API calls (default 200ms)
- **Consecutive failure tracking** with configurable cooldown (default: 3 failures → 5 min cooldown)
- **3 env vars**: `TCGDEX_SYNC_DELAY_MS`, `TCGDEX_SYNC_FAILURE_THRESHOLD`, `TCGDEX_SYNC_COOLDOWN_SECONDS`
- **10 unit tests** covering: delay enforcement, failure counting, cooldown activation/expiry, success reset

Closes #418

## Test plan
- [ ] `make phpstan` passes at level 10
- [ ] `make test.unit` — 860 tests pass (10 new throttle tests)
- [ ] `make lint-yaml` — config files valid
- [ ] `symfony console debug:container TcgdexApiThrottle` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)