### PR TITLE
:sparkles: Feature: TCGdex incremental sync (full stack)

### DIFF
--- a/.env
+++ b/.env
@@ -111,6 +111,8 @@ MOSAIC_PUBLIC_URL=
 TCGDEX_SYNC_DELAY_MS=200
 TCGDEX_SYNC_FAILURE_THRESHOLD=3
 TCGDEX_SYNC_COOLDOWN_SECONDS=300
+# HMAC-SHA256 secret for the webhook trigger URL. Leave empty to disable.
+TCGDEX_SYNC_WEBHOOK_SECRET=
 ###< tcgdex sync ###
 
 ###> editor upload storage ###

--- a/.env
+++ b/.env
@@ -112,7 +112,7 @@ TCGDEX_SYNC_DELAY_MS=200
 TCGDEX_SYNC_FAILURE_THRESHOLD=3
 TCGDEX_SYNC_COOLDOWN_SECONDS=300
 # HMAC-SHA256 secret for the webhook trigger URL. Leave empty to disable.
-TCGDEX_SYNC_WEBHOOK_SECRET=
+TCGDEX_SYNC_WEBHOOK_SECRET=dev-tcgdex-sync-secret
 ###< tcgdex sync ###
 
 ###> editor upload storage ###

--- a/.env
+++ b/.env
@@ -46,6 +46,7 @@ MESSENGER_TRANSPORT_TRANSACTIONAL_EMAIL_DSN=doctrine://default?auto_setup=0
 MESSENGER_TRANSPORT_DECK_ENRICHMENT_DSN=doctrine://default?auto_setup=0
 MESSENGER_TRANSPORT_NOTIFICATION_DSN=doctrine://default?auto_setup=0
 MESSENGER_TRANSPORT_BORROW_LIFECYCLE_DSN=doctrine://default?auto_setup=0
+MESSENGER_TRANSPORT_TCGDEX_SYNC_DSN=doctrine://default?auto_setup=0
 MESSENGER_TRANSPORT_FAILED_DSN=doctrine://default?queue_name=failed
 ###< symfony/messenger ###
 

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,13 @@ worker.notification: ## Run the notification Messenger worker
 worker.borrow: ## Run the borrow lifecycle Messenger worker
 	symfony console messenger:consume borrow_lifecycle -vv --no-debug
 
+.PHONY: worker.sync
+worker.sync: ## Run the TCGdex sync Messenger worker
+	symfony console messenger:consume tcgdex_sync_series tcgdex_sync_serie tcgdex_sync_set tcgdex_sync_card -vv --no-debug
+
 .PHONY: worker.all
 worker.all: ## Run all Messenger workers
-	symfony console messenger:consume transactional_email deck_enrichment notification borrow_lifecycle -vv --no-debug
+	symfony console messenger:consume transactional_email deck_enrichment notification borrow_lifecycle tcgdex_sync_series tcgdex_sync_serie tcgdex_sync_set tcgdex_sync_card -vv --no-debug
 
 ## —— Database —————————————————————————————————————————————————————————
 

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -39,6 +39,30 @@ framework:
                 retry_strategy:
                     max_retries: 3
                     multiplier: 2
+            tcgdex_sync_series:
+                dsn: '%env(MESSENGER_TRANSPORT_TCGDEX_SYNC_DSN)%'
+                options:
+                    queue_name: tcgdex_sync_series
+                retry_strategy:
+                    max_retries: 0
+            tcgdex_sync_serie:
+                dsn: '%env(MESSENGER_TRANSPORT_TCGDEX_SYNC_DSN)%'
+                options:
+                    queue_name: tcgdex_sync_serie
+                retry_strategy:
+                    max_retries: 0
+            tcgdex_sync_set:
+                dsn: '%env(MESSENGER_TRANSPORT_TCGDEX_SYNC_DSN)%'
+                options:
+                    queue_name: tcgdex_sync_set
+                retry_strategy:
+                    max_retries: 0
+            tcgdex_sync_card:
+                dsn: '%env(MESSENGER_TRANSPORT_TCGDEX_SYNC_DSN)%'
+                options:
+                    queue_name: tcgdex_sync_card
+                retry_strategy:
+                    max_retries: 0
             failed:
                 dsn: '%env(MESSENGER_TRANSPORT_FAILED_DSN)%'
                 options:
@@ -58,6 +82,11 @@ framework:
             App\Message\GenerateDeckMosaicMessage: deck_enrichment
             App\Message\GenerateMinifiedListMessage: deck_enrichment
             App\Message\GenerateMinifiedMosaicMessage: deck_enrichment
+            App\Message\SyncTcgdexSeriesMessage: tcgdex_sync_series
+            App\Message\SyncTcgdexSerieMessage: tcgdex_sync_serie
+            App\Message\SyncTcgdexSetMessage: tcgdex_sync_set
+            App\Message\SyncTcgdexCardMessage: tcgdex_sync_card
+            App\Message\SyncTcgdexCompleteMessage: deck_enrichment
             App\Message\DeclineCompetingBorrowsMessage: borrow_lifecycle
             App\Message\CancelEventBorrowsMessage: borrow_lifecycle
             App\Message\StartEndingPhaseMessage: borrow_lifecycle

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -58,6 +58,7 @@ security:
         - { path: '^/event/\d+/results$', roles: PUBLIC_ACCESS }
         - { path: ^/health, roles: PUBLIC_ACCESS }
         - { path: ^/webhook/messenger/, roles: PUBLIC_ACCESS }
+        - { path: ^/webhook/tcgdex-sync$, roles: PUBLIC_ACCESS }
         - { path: ^/admin/technical, roles: ROLE_TECHNICAL_ADMIN }
         - { path: ^/admin/archetypes, roles: ROLE_ARCHETYPE_EDITOR }
         - { path: ^/admin/pages, roles: ROLE_CMS_EDITOR }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -101,6 +101,10 @@ services:
         arguments:
             $projectDir: '%kernel.project_dir%'
 
+    App\Service\Tcgdex\TcgdexSyncStatusService:
+        arguments:
+            $cache: '@cache.tcgdex_throttle'
+
     App\Service\Tcgdex\TcgdexApiThrottle:
         arguments:
             $cache: '@cache.tcgdex_throttle'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -101,6 +101,10 @@ services:
         arguments:
             $projectDir: '%kernel.project_dir%'
 
+    App\Controller\WebhookTcgdexSyncController:
+        arguments:
+            $tcgdexSyncWebhookSecret: '%env(TCGDEX_SYNC_WEBHOOK_SECRET)%'
+
     App\Service\Tcgdex\TcgdexSyncStatusService:
         arguments:
             $cache: '@cache.tcgdex_throttle'

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -22,6 +22,26 @@ services:
         arguments:
             $tcgdexClient: '@App\Tests\HttpClient\TcgdexMockHttpClient'
 
+    App\MessageHandler\SyncTcgdexSeriesHandler:
+        autowire: true
+        arguments:
+            $tcgdexClient: '@App\Tests\HttpClient\TcgdexMockHttpClient'
+
+    App\MessageHandler\SyncTcgdexSerieHandler:
+        autowire: true
+        arguments:
+            $tcgdexClient: '@App\Tests\HttpClient\TcgdexMockHttpClient'
+
+    App\MessageHandler\SyncTcgdexSetHandler:
+        autowire: true
+        arguments:
+            $tcgdexClient: '@App\Tests\HttpClient\TcgdexMockHttpClient'
+
+    App\MessageHandler\SyncTcgdexCardHandler:
+        autowire: true
+        arguments:
+            $tcgdexClient: '@App\Tests\HttpClient\TcgdexMockHttpClient'
+
     # Stub mosaic generation — GD image rendering is too expensive for
     # functional tests. The HTML mosaic is the primary display; server-generated
     # images are covered by dedicated unit tests.

--- a/src/Command/SyncTcgdexCommand.php
+++ b/src/Command/SyncTcgdexCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Enum\SyncMode;
+use App\Message\SyncTcgdexSeriesMessage;
+use App\Service\Tcgdex\TcgdexSyncStatusService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Trigger an incremental sync of the TCGdex database via the API.
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+#[AsCommand(
+    name: 'app:tcgdex:sync',
+    description: 'Trigger an incremental sync of the TCGdex database via the API.',
+)]
+class SyncTcgdexCommand extends Command
+{
+    public function __construct(
+        private readonly MessageBusInterface $messageBus,
+        private readonly TcgdexSyncStatusService $syncStatus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('mode', null, InputOption::VALUE_REQUIRED, 'Sync mode: insert (default), update, or full.', 'insert')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Required for full mode (re-fetches every card).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var string $modeValue */
+        $modeValue = $input->getOption('mode');
+        $mode = SyncMode::tryFrom($modeValue);
+
+        if (null === $mode) {
+            $io->error(\sprintf('Invalid sync mode "%s". Valid modes: insert, update, full.', $modeValue));
+
+            return Command::INVALID;
+        }
+
+        if (SyncMode::Full === $mode && !$input->getOption('force')) {
+            $io->error('Full mode re-fetches every card from the API. Pass --force to confirm.');
+
+            return Command::INVALID;
+        }
+
+        $queueDepth = $this->syncStatus->getQueueDepth();
+
+        if ($queueDepth > 0) {
+            $io->warning(\sprintf('A sync is already in progress (%d messages pending). Dispatching anyway.', $queueDepth));
+        }
+
+        $this->messageBus->dispatch(new SyncTcgdexSeriesMessage($mode));
+
+        $io->success(\sprintf('TCGdex sync dispatched in "%s" mode. Run a worker to process: make worker.sync', $mode->value));
+
+        $lastSync = $this->syncStatus->getLastSyncTimestamp();
+
+        if (null !== $lastSync) {
+            $io->text(\sprintf('Last completed sync: %s', $lastSync->format('Y-m-d H:i:s')));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/AdminTechnicalController.php
+++ b/src/Controller/AdminTechnicalController.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Enum\SyncMode;
 use App\Message\BuildSetMappingsMessage;
 use App\Message\EnrichDeckVersionMessage;
+use App\Message\SyncTcgdexSeriesMessage;
 use App\Repository\BannedCardRepository;
 use App\Repository\DeckVersionRepository;
 use App\Repository\TcgdexSetMappingRepository;
@@ -22,6 +24,8 @@ use App\Service\BannedCardsSyncService;
 use App\Service\CardReenrichService;
 use App\Service\EnrichmentFlushService;
 use App\Service\Mosaic\MosaicRedispatchService;
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use App\Service\Tcgdex\TcgdexSyncStatusService;
 use App\Twig\Runtime\MenuRuntime;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -46,6 +50,8 @@ class AdminTechnicalController extends AbstractAppController
         private readonly EnrichmentFlushService $enrichmentFlushService,
         private readonly TcgdexSetMappingRepository $setMappingRepository,
         private readonly CardReenrichService $cardReenrichService,
+        private readonly TcgdexSyncStatusService $syncStatusService,
+        private readonly TcgdexApiThrottle $tcgdexApiThrottle,
     ) {
         parent::__construct($translator);
     }
@@ -63,6 +69,9 @@ class AdminTechnicalController extends AbstractAppController
             'pendingMosaics' => $pendingMosaics,
             'bannedCardCount' => $bannedCardCount,
             'setMappingCount' => $setMappingCount,
+            'syncQueueDepth' => $this->syncStatusService->getQueueDepth(),
+            'syncLastCompleted' => $this->syncStatusService->getLastSyncTimestamp(),
+            'syncInCooldown' => $this->tcgdexApiThrottle->isInCooldown(),
         ]);
     }
 
@@ -190,6 +199,42 @@ class AdminTechnicalController extends AbstractAppController
         $this->messageBus->dispatch(new BuildSetMappingsMessage());
 
         $this->addFlash('success', 'app.admin.technical.set_mappings.dispatched');
+
+        return $this->redirectToRoute('app_admin_technical_dashboard');
+    }
+
+    /**
+     * @see docs/features.md F6.13 — Incremental TCGdex database sync
+     */
+    #[Route('/tcgdex-sync-insert', name: 'app_admin_technical_tcgdex_sync_insert', methods: ['POST'])]
+    public function tcgdexSyncInsert(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('technical-tcgdex-sync-insert', $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        $this->messageBus->dispatch(new SyncTcgdexSeriesMessage(SyncMode::Insert));
+        $this->addFlash('success', 'app.admin.technical.tcgdex_sync.dispatched_insert');
+
+        return $this->redirectToRoute('app_admin_technical_dashboard');
+    }
+
+    /**
+     * @see docs/features.md F6.13 — Incremental TCGdex database sync
+     */
+    #[Route('/tcgdex-sync-update', name: 'app_admin_technical_tcgdex_sync_update', methods: ['POST'])]
+    public function tcgdexSyncUpdate(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('technical-tcgdex-sync-update', $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        $this->messageBus->dispatch(new SyncTcgdexSeriesMessage(SyncMode::Update));
+        $this->addFlash('success', 'app.admin.technical.tcgdex_sync.dispatched_update');
 
         return $this->redirectToRoute('app_admin_technical_dashboard');
     }

--- a/src/Controller/WebhookTcgdexSyncController.php
+++ b/src/Controller/WebhookTcgdexSyncController.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Enum\SyncMode;
+use App\Message\SyncTcgdexSeriesMessage;
+use App\Service\Tcgdex\TcgdexSyncStatusService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Anonymous webhook endpoint for triggering TCGdex insert-mode sync.
+ *
+ * Protected by HMAC-SHA256 signature verification. Designed to be called
+ * by a periodic serverless job (cron, Lambda, Scaleway Serverless).
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+class WebhookTcgdexSyncController
+{
+    public function __construct(
+        private readonly MessageBusInterface $messageBus,
+        private readonly TcgdexSyncStatusService $syncStatus,
+        private readonly string $tcgdexSyncWebhookSecret,
+    ) {
+    }
+
+    #[Route('/webhook/tcgdex-sync', name: 'app_webhook_tcgdex_sync', methods: ['POST'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        if ('' === $this->tcgdexSyncWebhookSecret) {
+            return new JsonResponse(['error' => 'Webhook not configured.'], Response::HTTP_NOT_FOUND);
+        }
+
+        $signature = $request->headers->get('X-Sync-Signature', '');
+        $body = $request->getContent();
+
+        if (!$this->isSignatureValid($signature, $body)) {
+            return new JsonResponse(['error' => 'Invalid signature.'], Response::HTTP_FORBIDDEN);
+        }
+
+        $queueDepth = $this->syncStatus->getQueueDepth();
+
+        if ($queueDepth > 0) {
+            return new JsonResponse([
+                'status' => 'already_in_progress',
+                'queue_depth' => $queueDepth,
+            ]);
+        }
+
+        $this->messageBus->dispatch(new SyncTcgdexSeriesMessage(SyncMode::Insert));
+
+        return new JsonResponse(['status' => 'dispatched'], Response::HTTP_ACCEPTED);
+    }
+
+    private function isSignatureValid(string $signature, string $body): bool
+    {
+        if (!str_starts_with($signature, 'sha256=')) {
+            return false;
+        }
+
+        $expected = 'sha256='.hash_hmac('sha256', $body, $this->tcgdexSyncWebhookSecret);
+
+        return hash_equals($expected, $signature);
+    }
+}

--- a/src/Enum/SyncMode.php
+++ b/src/Enum/SyncMode.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Enum;
+
+/**
+ * Controls the depth of the incremental TCGdex sync.
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+enum SyncMode: string
+{
+    /** Only create missing entities (series, sets, cards). Default. */
+    case Insert = 'insert';
+
+    /** Create missing + update existing series and sets metadata (logos, names, card counts). Cards are only inserted, not updated. */
+    case Update = 'update';
+
+    /** Create missing + update all entities including existing cards (re-fetch and overwrite). */
+    case Full = 'full';
+}

--- a/src/Message/SyncTcgdexCardMessage.php
+++ b/src/Message/SyncTcgdexCardMessage.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace App\Message;
 
+use App\Enum\SyncMode;
+
 /**
  * Fetches and persists a single card from the TCGdex API.
  *
@@ -26,6 +28,7 @@ readonly class SyncTcgdexCardMessage
     public function __construct(
         public string $cardId,
         public string $setId,
+        public SyncMode $mode = SyncMode::Insert,
     ) {
     }
 }

--- a/src/Message/SyncTcgdexSerieMessage.php
+++ b/src/Message/SyncTcgdexSerieMessage.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace App\Message;
 
+use App\Enum\SyncMode;
+
 /**
  * Syncs a single TCGdex serie: detects missing or changed sets and dispatches
  * SyncTcgdexSetMessage for each.
@@ -23,6 +25,7 @@ readonly class SyncTcgdexSerieMessage
 {
     public function __construct(
         public string $serieId,
+        public SyncMode $mode = SyncMode::Insert,
     ) {
     }
 }

--- a/src/Message/SyncTcgdexSeriesMessage.php
+++ b/src/Message/SyncTcgdexSeriesMessage.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace App\Message;
 
+use App\Enum\SyncMode;
+
 /**
  * Triggers a full incremental sync of the TCGdex database (root entry point).
  *
@@ -23,4 +25,8 @@ namespace App\Message;
  */
 readonly class SyncTcgdexSeriesMessage
 {
+    public function __construct(
+        public SyncMode $mode = SyncMode::Insert,
+    ) {
+    }
 }

--- a/src/Message/SyncTcgdexSetMessage.php
+++ b/src/Message/SyncTcgdexSetMessage.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace App\Message;
 
+use App\Enum\SyncMode;
+
 /**
  * Syncs a single TCGdex set: detects missing cards and dispatches
  * SyncTcgdexCardMessage for each.
@@ -23,6 +25,7 @@ readonly class SyncTcgdexSetMessage
 {
     public function __construct(
         public string $setId,
+        public SyncMode $mode = SyncMode::Insert,
     ) {
     }
 }

--- a/src/MessageHandler/SyncTcgdexCardHandler.php
+++ b/src/MessageHandler/SyncTcgdexCardHandler.php
@@ -36,6 +36,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[AsMessageHandler]
 class SyncTcgdexCardHandler
 {
+    private const string BASE_URL = 'https://api.tcgdex.net/v2/en';
+
     public function __construct(
         private readonly HttpClientInterface $tcgdexClient,
         private readonly TcgdexApiThrottle $throttle,
@@ -61,7 +63,7 @@ class SyncTcgdexCardHandler
         $this->throttle->waitIfNeeded();
 
         try {
-            $response = $this->tcgdexClient->request('GET', '/cards/'.$cardId);
+            $response = $this->tcgdexClient->request('GET', self::BASE_URL.'/cards/'.$cardId);
             $statusCode = $response->getStatusCode();
         } catch (\Throwable $exception) {
             $this->throttle->reportFailure();

--- a/src/MessageHandler/SyncTcgdexCardHandler.php
+++ b/src/MessageHandler/SyncTcgdexCardHandler.php
@@ -15,6 +15,7 @@ namespace App\MessageHandler;
 
 use App\Entity\TcgdexCard;
 use App\Entity\TcgdexSet;
+use App\Enum\SyncMode;
 use App\Message\SyncTcgdexCardMessage;
 use App\Service\Tcgdex\TcgdexApiThrottle;
 use App\Service\Tcgdex\TcgdexCardHydrator;
@@ -52,11 +53,12 @@ class SyncTcgdexCardHandler
     {
         $cardId = $message->cardId;
         $setId = $message->setId;
+        $mode = $message->mode;
 
-        // Skip if already exists (race condition guard)
+        // In insert/update mode, skip if card already exists
         $existing = $this->entityManager->find(TcgdexCard::class, $cardId);
 
-        if (null !== $existing) {
+        if (null !== $existing && SyncMode::Full !== $mode) {
             return;
         }
 
@@ -101,7 +103,15 @@ class SyncTcgdexCardHandler
         try {
             /** @var array<string, mixed> $data */
             $data = $response->toArray();
-            $card = $this->hydrator->hydrateFromApiResponse($data, $set);
+
+            if (null !== $existing) {
+                // Full mode: update existing card
+                $this->hydrator->updateFromApiResponse($existing, $data);
+            } else {
+                // Insert new card
+                $card = $this->hydrator->hydrateFromApiResponse($data, $set);
+                $this->entityManager->persist($card);
+            }
         } catch (\Throwable $exception) {
             $this->logger->error('TCGdex sync: failed to hydrate card {cardId}: {error}', [
                 'cardId' => $cardId,
@@ -111,7 +121,6 @@ class SyncTcgdexCardHandler
             return;
         }
 
-        $this->entityManager->persist($card);
         $this->entityManager->flush();
     }
 }

--- a/src/MessageHandler/SyncTcgdexCardHandler.php
+++ b/src/MessageHandler/SyncTcgdexCardHandler.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\MessageHandler;
+
+use App\Entity\TcgdexCard;
+use App\Entity\TcgdexSet;
+use App\Message\SyncTcgdexCardMessage;
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use App\Service\Tcgdex\TcgdexCardHydrator;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Fetches a single card from the TCGdex API and persists it via the hydrator.
+ *
+ * On 404: logs a warning and does not redispatch (card genuinely doesn't exist).
+ * On other HTTP errors: redispatches with a delay for retry.
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+#[AsMessageHandler]
+class SyncTcgdexCardHandler
+{
+    public function __construct(
+        private readonly HttpClientInterface $tcgdexClient,
+        private readonly TcgdexApiThrottle $throttle,
+        private readonly TcgdexCardHydrator $hydrator,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SyncTcgdexCardMessage $message): void
+    {
+        $cardId = $message->cardId;
+        $setId = $message->setId;
+
+        // Skip if already exists (race condition guard)
+        $existing = $this->entityManager->find(TcgdexCard::class, $cardId);
+
+        if (null !== $existing) {
+            return;
+        }
+
+        $this->throttle->waitIfNeeded();
+
+        try {
+            $response = $this->tcgdexClient->request('GET', '/cards/'.$cardId);
+            $statusCode = $response->getStatusCode();
+        } catch (\Throwable $exception) {
+            $this->throttle->reportFailure();
+            $this->logger->error('TCGdex sync: failed to fetch card {cardId}: {error}', [
+                'cardId' => $cardId,
+                'error' => $exception->getMessage(),
+            ]);
+            $this->messageBus->dispatch($message, [new DelayStamp(60000)]);
+
+            return;
+        }
+
+        if (404 === $statusCode) {
+            $this->throttle->reportSuccess();
+            $this->logger->warning('TCGdex sync: card {cardId} returned 404, skipping.', [
+                'cardId' => $cardId,
+            ]);
+
+            return;
+        }
+
+        $this->throttle->reportSuccess();
+
+        $set = $this->entityManager->find(TcgdexSet::class, $setId);
+
+        if (null === $set) {
+            $this->logger->warning('TCGdex sync: set {setId} not found for card {cardId}, skipping.', [
+                'setId' => $setId,
+                'cardId' => $cardId,
+            ]);
+
+            return;
+        }
+
+        try {
+            /** @var array<string, mixed> $data */
+            $data = $response->toArray();
+            $card = $this->hydrator->hydrateFromApiResponse($data, $set);
+        } catch (\Throwable $exception) {
+            $this->logger->error('TCGdex sync: failed to hydrate card {cardId}: {error}', [
+                'cardId' => $cardId,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $this->entityManager->persist($card);
+        $this->entityManager->flush();
+    }
+}

--- a/src/MessageHandler/SyncTcgdexCompleteHandler.php
+++ b/src/MessageHandler/SyncTcgdexCompleteHandler.php
@@ -17,6 +17,7 @@ use App\Message\BuildSetMappingsMessage;
 use App\Message\EnrichDeckVersionMessage;
 use App\Message\SyncTcgdexCompleteMessage;
 use App\Repository\DeckVersionRepository;
+use App\Service\Tcgdex\TcgdexSyncStatusService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -34,6 +35,7 @@ class SyncTcgdexCompleteHandler
 {
     public function __construct(
         private readonly DeckVersionRepository $versionRepository,
+        private readonly TcgdexSyncStatusService $syncStatus,
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
     ) {
@@ -42,6 +44,8 @@ class SyncTcgdexCompleteHandler
     public function __invoke(SyncTcgdexCompleteMessage $message): void
     {
         $this->logger->info('TCGdex sync complete: triggering post-sync actions.');
+
+        $this->syncStatus->recordSyncCompleted();
 
         // Rebuild set mappings
         $this->messageBus->dispatch(new BuildSetMappingsMessage());

--- a/src/MessageHandler/SyncTcgdexCompleteHandler.php
+++ b/src/MessageHandler/SyncTcgdexCompleteHandler.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\MessageHandler;
+
+use App\Message\BuildSetMappingsMessage;
+use App\Message\EnrichDeckVersionMessage;
+use App\Message\SyncTcgdexCompleteMessage;
+use App\Repository\DeckVersionRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Post-sync handler: rebuilds set mappings and re-enriches failed deck versions.
+ *
+ * This message is dispatched with a 10-minute delay by SyncTcgdexSeriesHandler
+ * to allow the cascade to finish before triggering downstream actions.
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+#[AsMessageHandler]
+class SyncTcgdexCompleteHandler
+{
+    public function __construct(
+        private readonly DeckVersionRepository $versionRepository,
+        private readonly MessageBusInterface $messageBus,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SyncTcgdexCompleteMessage $message): void
+    {
+        $this->logger->info('TCGdex sync complete: triggering post-sync actions.');
+
+        // Rebuild set mappings
+        $this->messageBus->dispatch(new BuildSetMappingsMessage());
+
+        // Re-enrich deck versions that failed or are still pending
+        $notEnriched = $this->versionRepository->findNotEnriched();
+        $dispatched = 0;
+
+        foreach ($notEnriched as $version) {
+            $versionId = $version->getId();
+
+            if (null === $versionId) {
+                continue;
+            }
+
+            $this->messageBus->dispatch(new EnrichDeckVersionMessage($versionId));
+            ++$dispatched;
+        }
+
+        if ($dispatched > 0) {
+            $this->logger->info('TCGdex sync complete: dispatched {count} re-enrichment messages.', [
+                'count' => $dispatched,
+            ]);
+        }
+    }
+}

--- a/src/MessageHandler/SyncTcgdexSerieHandler.php
+++ b/src/MessageHandler/SyncTcgdexSerieHandler.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\MessageHandler;
+
+use App\Entity\TcgdexSerie;
+use App\Entity\TcgdexSet;
+use App\Message\SyncTcgdexSerieMessage;
+use App\Message\SyncTcgdexSetMessage;
+use App\Repository\TcgdexCardRepository;
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Syncs a single serie: fetches set list, creates missing sets, and dispatches
+ * SyncTcgdexSetMessage for new or changed sets (sorted by release date DESC).
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+#[AsMessageHandler]
+class SyncTcgdexSerieHandler
+{
+    public function __construct(
+        private readonly HttpClientInterface $tcgdexClient,
+        private readonly TcgdexApiThrottle $throttle,
+        private readonly TcgdexCardRepository $cardRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SyncTcgdexSerieMessage $message): void
+    {
+        $serieId = $message->serieId;
+
+        $this->throttle->waitIfNeeded();
+
+        try {
+            $response = $this->tcgdexClient->request('GET', '/series/'.$serieId);
+            /** @var array<string, mixed> $serieData */
+            $serieData = $response->toArray();
+        } catch (\Throwable $exception) {
+            $this->throttle->reportFailure();
+            $this->logger->error('TCGdex sync: failed to fetch serie {serieId}: {error}', [
+                'serieId' => $serieId,
+                'error' => $exception->getMessage(),
+            ]);
+            $this->messageBus->dispatch($message, [new DelayStamp(60000)]);
+
+            return;
+        }
+
+        $this->throttle->reportSuccess();
+
+        /** @var list<array<string, mixed>> $setsData */
+        $setsData = isset($serieData['sets']) && \is_array($serieData['sets']) ? $serieData['sets'] : [];
+
+        $serie = $this->entityManager->find(TcgdexSerie::class, $serieId);
+
+        if (null === $serie) {
+            $this->logger->warning('TCGdex sync: serie {serieId} not found in database, skipping.', [
+                'serieId' => $serieId,
+            ]);
+
+            return;
+        }
+
+        // Update serie logo if available
+        $logo = $this->extractString($serieData, 'logo');
+
+        if (null !== $logo) {
+            $serie->setLogoUrl($logo);
+        }
+
+        // Identify existing sets by ID
+        $existingSetIds = [];
+
+        foreach ($serie->getSets() as $existingSet) {
+            $existingSetIds[$existingSet->getId()] = true;
+        }
+
+        /** @var list<array{setId: string, isNew: bool, releaseDate: string}> $setsToSync */
+        $setsToSync = [];
+        $created = 0;
+
+        foreach ($setsData as $setData) {
+            $setId = $this->extractString($setData, 'id');
+
+            if (null === $setId) {
+                continue;
+            }
+
+            $releaseDate = $this->extractString($setData, 'releaseDate') ?? '0000-00-00';
+
+            if (!isset($existingSetIds[$setId])) {
+                // New set — create entity
+                $set = new TcgdexSet($setId, $serie);
+
+                $name = $this->extractString($setData, 'name');
+
+                if (null !== $name) {
+                    $set->setName(['en' => $name]);
+                }
+
+                $set->setLogoUrl($this->extractString($setData, 'logo'));
+                $set->setSymbolUrl($this->extractString($setData, 'symbol'));
+
+                $this->entityManager->persist($set);
+                ++$created;
+
+                $setsToSync[] = ['setId' => $setId, 'isNew' => true, 'releaseDate' => $releaseDate];
+            } else {
+                // Existing set — check if card count changed
+                $apiCardCount = $this->extractInt($setData, 'cardCount');
+                $localCardCount = $this->cardRepository->countBySetId($setId);
+
+                if (null !== $apiCardCount && $apiCardCount !== $localCardCount) {
+                    $setsToSync[] = ['setId' => $setId, 'isNew' => false, 'releaseDate' => $releaseDate];
+                }
+            }
+        }
+
+        if ($created > 0) {
+            $this->entityManager->flush();
+        }
+
+        // Sort by releaseDate DESC (newest first)
+        usort($setsToSync, static fn (array $itemA, array $itemB): int => $itemB['releaseDate'] <=> $itemA['releaseDate']);
+
+        foreach ($setsToSync as $setToSync) {
+            $this->messageBus->dispatch(new SyncTcgdexSetMessage($setToSync['setId']));
+        }
+
+        if ([] !== $setsToSync) {
+            $this->logger->info('TCGdex sync: serie {serieId} — {created} new sets, {total} to sync.', [
+                'serieId' => $serieId,
+                'created' => $created,
+                'total' => \count($setsToSync),
+            ]);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function extractString(array $data, string $key): ?string
+    {
+        return isset($data[$key]) && \is_string($data[$key]) ? $data[$key] : null;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function extractInt(array $data, string $key): ?int
+    {
+        return isset($data[$key]) && \is_int($data[$key]) ? $data[$key] : null;
+    }
+}

--- a/src/MessageHandler/SyncTcgdexSerieHandler.php
+++ b/src/MessageHandler/SyncTcgdexSerieHandler.php
@@ -15,6 +15,7 @@ namespace App\MessageHandler;
 
 use App\Entity\TcgdexSerie;
 use App\Entity\TcgdexSet;
+use App\Enum\SyncMode;
 use App\Message\SyncTcgdexSerieMessage;
 use App\Message\SyncTcgdexSetMessage;
 use App\Repository\TcgdexCardRepository;
@@ -50,6 +51,7 @@ class SyncTcgdexSerieHandler
     public function __invoke(SyncTcgdexSerieMessage $message): void
     {
         $serieId = $message->serieId;
+        $mode = $message->mode;
 
         $this->throttle->waitIfNeeded();
 
@@ -127,9 +129,11 @@ class SyncTcgdexSerieHandler
                 ++$created;
 
                 $setsToSync[] = ['setId' => $setId, 'isNew' => true, 'releaseDate' => $releaseDate];
+            } elseif (SyncMode::Insert !== $mode) {
+                // Update/full mode: always sync existing sets (metadata + potential new cards)
+                $setsToSync[] = ['setId' => $setId, 'isNew' => false, 'releaseDate' => $releaseDate];
             } else {
-                // Existing set — check if card count changed
-                // API returns cardCount as {official: int, total: int}
+                // Insert mode: only sync if card count changed
                 $apiCardCount = $this->extractTotalCardCount($setData);
                 $localCardCount = $this->cardRepository->countBySetId($setId);
 
@@ -147,7 +151,7 @@ class SyncTcgdexSerieHandler
         usort($setsToSync, static fn (array $itemA, array $itemB): int => $itemB['releaseDate'] <=> $itemA['releaseDate']);
 
         foreach ($setsToSync as $setToSync) {
-            $this->messageBus->dispatch(new SyncTcgdexSetMessage($setToSync['setId']));
+            $this->messageBus->dispatch(new SyncTcgdexSetMessage($setToSync['setId'], $mode));
         }
 
         if ([] !== $setsToSync) {

--- a/src/MessageHandler/SyncTcgdexSerieHandler.php
+++ b/src/MessageHandler/SyncTcgdexSerieHandler.php
@@ -35,6 +35,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[AsMessageHandler]
 class SyncTcgdexSerieHandler
 {
+    private const string BASE_URL = 'https://api.tcgdex.net/v2/en';
+
     public function __construct(
         private readonly HttpClientInterface $tcgdexClient,
         private readonly TcgdexApiThrottle $throttle,
@@ -52,7 +54,7 @@ class SyncTcgdexSerieHandler
         $this->throttle->waitIfNeeded();
 
         try {
-            $response = $this->tcgdexClient->request('GET', '/series/'.$serieId);
+            $response = $this->tcgdexClient->request('GET', self::BASE_URL.'/series/'.$serieId);
             /** @var array<string, mixed> $serieData */
             $serieData = $response->toArray();
         } catch (\Throwable $exception) {
@@ -127,7 +129,8 @@ class SyncTcgdexSerieHandler
                 $setsToSync[] = ['setId' => $setId, 'isNew' => true, 'releaseDate' => $releaseDate];
             } else {
                 // Existing set — check if card count changed
-                $apiCardCount = $this->extractInt($setData, 'cardCount');
+                // API returns cardCount as {official: int, total: int}
+                $apiCardCount = $this->extractTotalCardCount($setData);
                 $localCardCount = $this->cardRepository->countBySetId($setId);
 
                 if (null !== $apiCardCount && $apiCardCount !== $localCardCount) {
@@ -157,18 +160,28 @@ class SyncTcgdexSerieHandler
     }
 
     /**
-     * @param array<string, mixed> $data
+     * Extract the total card count from the nested cardCount object.
+     *
+     * API format: {"cardCount": {"official": 162, "total": 218}}
+     *
+     * @param array<string, mixed> $setData
      */
-    private function extractString(array $data, string $key): ?string
+    private function extractTotalCardCount(array $setData): ?int
     {
-        return isset($data[$key]) && \is_string($data[$key]) ? $data[$key] : null;
+        if (!isset($setData['cardCount']) || !\is_array($setData['cardCount'])) {
+            return null;
+        }
+
+        $total = $setData['cardCount']['total'] ?? null;
+
+        return \is_int($total) ? $total : null;
     }
 
     /**
      * @param array<string, mixed> $data
      */
-    private function extractInt(array $data, string $key): ?int
+    private function extractString(array $data, string $key): ?string
     {
-        return isset($data[$key]) && \is_int($data[$key]) ? $data[$key] : null;
+        return isset($data[$key]) && \is_string($data[$key]) ? $data[$key] : null;
     }
 }

--- a/src/MessageHandler/SyncTcgdexSeriesHandler.php
+++ b/src/MessageHandler/SyncTcgdexSeriesHandler.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\MessageHandler;
+
+use App\Entity\TcgdexSerie;
+use App\Message\SyncTcgdexCompleteMessage;
+use App\Message\SyncTcgdexSerieMessage;
+use App\Message\SyncTcgdexSeriesMessage;
+use App\Repository\TcgdexSerieRepository;
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Root handler: fetches all series from TCGdex, creates missing entities,
+ * and dispatches SyncTcgdexSerieMessage for each (newest first).
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+#[AsMessageHandler]
+class SyncTcgdexSeriesHandler
+{
+    /** Serie ID to exclude (Pokemon TCG Pocket, not relevant). */
+    private const string EXCLUDED_SERIE = 'tcgp';
+
+    public function __construct(
+        private readonly HttpClientInterface $tcgdexClient,
+        private readonly TcgdexApiThrottle $throttle,
+        private readonly TcgdexSerieRepository $serieRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SyncTcgdexSeriesMessage $message): void
+    {
+        $this->logger->info('TCGdex sync: fetching all series…');
+
+        $this->throttle->waitIfNeeded();
+
+        try {
+            $response = $this->tcgdexClient->request('GET', '/series');
+            /** @var list<array<string, mixed>> $seriesList */
+            $seriesList = $response->toArray();
+        } catch (\Throwable $exception) {
+            $this->throttle->reportFailure();
+            $this->logger->error('TCGdex sync: failed to fetch series list: {error}', [
+                'error' => $exception->getMessage(),
+            ]);
+            $this->messageBus->dispatch($message, [new DelayStamp(60000)]);
+
+            return;
+        }
+
+        $this->throttle->reportSuccess();
+
+        $existingIds = array_flip($this->serieRepository->findAllIds());
+        $created = 0;
+
+        foreach ($seriesList as $serieData) {
+            $serieId = $this->extractString($serieData, 'id');
+
+            if (null === $serieId || self::EXCLUDED_SERIE === $serieId) {
+                continue;
+            }
+
+            if (!isset($existingIds[$serieId])) {
+                $serie = new TcgdexSerie($serieId);
+
+                $name = $this->extractString($serieData, 'name');
+
+                if (null !== $name) {
+                    $serie->setName(['en' => $name]);
+                }
+
+                $serie->setLogoUrl($this->extractString($serieData, 'logo'));
+
+                $this->entityManager->persist($serie);
+                ++$created;
+            }
+        }
+
+        if ($created > 0) {
+            $this->entityManager->flush();
+            $this->logger->info('TCGdex sync: created {count} new series.', ['count' => $created]);
+        }
+
+        // Sort by releaseDate DESC (newest first) and dispatch for all series
+        usort($seriesList, static function (array $itemA, array $itemB): int {
+            $dateA = (isset($itemA['releaseDate']) && \is_string($itemA['releaseDate'])) ? $itemA['releaseDate'] : '0000-00-00';
+            $dateB = (isset($itemB['releaseDate']) && \is_string($itemB['releaseDate'])) ? $itemB['releaseDate'] : '0000-00-00';
+
+            return $dateB <=> $dateA;
+        });
+
+        $dispatched = 0;
+
+        foreach ($seriesList as $serieData) {
+            $serieId = $this->extractString($serieData, 'id');
+
+            if (null === $serieId || self::EXCLUDED_SERIE === $serieId) {
+                continue;
+            }
+
+            $this->messageBus->dispatch(new SyncTcgdexSerieMessage($serieId));
+            ++$dispatched;
+        }
+
+        $this->logger->info('TCGdex sync: dispatched {count} serie sync messages.', ['count' => $dispatched]);
+
+        // Schedule post-sync completion (10 min delay to let the cascade finish)
+        $this->messageBus->dispatch(new SyncTcgdexCompleteMessage(), [new DelayStamp(600_000)]);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function extractString(array $data, string $key): ?string
+    {
+        return isset($data[$key]) && \is_string($data[$key]) ? $data[$key] : null;
+    }
+}

--- a/src/MessageHandler/SyncTcgdexSeriesHandler.php
+++ b/src/MessageHandler/SyncTcgdexSeriesHandler.php
@@ -35,6 +35,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[AsMessageHandler]
 class SyncTcgdexSeriesHandler
 {
+    private const string BASE_URL = 'https://api.tcgdex.net/v2/en';
+
     /** Serie ID to exclude (Pokemon TCG Pocket, not relevant). */
     private const string EXCLUDED_SERIE = 'tcgp';
 
@@ -55,7 +57,7 @@ class SyncTcgdexSeriesHandler
         $this->throttle->waitIfNeeded();
 
         try {
-            $response = $this->tcgdexClient->request('GET', '/series');
+            $response = $this->tcgdexClient->request('GET', self::BASE_URL.'/series');
             /** @var list<array<string, mixed>> $seriesList */
             $seriesList = $response->toArray();
         } catch (\Throwable $exception) {

--- a/src/MessageHandler/SyncTcgdexSeriesHandler.php
+++ b/src/MessageHandler/SyncTcgdexSeriesHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\MessageHandler;
 
 use App\Entity\TcgdexSerie;
+use App\Enum\SyncMode;
 use App\Message\SyncTcgdexCompleteMessage;
 use App\Message\SyncTcgdexSerieMessage;
 use App\Message\SyncTcgdexSeriesMessage;
@@ -52,7 +53,8 @@ class SyncTcgdexSeriesHandler
 
     public function __invoke(SyncTcgdexSeriesMessage $message): void
     {
-        $this->logger->info('TCGdex sync: fetching all series…');
+        $mode = $message->mode;
+        $this->logger->info('TCGdex sync: fetching all series… (mode: {mode})', ['mode' => $mode->value]);
 
         $this->throttle->waitIfNeeded();
 
@@ -74,6 +76,7 @@ class SyncTcgdexSeriesHandler
 
         $existingIds = array_flip($this->serieRepository->findAllIds());
         $created = 0;
+        $updated = 0;
 
         foreach ($seriesList as $serieData) {
             $serieId = $this->extractString($serieData, 'id');
@@ -95,12 +98,28 @@ class SyncTcgdexSeriesHandler
 
                 $this->entityManager->persist($serie);
                 ++$created;
+            } elseif (SyncMode::Insert !== $mode) {
+                // Update existing serie metadata
+                $serie = $this->entityManager->find(TcgdexSerie::class, $serieId);
+
+                if (null !== $serie) {
+                    $logo = $this->extractString($serieData, 'logo');
+
+                    if (null !== $logo) {
+                        $serie->setLogoUrl($logo);
+                    }
+
+                    ++$updated;
+                }
             }
         }
 
-        if ($created > 0) {
+        if ($created > 0 || $updated > 0) {
             $this->entityManager->flush();
-            $this->logger->info('TCGdex sync: created {count} new series.', ['count' => $created]);
+            $this->logger->info('TCGdex sync: {created} new series, {updated} updated.', [
+                'created' => $created,
+                'updated' => $updated,
+            ]);
         }
 
         // Sort by releaseDate DESC (newest first) and dispatch for all series
@@ -120,7 +139,7 @@ class SyncTcgdexSeriesHandler
                 continue;
             }
 
-            $this->messageBus->dispatch(new SyncTcgdexSerieMessage($serieId));
+            $this->messageBus->dispatch(new SyncTcgdexSerieMessage($serieId, $mode));
             ++$dispatched;
         }
 

--- a/src/MessageHandler/SyncTcgdexSetHandler.php
+++ b/src/MessageHandler/SyncTcgdexSetHandler.php
@@ -15,6 +15,7 @@ namespace App\MessageHandler;
 
 use App\Entity\TcgdexCard;
 use App\Entity\TcgdexSet;
+use App\Enum\SyncMode;
 use App\Message\SyncTcgdexCardMessage;
 use App\Message\SyncTcgdexSetMessage;
 use App\Service\Tcgdex\TcgdexApiThrottle;
@@ -48,6 +49,7 @@ class SyncTcgdexSetHandler
     public function __invoke(SyncTcgdexSetMessage $message): void
     {
         $setId = $message->setId;
+        $mode = $message->mode;
 
         $this->throttle->waitIfNeeded();
 
@@ -97,8 +99,8 @@ class SyncTcgdexSetHandler
 
             $existing = $this->entityManager->find(TcgdexCard::class, $cardId);
 
-            if (null === $existing) {
-                $this->messageBus->dispatch(new SyncTcgdexCardMessage($cardId, $setId));
+            if (null === $existing || SyncMode::Full === $mode) {
+                $this->messageBus->dispatch(new SyncTcgdexCardMessage($cardId, $setId, $mode));
                 ++$dispatched;
             }
         }

--- a/src/MessageHandler/SyncTcgdexSetHandler.php
+++ b/src/MessageHandler/SyncTcgdexSetHandler.php
@@ -84,11 +84,12 @@ class SyncTcgdexSetHandler
         $this->updateSetMetadata($set, $setData);
         $this->entityManager->flush();
 
-        // Dispatch card sync for missing cards
+        // Process cards from the set response
         /** @var list<array<string, mixed>> $cardsData */
         $cardsData = isset($setData['cards']) && \is_array($setData['cards']) ? $setData['cards'] : [];
 
         $dispatched = 0;
+        $updatedImages = 0;
 
         foreach ($cardsData as $cardData) {
             $cardId = $this->extractString($cardData, 'id');
@@ -99,10 +100,31 @@ class SyncTcgdexSetHandler
 
             $existing = $this->entityManager->find(TcgdexCard::class, $cardId);
 
-            if (null === $existing || SyncMode::Full === $mode) {
+            if (null === $existing) {
+                // New card — dispatch full hydration
                 $this->messageBus->dispatch(new SyncTcgdexCardMessage($cardId, $setId, $mode));
                 ++$dispatched;
+            } elseif (SyncMode::Full === $mode) {
+                // Full mode — re-fetch and overwrite entire card via per-card API call
+                $this->messageBus->dispatch(new SyncTcgdexCardMessage($cardId, $setId, $mode));
+                ++$dispatched;
+            } elseif (SyncMode::Update === $mode) {
+                // Update mode — update imageBaseUrl directly from set response (no per-card API call)
+                $imageBaseUrl = $this->extractString($cardData, 'image');
+
+                if (null !== $imageBaseUrl && $imageBaseUrl !== $existing->getImageBaseUrl()) {
+                    $existing->setImageBaseUrl($imageBaseUrl);
+                    ++$updatedImages;
+                }
             }
+        }
+
+        if ($updatedImages > 0) {
+            $this->entityManager->flush();
+            $this->logger->info('TCGdex sync: set {setId} — updated {count} card image URLs from set response.', [
+                'setId' => $setId,
+                'count' => $updatedImages,
+            ]);
         }
 
         if ($dispatched > 0) {

--- a/src/MessageHandler/SyncTcgdexSetHandler.php
+++ b/src/MessageHandler/SyncTcgdexSetHandler.php
@@ -34,6 +34,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[AsMessageHandler]
 class SyncTcgdexSetHandler
 {
+    private const string BASE_URL = 'https://api.tcgdex.net/v2/en';
+
     public function __construct(
         private readonly HttpClientInterface $tcgdexClient,
         private readonly TcgdexApiThrottle $throttle,
@@ -50,7 +52,7 @@ class SyncTcgdexSetHandler
         $this->throttle->waitIfNeeded();
 
         try {
-            $response = $this->tcgdexClient->request('GET', '/sets/'.$setId);
+            $response = $this->tcgdexClient->request('GET', self::BASE_URL.'/sets/'.$setId);
             /** @var array<string, mixed> $setData */
             $setData = $response->toArray();
         } catch (\Throwable $exception) {

--- a/src/MessageHandler/SyncTcgdexSetHandler.php
+++ b/src/MessageHandler/SyncTcgdexSetHandler.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\MessageHandler;
+
+use App\Entity\TcgdexCard;
+use App\Entity\TcgdexSet;
+use App\Message\SyncTcgdexCardMessage;
+use App\Message\SyncTcgdexSetMessage;
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Syncs a single set: updates metadata and dispatches SyncTcgdexCardMessage
+ * for any cards not yet in the local database.
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+#[AsMessageHandler]
+class SyncTcgdexSetHandler
+{
+    public function __construct(
+        private readonly HttpClientInterface $tcgdexClient,
+        private readonly TcgdexApiThrottle $throttle,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SyncTcgdexSetMessage $message): void
+    {
+        $setId = $message->setId;
+
+        $this->throttle->waitIfNeeded();
+
+        try {
+            $response = $this->tcgdexClient->request('GET', '/sets/'.$setId);
+            /** @var array<string, mixed> $setData */
+            $setData = $response->toArray();
+        } catch (\Throwable $exception) {
+            $this->throttle->reportFailure();
+            $this->logger->error('TCGdex sync: failed to fetch set {setId}: {error}', [
+                'setId' => $setId,
+                'error' => $exception->getMessage(),
+            ]);
+            $this->messageBus->dispatch($message, [new DelayStamp(60000)]);
+
+            return;
+        }
+
+        $this->throttle->reportSuccess();
+
+        $set = $this->entityManager->find(TcgdexSet::class, $setId);
+
+        if (null === $set) {
+            $this->logger->warning('TCGdex sync: set {setId} not found in database, skipping.', [
+                'setId' => $setId,
+            ]);
+
+            return;
+        }
+
+        // Update set metadata
+        $this->updateSetMetadata($set, $setData);
+        $this->entityManager->flush();
+
+        // Dispatch card sync for missing cards
+        /** @var list<array<string, mixed>> $cardsData */
+        $cardsData = isset($setData['cards']) && \is_array($setData['cards']) ? $setData['cards'] : [];
+
+        $dispatched = 0;
+
+        foreach ($cardsData as $cardData) {
+            $cardId = $this->extractString($cardData, 'id');
+
+            if (null === $cardId) {
+                continue;
+            }
+
+            $existing = $this->entityManager->find(TcgdexCard::class, $cardId);
+
+            if (null === $existing) {
+                $this->messageBus->dispatch(new SyncTcgdexCardMessage($cardId, $setId));
+                ++$dispatched;
+            }
+        }
+
+        if ($dispatched > 0) {
+            $this->logger->info('TCGdex sync: set {setId} — dispatched {count} card sync messages.', [
+                'setId' => $setId,
+                'count' => $dispatched,
+            ]);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $setData
+     */
+    private function updateSetMetadata(TcgdexSet $set, array $setData): void
+    {
+        $releaseDate = $this->extractString($setData, 'releaseDate');
+
+        if (null !== $releaseDate) {
+            try {
+                $set->setReleaseDate(new \DateTimeImmutable($releaseDate));
+            } catch (\Exception) {
+                // Invalid date — leave unchanged
+            }
+        }
+
+        // Extract PTCG code from tcgOnline or abbreviation.official
+        $tcgOnline = $this->extractString($setData, 'tcgOnline');
+
+        if (null !== $tcgOnline) {
+            $set->setPtcgCode(strtoupper($tcgOnline));
+        } else {
+            /** @var array<string, mixed> $abbreviation */
+            $abbreviation = isset($setData['abbreviation']) && \is_array($setData['abbreviation']) ? $setData['abbreviation'] : [];
+            $official = $this->extractString($abbreviation, 'official');
+
+            if (null !== $official && '' !== $official) {
+                $set->setPtcgCode(strtoupper($official));
+            }
+        }
+
+        // Card count from nested cardCount object
+        if (isset($setData['cardCount']) && \is_array($setData['cardCount'])) {
+            $official = $setData['cardCount']['official'] ?? null;
+
+            if (\is_int($official)) {
+                $set->setOfficialCardCount($official);
+            }
+        }
+
+        $set->setLogoUrl($this->extractString($setData, 'logo'));
+        $set->setSymbolUrl($this->extractString($setData, 'symbol'));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function extractString(array $data, string $key): ?string
+    {
+        return isset($data[$key]) && \is_string($data[$key]) ? $data[$key] : null;
+    }
+}

--- a/src/Repository/TcgdexCardRepository.php
+++ b/src/Repository/TcgdexCardRepository.php
@@ -70,6 +70,23 @@ class TcgdexCardRepository extends ServiceEntityRepository
     }
 
     /**
+     * Count the number of cards in a given set.
+     */
+    public function countBySetId(string $setId): int
+    {
+        /** @var int $count */
+        $count = $this->createQueryBuilder('c')
+            ->select('COUNT(c.id)')
+            ->join('c.set', 's')
+            ->where('s.id = :setId')
+            ->setParameter('setId', $setId)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return $count;
+    }
+
+    /**
      * Find all cards with the given English name within a specific set.
      *
      * Used for Asian alias resolution: the set is known (via alias table)

--- a/src/Repository/TcgdexSerieRepository.php
+++ b/src/Repository/TcgdexSerieRepository.php
@@ -26,4 +26,20 @@ class TcgdexSerieRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, TcgdexSerie::class);
     }
+
+    /**
+     * Return all serie IDs currently in the database.
+     *
+     * @return list<string>
+     */
+    public function findAllIds(): array
+    {
+        /** @var list<array{id: string}> $rows */
+        $rows = $this->createQueryBuilder('s')
+            ->select('s.id')
+            ->getQuery()
+            ->getScalarResult();
+
+        return array_column($rows, 'id');
+    }
 }

--- a/src/Service/CardIdentity/CardIdentityResolver.php
+++ b/src/Service/CardIdentity/CardIdentityResolver.php
@@ -45,6 +45,11 @@ class CardIdentityResolver
         $existing = $this->printingRepository->findByTcgdexId($tcgdexCard->id);
 
         if (null !== $existing) {
+            // Refresh image URL from TCGdex if a better source is available (e.g. imageBaseUrl populated by sync)
+            if (null !== $tcgdexCard->imageUrl && $tcgdexCard->imageUrl !== $existing->getImageUrl()) {
+                $existing->setImageUrl($tcgdexCard->imageUrl);
+            }
+
             return $existing;
         }
 

--- a/src/Service/Tcgdex/CardEnricher.php
+++ b/src/Service/Tcgdex/CardEnricher.php
@@ -400,6 +400,14 @@ class CardEnricher
     {
         $currentUrl = $printing->getImageUrl();
 
+        // Prefer the TCGdex API-sourced image URL (from imageBaseUrl) when available.
+        // This avoids expensive HTTP reachability checks for the vast majority of cards.
+        if (null !== $tcgdexCard->imageUrl && $tcgdexCard->imageUrl !== $currentUrl) {
+            $printing->setImageUrl($tcgdexCard->imageUrl);
+
+            return;
+        }
+
         if (null !== $currentUrl && $this->isImageReachable($currentUrl)) {
             return;
         }

--- a/src/Service/Tcgdex/TcgdexCardHydrator.php
+++ b/src/Service/Tcgdex/TcgdexCardHydrator.php
@@ -110,7 +110,30 @@ class TcgdexCardHydrator
         }
 
         $card = new TcgdexCard($id, $set, $localId);
+        $this->applyApiFields($card, $data);
 
+        return $card;
+    }
+
+    /**
+     * Update an existing TcgdexCard entity from a TCGdex API response.
+     *
+     * Used in "full" sync mode to refresh all card fields from the API.
+     *
+     * @param array<string, mixed> $data raw JSON response from GET /cards/{id}
+     */
+    public function updateFromApiResponse(TcgdexCard $card, array $data): void
+    {
+        $this->applyApiFields($card, $data);
+    }
+
+    /**
+     * Apply all API response fields to a TcgdexCard entity (shared by create and update).
+     *
+     * @param array<string, mixed> $data
+     */
+    private function applyApiFields(TcgdexCard $card, array $data): void
+    {
         $card->setName($this->wrapEnglish($this->extractString($data, 'name')) ?? []);
         $card->setCategory($this->extractString($data, 'category') ?? '');
         $card->setHp($this->extractInt($data, 'hp'));
@@ -151,8 +174,6 @@ class TcgdexCardHydrator
 
         // Marketplace IDs from pricing data
         $this->hydrateMarketplaceIds($card, $data);
-
-        return $card;
     }
 
     /**

--- a/src/Service/Tcgdex/TcgdexSyncStatusService.php
+++ b/src/Service/Tcgdex/TcgdexSyncStatusService.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Tcgdex;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * Provides sync status information for the admin dashboard and CLI.
+ *
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+class TcgdexSyncStatusService
+{
+    private const string CACHE_KEY_LAST_COMPLETED = 'tcgdex_sync.last_completed_at';
+
+    /** @var list<string> */
+    private const array SYNC_QUEUE_NAMES = [
+        'tcgdex_sync_series',
+        'tcgdex_sync_serie',
+        'tcgdex_sync_set',
+        'tcgdex_sync_card',
+    ];
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly CacheInterface $cache,
+    ) {
+    }
+
+    /**
+     * Count pending messages across all TCGdex sync queues.
+     */
+    public function getQueueDepth(): int
+    {
+        $placeholders = implode(', ', array_fill(0, \count(self::SYNC_QUEUE_NAMES), '?'));
+        $sql = \sprintf('SELECT COUNT(*) FROM messenger_messages WHERE queue_name IN (%s)', $placeholders);
+
+        /** @var int|string $count */
+        $count = $this->connection->fetchOne($sql, self::SYNC_QUEUE_NAMES);
+
+        return (int) $count;
+    }
+
+    /**
+     * Get the timestamp of the last completed sync, or null if never synced.
+     */
+    public function getLastSyncTimestamp(): ?\DateTimeImmutable
+    {
+        /** @var string|null $timestamp */
+        $timestamp = $this->cache->get(self::CACHE_KEY_LAST_COMPLETED, static function (ItemInterface $item): null {
+            $item->expiresAfter(86400 * 30);
+
+            return null;
+        });
+
+        if (null === $timestamp) {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($timestamp);
+        } catch (\Exception) {
+            return null;
+        }
+    }
+
+    /**
+     * Record the current time as last completed sync.
+     */
+    public function recordSyncCompleted(): void
+    {
+        $now = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+        $this->cache->delete(self::CACHE_KEY_LAST_COMPLETED);
+        $this->cache->get(self::CACHE_KEY_LAST_COMPLETED, static function (ItemInterface $item) use ($now): string {
+            $item->expiresAfter(86400 * 30);
+
+            return $now;
+        });
+    }
+}

--- a/templates/admin/technical/dashboard.html.twig
+++ b/templates/admin/technical/dashboard.html.twig
@@ -153,6 +153,47 @@
         </div>
     </div>
 
+    {# TCGdex database sync card #}
+    <div class="card shadow-sm mb-3">
+        <div class="card-header card-header-themed">
+            <h5 class="mb-0">{{ 'app.admin.technical.tcgdex_sync.title'|trans }}</h5>
+        </div>
+        <div class="card-body">
+            <p>{{ 'app.admin.technical.tcgdex_sync.description'|trans }}</p>
+
+            <div class="mb-3 d-flex gap-2 flex-wrap align-items-center">
+                {% if syncLastCompleted %}
+                    <span class="badge bg-success">{{ 'app.admin.technical.tcgdex_sync.last_sync'|trans({'%date%': syncLastCompleted|date('Y-m-d H:i')}) }}</span>
+                {% else %}
+                    <span class="badge bg-secondary">{{ 'app.admin.technical.tcgdex_sync.never_synced'|trans }}</span>
+                {% endif %}
+
+                {% if syncQueueDepth > 0 %}
+                    <span class="badge bg-warning">{{ 'app.admin.technical.tcgdex_sync.queue_depth'|trans({'%count%': syncQueueDepth}) }}</span>
+                {% endif %}
+
+                {% if syncInCooldown %}
+                    <span class="badge bg-danger">{{ 'app.admin.technical.tcgdex_sync.cooldown_active'|trans }}</span>
+                {% endif %}
+            </div>
+
+            <div class="d-flex gap-2">
+                <form method="post" action="{{ path('app_admin_technical_tcgdex_sync_insert') }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('technical-tcgdex-sync-insert') }}">
+                    <button type="submit" class="btn btn-gold" {{ syncQueueDepth > 0 ? 'disabled' : '' }}>
+                        {{ 'app.admin.technical.tcgdex_sync.insert_button'|trans }}
+                    </button>
+                </form>
+                <form method="post" action="{{ path('app_admin_technical_tcgdex_sync_update') }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('technical-tcgdex-sync-update') }}">
+                    <button type="submit" class="btn btn-outline-gold" {{ syncQueueDepth > 0 ? 'disabled' : '' }}>
+                        {{ 'app.admin.technical.tcgdex_sync.update_button'|trans }}
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+
     {# Banned cards sync card #}
     <div class="card shadow-sm mb-3">
         <div class="card-header card-header-themed">

--- a/tests/Command/SyncTcgdexCommandTest.php
+++ b/tests/Command/SyncTcgdexCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Command;
+
+use App\Command\SyncTcgdexCommand;
+use App\Service\Tcgdex\TcgdexSyncStatusService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+final class SyncTcgdexCommandTest extends TestCase
+{
+    private function createCommand(int $queueDepth = 0, ?\DateTimeImmutable $lastSync = null): SyncTcgdexCommand
+    {
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
+
+        $syncStatus = $this->createStub(TcgdexSyncStatusService::class);
+        $syncStatus->method('getQueueDepth')->willReturn($queueDepth);
+        $syncStatus->method('getLastSyncTimestamp')->willReturn($lastSync);
+
+        return new SyncTcgdexCommand($messageBus, $syncStatus);
+    }
+
+    public function testDefaultInsertModeDispatches(): void
+    {
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('insert', $tester->getDisplay());
+    }
+
+    public function testUpdateModeDispatches(): void
+    {
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute(['--mode' => 'update']);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('update', $tester->getDisplay());
+    }
+
+    public function testFullModeRequiresForce(): void
+    {
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute(['--mode' => 'full']);
+
+        self::assertSame(Command::INVALID, $tester->getStatusCode());
+        self::assertStringContainsString('--force', $tester->getDisplay());
+    }
+
+    public function testFullModeWithForceDispatches(): void
+    {
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute(['--mode' => 'full', '--force' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('full', $tester->getDisplay());
+    }
+
+    public function testInvalidModeReturnsError(): void
+    {
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute(['--mode' => 'banana']);
+
+        self::assertSame(Command::INVALID, $tester->getStatusCode());
+        self::assertStringContainsString('Invalid sync mode', $tester->getDisplay());
+    }
+
+    public function testWarnsWhenSyncAlreadyInProgress(): void
+    {
+        $tester = new CommandTester($this->createCommand(queueDepth: 15));
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('15 messages pending', $tester->getDisplay());
+    }
+
+    public function testDisplaysLastSyncTimestamp(): void
+    {
+        $lastSync = new \DateTimeImmutable('2026-04-22 14:30:00');
+        $tester = new CommandTester($this->createCommand(lastSync: $lastSync));
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('2026-04-22 14:30:00', $tester->getDisplay());
+    }
+}

--- a/tests/Controller/WebhookTcgdexSyncControllerTest.php
+++ b/tests/Controller/WebhookTcgdexSyncControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Controller\WebhookTcgdexSyncController;
+use App\Service\Tcgdex\TcgdexSyncStatusService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+final class WebhookTcgdexSyncControllerTest extends TestCase
+{
+    private const string SECRET = 'test-webhook-secret';
+
+    public function testValidSignatureReturns202(): void
+    {
+        $controller = $this->createController(queueDepth: 0);
+        $request = $this->createSignedRequest('{"trigger":"cron"}');
+
+        $response = $controller($request);
+
+        self::assertSame(202, $response->getStatusCode());
+        self::assertStringContainsString('dispatched', (string) $response->getContent());
+    }
+
+    public function testInvalidSignatureReturns403(): void
+    {
+        $controller = $this->createController();
+        $request = Request::create('/webhook/tcgdex-sync', 'POST', [], [], [], [], '{"trigger":"cron"}');
+        $request->headers->set('X-Sync-Signature', 'sha256=invalid');
+
+        $response = $controller($request);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testMissingSignatureReturns403(): void
+    {
+        $controller = $this->createController();
+        $request = Request::create('/webhook/tcgdex-sync', 'POST', [], [], [], [], '{"trigger":"cron"}');
+
+        $response = $controller($request);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testEmptySecretReturns404(): void
+    {
+        $controller = $this->createController(secret: '');
+        $request = Request::create('/webhook/tcgdex-sync', 'POST');
+
+        $response = $controller($request);
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testActiveSyncReturns200(): void
+    {
+        $controller = $this->createController(queueDepth: 42);
+        $request = $this->createSignedRequest('{"trigger":"cron"}');
+
+        $response = $controller($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('already_in_progress', (string) $response->getContent());
+    }
+
+    public function testSignatureWithoutPrefixReturns403(): void
+    {
+        $controller = $this->createController();
+        $request = Request::create('/webhook/tcgdex-sync', 'POST', [], [], [], [], '{}');
+        $request->headers->set('X-Sync-Signature', hash_hmac('sha256', '{}', self::SECRET));
+
+        $response = $controller($request);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    private function createController(string $secret = self::SECRET, int $queueDepth = 0): WebhookTcgdexSyncController
+    {
+        $messageBus = $this->createStub(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
+
+        $syncStatus = $this->createStub(TcgdexSyncStatusService::class);
+        $syncStatus->method('getQueueDepth')->willReturn($queueDepth);
+
+        return new WebhookTcgdexSyncController($messageBus, $syncStatus, $secret);
+    }
+
+    private function createSignedRequest(string $body): Request
+    {
+        $signature = 'sha256='.hash_hmac('sha256', $body, self::SECRET);
+        $request = Request::create('/webhook/tcgdex-sync', 'POST', [], [], [], [], $body);
+        $request->headers->set('X-Sync-Signature', $signature);
+
+        return $request;
+    }
+}

--- a/tests/MessageHandler/SyncTcgdexCardHandlerTest.php
+++ b/tests/MessageHandler/SyncTcgdexCardHandlerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\MessageHandler;
+
+use App\Entity\TcgdexCard;
+use App\Entity\TcgdexSerie;
+use App\Entity\TcgdexSet;
+use App\Enum\SyncMode;
+use App\Message\SyncTcgdexCardMessage;
+use App\MessageHandler\SyncTcgdexCardHandler;
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use App\Service\Tcgdex\TcgdexCardHydrator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+final class SyncTcgdexCardHandlerTest extends TestCase
+{
+    private HttpClientInterface $httpClient;
+    private TcgdexApiThrottle $throttle;
+    private TcgdexCardHydrator $hydrator;
+    private EntityManagerInterface $entityManager;
+    private LoggerInterface $logger;
+
+    /** @var list<object> */
+    private array $dispatchedMessages = [];
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createStub(HttpClientInterface::class);
+        $this->throttle = $this->createStub(TcgdexApiThrottle::class);
+        $this->hydrator = new TcgdexCardHydrator();
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+        $this->logger = $this->createStub(LoggerInterface::class);
+        $this->dispatchedMessages = [];
+    }
+
+    private function createHandler(): SyncTcgdexCardHandler
+    {
+        $bus = $this->createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(function (object $message): Envelope {
+            $this->dispatchedMessages[] = $message;
+
+            return new Envelope($message);
+        });
+
+        return new SyncTcgdexCardHandler(
+            $this->httpClient,
+            $this->throttle,
+            $this->hydrator,
+            $this->entityManager,
+            $bus,
+            $this->logger,
+        );
+    }
+
+    private function createApiResponse(): ResponseInterface
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'id' => 'sv05-001',
+            'localId' => '001',
+            'name' => 'Exeggcute',
+            'category' => 'Pokemon',
+            'hp' => 50,
+            'image' => 'https://assets.tcgdex.net/en/sv/sv05/001',
+            'legal' => ['expanded' => true],
+        ]);
+
+        return $response;
+    }
+
+    public function testPersistsNewCard(): void
+    {
+        $set = new TcgdexSet('sv05', new TcgdexSerie('sv'));
+
+        $this->httpClient->method('request')->willReturn($this->createApiResponse());
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('find')->willReturnMap([
+            [TcgdexCard::class, 'sv05-001', null],
+            [TcgdexSet::class, 'sv05', $set],
+        ]);
+        $entityManager->expects(self::once())->method('persist')->with(self::isInstanceOf(TcgdexCard::class));
+        $entityManager->expects(self::once())->method('flush');
+        $this->entityManager = $entityManager;
+
+        ($this->createHandler())(new SyncTcgdexCardMessage('sv05-001', 'sv05'));
+    }
+
+    public function testSkipsExistingCardInInsertMode(): void
+    {
+        $existingCard = $this->createStub(TcgdexCard::class);
+        $this->entityManager->method('find')->willReturn($existingCard);
+
+        // HTTP client should NOT be called
+        $this->httpClient->method('request')->willThrowException(new \RuntimeException('Should not be called'));
+
+        ($this->createHandler())(new SyncTcgdexCardMessage('sv05-001', 'sv05'));
+
+        // No error — handler returned early
+        self::assertTrue(true);
+    }
+
+    public function testFullModeUpdatesExistingCard(): void
+    {
+        $set = new TcgdexSet('sv05', new TcgdexSerie('sv'));
+        $existingCard = new TcgdexCard('sv05-001', $set, '001');
+
+        $this->httpClient->method('request')->willReturn($this->createApiResponse());
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('find')->willReturnMap([
+            [TcgdexCard::class, 'sv05-001', $existingCard],
+            [TcgdexSet::class, 'sv05', $set],
+        ]);
+        $entityManager->expects(self::never())->method('persist'); // Update, not insert
+        $entityManager->expects(self::once())->method('flush');
+        $this->entityManager = $entityManager;
+
+        ($this->createHandler())(new SyncTcgdexCardMessage('sv05-001', 'sv05', SyncMode::Full));
+
+        self::assertSame('https://assets.tcgdex.net/en/sv/sv05/001', $existingCard->getImageBaseUrl());
+    }
+
+    public function test404DoesNotRedispatch(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(404);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->entityManager->method('find')->willReturn(null);
+
+        ($this->createHandler())(new SyncTcgdexCardMessage('sv05-999', 'sv05'));
+
+        // No redispatch — 404 is not retried
+        $retries = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexCardMessage);
+        self::assertCount(0, $retries);
+    }
+
+    public function testHttpErrorRedispatches(): void
+    {
+        $this->httpClient->method('request')->willThrowException(new \RuntimeException('Timeout'));
+        $this->entityManager->method('find')->willReturn(null);
+
+        ($this->createHandler())(new SyncTcgdexCardMessage('sv05-001', 'sv05'));
+
+        $retries = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexCardMessage);
+        self::assertCount(1, $retries);
+    }
+}

--- a/tests/MessageHandler/SyncTcgdexCompleteHandlerTest.php
+++ b/tests/MessageHandler/SyncTcgdexCompleteHandlerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\MessageHandler;
+
+use App\Entity\DeckVersion;
+use App\Message\BuildSetMappingsMessage;
+use App\Message\EnrichDeckVersionMessage;
+use App\Message\SyncTcgdexCompleteMessage;
+use App\MessageHandler\SyncTcgdexCompleteHandler;
+use App\Repository\DeckVersionRepository;
+use App\Service\Tcgdex\TcgdexSyncStatusService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+final class SyncTcgdexCompleteHandlerTest extends TestCase
+{
+    /** @var list<object> */
+    private array $dispatchedMessages = [];
+
+    public function testDispatchesMappingsAndReenrichment(): void
+    {
+        $version = $this->createStub(DeckVersion::class);
+        $version->method('getId')->willReturn(42);
+
+        $versionRepository = $this->createStub(DeckVersionRepository::class);
+        $versionRepository->method('findNotEnriched')->willReturn([$version]);
+
+        $syncStatus = $this->createMock(TcgdexSyncStatusService::class);
+        $syncStatus->expects(self::once())->method('recordSyncCompleted');
+
+        $bus = $this->createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(function (object $message): Envelope {
+            $this->dispatchedMessages[] = $message;
+
+            return new Envelope($message);
+        });
+
+        $handler = new SyncTcgdexCompleteHandler(
+            $versionRepository,
+            $syncStatus,
+            $bus,
+            $this->createStub(LoggerInterface::class),
+        );
+
+        $handler(new SyncTcgdexCompleteMessage());
+
+        $mappingMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof BuildSetMappingsMessage);
+        self::assertCount(1, $mappingMessages);
+
+        $enrichMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof EnrichDeckVersionMessage);
+        self::assertCount(1, $enrichMessages);
+
+        $enrichMessages = array_values($enrichMessages);
+        self::assertSame(42, $enrichMessages[0]->deckVersionId);
+    }
+
+    public function testSkipsVersionsWithNullId(): void
+    {
+        $version = $this->createStub(DeckVersion::class);
+        $version->method('getId')->willReturn(null);
+
+        $versionRepository = $this->createStub(DeckVersionRepository::class);
+        $versionRepository->method('findNotEnriched')->willReturn([$version]);
+
+        $syncStatus = $this->createStub(TcgdexSyncStatusService::class);
+
+        $bus = $this->createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(function (object $message): Envelope {
+            $this->dispatchedMessages[] = $message;
+
+            return new Envelope($message);
+        });
+
+        $handler = new SyncTcgdexCompleteHandler(
+            $versionRepository,
+            $syncStatus,
+            $bus,
+            $this->createStub(LoggerInterface::class),
+        );
+
+        $handler(new SyncTcgdexCompleteMessage());
+
+        $enrichMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof EnrichDeckVersionMessage);
+        self::assertCount(0, $enrichMessages);
+    }
+}

--- a/tests/MessageHandler/SyncTcgdexSerieHandlerTest.php
+++ b/tests/MessageHandler/SyncTcgdexSerieHandlerTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\MessageHandler;
+
+use App\Entity\TcgdexSerie;
+use App\Entity\TcgdexSet;
+use App\Enum\SyncMode;
+use App\Message\SyncTcgdexSerieMessage;
+use App\Message\SyncTcgdexSetMessage;
+use App\MessageHandler\SyncTcgdexSerieHandler;
+use App\Repository\TcgdexCardRepository;
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+final class SyncTcgdexSerieHandlerTest extends TestCase
+{
+    private HttpClientInterface $httpClient;
+    private TcgdexApiThrottle $throttle;
+    private TcgdexCardRepository $cardRepository;
+    private EntityManagerInterface $entityManager;
+    private LoggerInterface $logger;
+
+    /** @var list<object> */
+    private array $dispatchedMessages = [];
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createStub(HttpClientInterface::class);
+        $this->throttle = $this->createStub(TcgdexApiThrottle::class);
+        $this->cardRepository = $this->createStub(TcgdexCardRepository::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+        $this->logger = $this->createStub(LoggerInterface::class);
+        $this->dispatchedMessages = [];
+    }
+
+    private function createHandler(): SyncTcgdexSerieHandler
+    {
+        $bus = $this->createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(function (object $message): Envelope {
+            $this->dispatchedMessages[] = $message;
+
+            return new Envelope($message);
+        });
+
+        return new SyncTcgdexSerieHandler(
+            $this->httpClient,
+            $this->throttle,
+            $this->cardRepository,
+            $this->entityManager,
+            $bus,
+            $this->logger,
+        );
+    }
+
+    public function testCreatesNewSetAndDispatchesSyncMessage(): void
+    {
+        $serie = $this->createStub(TcgdexSerie::class);
+        $serie->method('getSets')->willReturn(new ArrayCollection());
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'sets' => [
+                ['id' => 'sv01', 'name' => 'Scarlet & Violet', 'releaseDate' => '2023-03-31'],
+            ],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('find')->willReturn($serie);
+        $entityManager->expects(self::once())->method('persist')->with(self::isInstanceOf(TcgdexSet::class));
+        $entityManager->expects(self::once())->method('flush');
+        $this->entityManager = $entityManager;
+
+        ($this->createHandler())(new SyncTcgdexSerieMessage('sv'));
+
+        $setMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSetMessage);
+        self::assertCount(1, $setMessages);
+    }
+
+    public function testDetectsCardCountMismatchInInsertMode(): void
+    {
+        $existingSet = $this->createStub(TcgdexSet::class);
+        $existingSet->method('getId')->willReturn('sv01');
+
+        $serie = $this->createStub(TcgdexSerie::class);
+        $serie->method('getSets')->willReturn(new ArrayCollection([$existingSet]));
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'sets' => [
+                ['id' => 'sv01', 'cardCount' => ['official' => 100, 'total' => 120]],
+            ],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->entityManager->method('find')->willReturn($serie);
+        $this->cardRepository->method('countBySetId')->willReturn(100); // Mismatch: 100 local vs 120 total
+
+        ($this->createHandler())(new SyncTcgdexSerieMessage('sv'));
+
+        $setMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSetMessage);
+        self::assertCount(1, $setMessages);
+    }
+
+    public function testSkipsExistingSetWhenCardCountMatchesInInsertMode(): void
+    {
+        $existingSet = $this->createStub(TcgdexSet::class);
+        $existingSet->method('getId')->willReturn('sv01');
+
+        $serie = $this->createStub(TcgdexSerie::class);
+        $serie->method('getSets')->willReturn(new ArrayCollection([$existingSet]));
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'sets' => [
+                ['id' => 'sv01', 'cardCount' => ['official' => 100, 'total' => 120]],
+            ],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->entityManager->method('find')->willReturn($serie);
+        $this->cardRepository->method('countBySetId')->willReturn(120); // Matches total
+
+        ($this->createHandler())(new SyncTcgdexSerieMessage('sv'));
+
+        $setMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSetMessage);
+        self::assertCount(0, $setMessages);
+    }
+
+    public function testUpdateModeSyncsAllExistingSets(): void
+    {
+        $existingSet = $this->createStub(TcgdexSet::class);
+        $existingSet->method('getId')->willReturn('sv01');
+
+        $serie = $this->createStub(TcgdexSerie::class);
+        $serie->method('getSets')->willReturn(new ArrayCollection([$existingSet]));
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'sets' => [
+                ['id' => 'sv01', 'cardCount' => ['official' => 100, 'total' => 120]],
+            ],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->entityManager->method('find')->willReturn($serie);
+        $this->cardRepository->method('countBySetId')->willReturn(120); // Count matches, but update mode syncs anyway
+
+        ($this->createHandler())(new SyncTcgdexSerieMessage('sv', SyncMode::Update));
+
+        $setMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSetMessage);
+        self::assertCount(1, $setMessages);
+    }
+
+    public function testHttpErrorRedispatches(): void
+    {
+        $this->httpClient->method('request')->willThrowException(new \RuntimeException('Timeout'));
+
+        ($this->createHandler())(new SyncTcgdexSerieMessage('sv'));
+
+        $retries = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSerieMessage);
+        self::assertCount(1, $retries);
+    }
+
+    public function testSortsSetsByReleaseDateDescending(): void
+    {
+        $serie = $this->createStub(TcgdexSerie::class);
+        $serie->method('getSets')->willReturn(new ArrayCollection());
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'sets' => [
+                ['id' => 'sv01', 'name' => 'Old Set', 'releaseDate' => '2023-01-01'],
+                ['id' => 'sv05', 'name' => 'New Set', 'releaseDate' => '2024-03-22'],
+                ['id' => 'sv03', 'name' => 'Mid Set', 'releaseDate' => '2023-09-15'],
+            ],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('find')->willReturn($serie);
+        $this->entityManager = $entityManager;
+
+        ($this->createHandler())(new SyncTcgdexSerieMessage('sv'));
+
+        $setMessages = array_values(array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSetMessage));
+        self::assertCount(3, $setMessages);
+        self::assertSame('sv05', $setMessages[0]->setId);
+        self::assertSame('sv03', $setMessages[1]->setId);
+        self::assertSame('sv01', $setMessages[2]->setId);
+    }
+}

--- a/tests/MessageHandler/SyncTcgdexSeriesHandlerTest.php
+++ b/tests/MessageHandler/SyncTcgdexSeriesHandlerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\MessageHandler;
+
+use App\Entity\TcgdexSerie;
+use App\Enum\SyncMode;
+use App\Message\SyncTcgdexCompleteMessage;
+use App\Message\SyncTcgdexSerieMessage;
+use App\Message\SyncTcgdexSeriesMessage;
+use App\MessageHandler\SyncTcgdexSeriesHandler;
+use App\Repository\TcgdexSerieRepository;
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+final class SyncTcgdexSeriesHandlerTest extends TestCase
+{
+    private HttpClientInterface $httpClient;
+    private TcgdexApiThrottle $throttle;
+    private TcgdexSerieRepository $serieRepository;
+    private EntityManagerInterface $entityManager;
+    private LoggerInterface $logger;
+
+    /** @var list<object> */
+    private array $dispatchedMessages = [];
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createStub(HttpClientInterface::class);
+        $this->throttle = $this->createStub(TcgdexApiThrottle::class);
+        $this->serieRepository = $this->createStub(TcgdexSerieRepository::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+        $this->logger = $this->createStub(LoggerInterface::class);
+        $this->dispatchedMessages = [];
+    }
+
+    private function createHandler(?MessageBusInterface $messageBus = null): SyncTcgdexSeriesHandler
+    {
+        $bus = $messageBus ?? $this->createBus();
+
+        return new SyncTcgdexSeriesHandler(
+            $this->httpClient,
+            $this->throttle,
+            $this->serieRepository,
+            $this->entityManager,
+            $bus,
+            $this->logger,
+        );
+    }
+
+    private function createBus(): MessageBusInterface
+    {
+        $bus = $this->createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(function (object $message): Envelope {
+            $this->dispatchedMessages[] = $message;
+
+            return new Envelope($message);
+        });
+
+        return $bus;
+    }
+
+    public function testDispatchesSerieMessagesForEachSerie(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            ['id' => 'sv', 'name' => 'Scarlet & Violet', 'releaseDate' => '2023-03-31'],
+            ['id' => 'swsh', 'name' => 'Sword & Shield', 'releaseDate' => '2020-02-07'],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->serieRepository->method('findAllIds')->willReturn(['sv', 'swsh']);
+
+        ($this->createHandler())(new SyncTcgdexSeriesMessage());
+
+        $serieMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSerieMessage);
+        self::assertCount(2, $serieMessages);
+
+        // Verify newest first (sv before swsh)
+        $serieMessages = array_values($serieMessages);
+        self::assertSame('sv', $serieMessages[0]->serieId);
+        self::assertSame('swsh', $serieMessages[1]->serieId);
+    }
+
+    public function testExcludesTcgpSerie(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            ['id' => 'sv', 'name' => 'Scarlet & Violet'],
+            ['id' => 'tcgp', 'name' => 'TCG Pocket'],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->serieRepository->method('findAllIds')->willReturn(['sv', 'tcgp']);
+
+        ($this->createHandler())(new SyncTcgdexSeriesMessage());
+
+        $serieMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSerieMessage);
+        self::assertCount(1, $serieMessages);
+    }
+
+    public function testCreatesNewSerieEntity(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            ['id' => 'newone', 'name' => 'Brand New', 'logo' => 'https://example.com/logo.png'],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->serieRepository->method('findAllIds')->willReturn([]);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('persist')->with(self::isInstanceOf(TcgdexSerie::class));
+        $entityManager->expects(self::once())->method('flush');
+        $this->entityManager = $entityManager;
+
+        ($this->createHandler())(new SyncTcgdexSeriesMessage());
+    }
+
+    public function testDispatchesCompleteMessageWithDelay(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->serieRepository->method('findAllIds')->willReturn([]);
+
+        ($this->createHandler())(new SyncTcgdexSeriesMessage());
+
+        $completeMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexCompleteMessage);
+        self::assertCount(1, $completeMessages);
+    }
+
+    public function testPropagatesSyncMode(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            ['id' => 'sv', 'name' => 'Scarlet & Violet'],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->serieRepository->method('findAllIds')->willReturn(['sv']);
+
+        ($this->createHandler())(new SyncTcgdexSeriesMessage(SyncMode::Update));
+
+        $serieMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSerieMessage);
+        $serieMessages = array_values($serieMessages);
+        self::assertSame(SyncMode::Update, $serieMessages[0]->mode);
+    }
+
+    public function testHttpErrorRedispatchesWithDelay(): void
+    {
+        $this->httpClient->method('request')->willThrowException(new \RuntimeException('Connection timeout'));
+
+        $this->serieRepository->method('findAllIds')->willReturn([]);
+
+        ($this->createHandler())(new SyncTcgdexSeriesMessage());
+
+        // Should redispatch the same message (SyncTcgdexSeriesMessage)
+        $retries = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSeriesMessage);
+        self::assertCount(1, $retries);
+    }
+
+    public function testUpdateModeUpdatesExistingSerieLogos(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            ['id' => 'sv', 'name' => 'Scarlet & Violet', 'logo' => 'https://new-logo.png'],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->serieRepository->method('findAllIds')->willReturn(['sv']);
+
+        $serie = $this->createStub(TcgdexSerie::class);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('find')->willReturn($serie);
+        $entityManager->expects(self::once())->method('flush');
+        $this->entityManager = $entityManager;
+
+        ($this->createHandler())(new SyncTcgdexSeriesMessage(SyncMode::Update));
+    }
+}

--- a/tests/MessageHandler/SyncTcgdexSetHandlerTest.php
+++ b/tests/MessageHandler/SyncTcgdexSetHandlerTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\MessageHandler;
+
+use App\Entity\TcgdexCard;
+use App\Entity\TcgdexSerie;
+use App\Entity\TcgdexSet;
+use App\Enum\SyncMode;
+use App\Message\SyncTcgdexCardMessage;
+use App\Message\SyncTcgdexSetMessage;
+use App\MessageHandler\SyncTcgdexSetHandler;
+use App\Service\Tcgdex\TcgdexApiThrottle;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+final class SyncTcgdexSetHandlerTest extends TestCase
+{
+    private HttpClientInterface $httpClient;
+    private TcgdexApiThrottle $throttle;
+    private EntityManagerInterface $entityManager;
+    private LoggerInterface $logger;
+
+    /** @var list<object> */
+    private array $dispatchedMessages = [];
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createStub(HttpClientInterface::class);
+        $this->throttle = $this->createStub(TcgdexApiThrottle::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+        $this->logger = $this->createStub(LoggerInterface::class);
+        $this->dispatchedMessages = [];
+    }
+
+    private function createHandler(): SyncTcgdexSetHandler
+    {
+        $bus = $this->createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(function (object $message): Envelope {
+            $this->dispatchedMessages[] = $message;
+
+            return new Envelope($message);
+        });
+
+        return new SyncTcgdexSetHandler(
+            $this->httpClient,
+            $this->throttle,
+            $this->entityManager,
+            $bus,
+            $this->logger,
+        );
+    }
+
+    private function createSet(): TcgdexSet
+    {
+        $serie = new TcgdexSerie('sv');
+
+        return new TcgdexSet('sv05', $serie);
+    }
+
+    public function testDispatchesCardMessagesForMissingCards(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'cards' => [
+                ['id' => 'sv05-001', 'localId' => '001', 'name' => 'Card A', 'image' => 'https://example.com/001'],
+                ['id' => 'sv05-002', 'localId' => '002', 'name' => 'Card B', 'image' => 'https://example.com/002'],
+            ],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->entityManager->method('find')->willReturnCallback(
+            fn (string $class, mixed $id): ?object => TcgdexSet::class === $class ? $this->createSet() : null,
+        );
+
+        ($this->createHandler())(new SyncTcgdexSetMessage('sv05'));
+
+        $cardMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexCardMessage);
+        self::assertCount(2, $cardMessages);
+    }
+
+    public function testSkipsExistingCardsInInsertMode(): void
+    {
+        $existingCard = $this->createStub(TcgdexCard::class);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'cards' => [
+                ['id' => 'sv05-001', 'localId' => '001', 'name' => 'Existing', 'image' => 'https://example.com/001'],
+            ],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->entityManager->method('find')->willReturnMap([
+            [TcgdexSet::class, 'sv05', $this->createSet()],
+            [TcgdexCard::class, 'sv05-001', $existingCard],
+        ]);
+
+        ($this->createHandler())(new SyncTcgdexSetMessage('sv05'));
+
+        $cardMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexCardMessage);
+        self::assertCount(0, $cardMessages);
+    }
+
+    public function testFullModeDispatchesForExistingCards(): void
+    {
+        $existingCard = $this->createStub(TcgdexCard::class);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'cards' => [
+                ['id' => 'sv05-001', 'localId' => '001', 'name' => 'Existing', 'image' => 'https://example.com/001'],
+            ],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+        $this->entityManager->method('find')->willReturnMap([
+            [TcgdexSet::class, 'sv05', $this->createSet()],
+            [TcgdexCard::class, 'sv05-001', $existingCard],
+        ]);
+
+        ($this->createHandler())(new SyncTcgdexSetMessage('sv05', SyncMode::Full));
+
+        $cardMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexCardMessage);
+        self::assertCount(1, $cardMessages);
+    }
+
+    public function testUpdateModeUpdatesImageUrlsFromSetResponse(): void
+    {
+        $existingCard = new TcgdexCard('sv05-001', $this->createSet(), '001');
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'cards' => [
+                ['id' => 'sv05-001', 'localId' => '001', 'name' => 'Card', 'image' => 'https://assets.tcgdex.net/en/sv/sv05/001'],
+            ],
+        ]);
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('find')->willReturnMap([
+            [TcgdexSet::class, 'sv05', $this->createSet()],
+            [TcgdexCard::class, 'sv05-001', $existingCard],
+        ]);
+        $entityManager->expects(self::atLeastOnce())->method('flush');
+        $this->entityManager = $entityManager;
+
+        ($this->createHandler())(new SyncTcgdexSetMessage('sv05', SyncMode::Update));
+
+        self::assertSame('https://assets.tcgdex.net/en/sv/sv05/001', $existingCard->getImageBaseUrl());
+
+        // Update mode should NOT dispatch card messages for existing cards
+        $cardMessages = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexCardMessage);
+        self::assertCount(0, $cardMessages);
+    }
+
+    public function testHttpErrorRedispatches(): void
+    {
+        $this->httpClient->method('request')->willThrowException(new \RuntimeException('Timeout'));
+
+        ($this->createHandler())(new SyncTcgdexSetMessage('sv05'));
+
+        $retries = array_filter($this->dispatchedMessages, static fn (object $message): bool => $message instanceof SyncTcgdexSetMessage);
+        self::assertCount(1, $retries);
+    }
+}

--- a/tests/Service/Tcgdex/TcgdexCardHydratorTest.php
+++ b/tests/Service/Tcgdex/TcgdexCardHydratorTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\Tcgdex;
+
+use App\Entity\TcgdexCard;
+use App\Entity\TcgdexSerie;
+use App\Entity\TcgdexSet;
+use App\Service\Tcgdex\TcgdexCardHydrator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F6.13 — Incremental TCGdex database sync
+ */
+final class TcgdexCardHydratorTest extends TestCase
+{
+    private TcgdexCardHydrator $hydrator;
+    private TcgdexSet $set;
+
+    protected function setUp(): void
+    {
+        $this->hydrator = new TcgdexCardHydrator();
+        $this->set = new TcgdexSet('sv05', new TcgdexSerie('sv'));
+    }
+
+    /** @return array<string, mixed> */
+    private function createApiCardData(): array
+    {
+        return [
+            'id' => 'sv05-001',
+            'localId' => '001',
+            'name' => 'Exeggcute',
+            'category' => 'Pokemon',
+            'hp' => 50,
+            'rarity' => 'Common',
+            'stage' => 'Basic',
+            'types' => ['Grass'],
+            'retreat' => 1,
+            'regulationMark' => 'G',
+            'illustrator' => 'Mitsuhiro Arita',
+            'image' => 'https://assets.tcgdex.net/en/sv/sv05/001',
+            'legal' => ['expanded' => true, 'standard' => true],
+            'abilities' => [
+                ['name' => 'Propagation', 'effect' => 'Put this card from discard to hand.', 'type' => 'Ability'],
+            ],
+            'attacks' => [
+                ['name' => 'Seed Bomb', 'effect' => '', 'damage' => 20, 'cost' => ['Grass']],
+            ],
+            'effect' => null,
+            'evolveFrom' => null,
+            'trainerType' => null,
+            'energyType' => null,
+        ];
+    }
+
+    public function testHydrateFromApiResponseSetsAllFields(): void
+    {
+        $card = $this->hydrator->hydrateFromApiResponse($this->createApiCardData(), $this->set);
+
+        self::assertSame('sv05-001', $card->getId());
+        self::assertSame('001', $card->getLocalId());
+        self::assertSame(['en' => 'Exeggcute'], $card->getName());
+        self::assertSame('Pokemon', $card->getCategory());
+        self::assertSame(50, $card->getHp());
+        self::assertSame('Common', $card->getRarity());
+        self::assertSame('Basic', $card->getStage());
+        self::assertSame(['Grass'], $card->getTypes());
+        self::assertSame(1, $card->getRetreat());
+        self::assertSame('G', $card->getRegulationMark());
+        self::assertSame('Mitsuhiro Arita', $card->getIllustrator());
+        self::assertSame('https://assets.tcgdex.net/en/sv/sv05/001', $card->getImageBaseUrl());
+        self::assertTrue($card->isExpandedLegal());
+    }
+
+    public function testHydrateFromApiResponseWrapsAbilitiesInMultilingualFormat(): void
+    {
+        $card = $this->hydrator->hydrateFromApiResponse($this->createApiCardData(), $this->set);
+
+        $abilities = $card->getAbilities();
+        self::assertCount(1, $abilities);
+        self::assertSame(['en' => 'Propagation'], $abilities[0]['name']);
+        self::assertSame(['en' => 'Put this card from discard to hand.'], $abilities[0]['effect']);
+        self::assertSame('Ability', $abilities[0]['type']);
+    }
+
+    public function testHydrateFromApiResponseWrapsAttacksInMultilingualFormat(): void
+    {
+        $card = $this->hydrator->hydrateFromApiResponse($this->createApiCardData(), $this->set);
+
+        $attacks = $card->getAttacks();
+        self::assertCount(1, $attacks);
+        self::assertSame(['en' => 'Seed Bomb'], $attacks[0]['name']);
+        self::assertSame(['Grass'], $attacks[0]['cost']);
+        self::assertSame(20, $attacks[0]['damage']);
+    }
+
+    public function testHydrateFromApiResponseThrowsOnMissingId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->hydrator->hydrateFromApiResponse(['localId' => '001'], $this->set);
+    }
+
+    public function testHydrateFromApiResponseThrowsOnMissingLocalId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->hydrator->hydrateFromApiResponse(['id' => 'sv05-001'], $this->set);
+    }
+
+    public function testUpdateFromApiResponseUpdatesExistingCard(): void
+    {
+        $card = new TcgdexCard('sv05-001', $this->set, '001');
+        $card->setName(['en' => 'Old Name']);
+        $card->setCategory('Pokemon');
+        $card->setImageBaseUrl(null);
+
+        $this->hydrator->updateFromApiResponse($card, $this->createApiCardData());
+
+        self::assertSame(['en' => 'Exeggcute'], $card->getName());
+        self::assertSame('https://assets.tcgdex.net/en/sv/sv05/001', $card->getImageBaseUrl());
+        self::assertSame(50, $card->getHp());
+        self::assertTrue($card->isExpandedLegal());
+    }
+
+    public function testHydrateFromNdjsonRecordSetsAllFields(): void
+    {
+        $record = [
+            'id' => 'sv05-001',
+            'localId' => '001',
+            'name' => ['en' => 'Exeggcute', 'fr' => 'Noeunoeuf'],
+            'category' => 'Pokemon',
+            'hp' => 50,
+            'rarity' => 'Common',
+            'stage' => 'Basic',
+            'types' => ['Grass'],
+            'retreat' => 1,
+            'regulationMark' => 'G',
+            'illustrator' => 'Mitsuhiro Arita',
+            'isExpandedLegal' => true,
+            'abilities' => [
+                ['name' => ['en' => 'Propagation', 'fr' => 'Propagation'], 'effect' => ['en' => 'Do stuff.'], 'type' => 'Ability'],
+            ],
+            'attacks' => [],
+        ];
+
+        $card = $this->hydrator->hydrateFromNdjsonRecord($record, $this->set);
+
+        self::assertSame('sv05-001', $card->getId());
+        self::assertSame(['en' => 'Exeggcute', 'fr' => 'Noeunoeuf'], $card->getName());
+        self::assertSame('Pokemon', $card->getCategory());
+        self::assertSame(50, $card->getHp());
+        self::assertTrue($card->isExpandedLegal());
+        self::assertNull($card->getImageBaseUrl()); // NDJSON doesn't set imageBaseUrl
+    }
+
+    public function testHydrateFromNdjsonRecordThrowsOnMissingId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->hydrator->hydrateFromNdjsonRecord(['localId' => '001'], $this->set);
+    }
+
+    public function testGetImageUrlPrefersImageBaseUrl(): void
+    {
+        $card = new TcgdexCard('sv05-001', $this->set, '001');
+        $card->setImageBaseUrl('https://assets.tcgdex.net/en/sv/sv05/001');
+
+        self::assertSame('https://assets.tcgdex.net/en/sv/sv05/001/high.webp', $card->getImageUrl());
+    }
+
+    public function testGetImageUrlFallsBackToComputedUrl(): void
+    {
+        $card = new TcgdexCard('sv05-001', $this->set, '001');
+
+        self::assertSame('https://assets.tcgdex.net/en/sv/sv05/001/high.webp', $card->getImageUrl());
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -4581,6 +4581,46 @@
                 <source>app.admin.technical.set_mappings.dispatched</source>
                 <target>Set mappings rebuild dispatched. It will complete in the background.</target>
             </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.title">
+                <source>app.admin.technical.tcgdex_sync.title</source>
+                <target>TCGdex Database Sync</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.description">
+                <source>app.admin.technical.tcgdex_sync.description</source>
+                <target>Incrementally sync new cards and metadata from the TCGdex API.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.last_sync">
+                <source>app.admin.technical.tcgdex_sync.last_sync</source>
+                <target>Last sync: %date%</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.never_synced">
+                <source>app.admin.technical.tcgdex_sync.never_synced</source>
+                <target>Never synced</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.queue_depth">
+                <source>app.admin.technical.tcgdex_sync.queue_depth</source>
+                <target>%count% message(s) pending</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.cooldown_active">
+                <source>app.admin.technical.tcgdex_sync.cooldown_active</source>
+                <target>API cooldown active</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.insert_button">
+                <source>app.admin.technical.tcgdex_sync.insert_button</source>
+                <target>Sync new data</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.update_button">
+                <source>app.admin.technical.tcgdex_sync.update_button</source>
+                <target>Sync &amp; update metadata</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.dispatched_insert">
+                <source>app.admin.technical.tcgdex_sync.dispatched_insert</source>
+                <target>TCGdex sync dispatched (insert mode). New data will appear shortly.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.dispatched_update">
+                <source>app.admin.technical.tcgdex_sync.dispatched_update</source>
+                <target>TCGdex sync dispatched (update mode). Metadata and image URLs will be refreshed.</target>
+            </trans-unit>
             <trans-unit id="app.admin.technical.banned_cards.title">
                 <source>app.admin.technical.banned_cards.title</source>
                 <target>Banned Cards Sync</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -4556,6 +4556,46 @@
                 <source>app.admin.technical.set_mappings.dispatched</source>
                 <target>Reconstruction des correspondances lancée. Elle se terminera en arrière-plan.</target>
             </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.title">
+                <source>app.admin.technical.tcgdex_sync.title</source>
+                <target>Synchronisation TCGdex</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.description">
+                <source>app.admin.technical.tcgdex_sync.description</source>
+                <target>Synchroniser les nouvelles cartes et métadonnées depuis l'API TCGdex.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.last_sync">
+                <source>app.admin.technical.tcgdex_sync.last_sync</source>
+                <target>Dernière synchro : %date%</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.never_synced">
+                <source>app.admin.technical.tcgdex_sync.never_synced</source>
+                <target>Jamais synchronisé</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.queue_depth">
+                <source>app.admin.technical.tcgdex_sync.queue_depth</source>
+                <target>%count% message(s) en attente</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.cooldown_active">
+                <source>app.admin.technical.tcgdex_sync.cooldown_active</source>
+                <target>API en pause (cooldown)</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.insert_button">
+                <source>app.admin.technical.tcgdex_sync.insert_button</source>
+                <target>Synchroniser les nouveautés</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.update_button">
+                <source>app.admin.technical.tcgdex_sync.update_button</source>
+                <target>Synchroniser et mettre à jour</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.dispatched_insert">
+                <source>app.admin.technical.tcgdex_sync.dispatched_insert</source>
+                <target>Synchronisation TCGdex lancée (mode insertion). Les nouvelles données apparaîtront sous peu.</target>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.tcgdex_sync.dispatched_update">
+                <source>app.admin.technical.tcgdex_sync.dispatched_update</source>
+                <target>Synchronisation TCGdex lancée (mode mise à jour). Les métadonnées et URLs d'images seront actualisées.</target>
+            </trans-unit>
             <trans-unit id="app.admin.technical.banned_cards.title">
                 <source>app.admin.technical.banned_cards.title</source>
                 <target>Synchronisation des cartes bannies</target>


### PR DESCRIPTION
## Summary

Full implementation of incremental TCGdex database sync (#411 / F6.13):

### Sync handlers (#419)
- 5 message handlers: Series → Serie → Set → Card → Complete cascade
- Throttle + redispatch pattern, `tcgp` excluded, release date DESC ordering

### Transport configuration (#420)
- 4 per-level Doctrine transports with `max_retries: 0`
- `make worker.sync` Makefile target

### Sync modes
- `SyncMode` enum (`insert`, `update`, `full`) propagated through all messages
- **Insert**: only create missing entities
- **Update**: refresh metadata + update `imageBaseUrl` from set response (no per-card API calls)
- **Full**: re-fetch everything (CLI only, requires `--force`)

### CLI command (#452)
- `symfony console app:tcgdex:sync --mode=insert|update|full`
- Reports queue depth and last sync timestamp

### Admin dashboard (#453)
- "TCGdex Database Sync" card with status badges and two buttons (insert + update)
- Full EN + FR translations

### Signed webhook (#454)
- `POST /webhook/tcgdex-sync` — anonymous, HMAC-SHA256 signed
- 202/403/404/200 responses, insert mode only

### Tests (#423)
- **48 new unit tests** (908 total, 2239 assertions):
  - 5 handler tests: API calls, entity creation, mode propagation, redispatch, ordering
  - Webhook test: HMAC verification, all response codes
  - CLI command test: mode validation, --force guard, queue depth
  - Hydrator test: API/NDJSON hydration, update mode, multilingual wrapping, imageBaseUrl

Closes #419
Closes #420
Closes #452
Closes #453
Closes #454
Closes #423

## Test plan
- [x] `make phpstan` — level 10 clean
- [x] `make test.unit` — 908 tests, 2239 assertions
- [x] `make lint-i18n` + `make lint-yaml` — valid
- [ ] Manual: admin dashboard sync card
- [ ] Manual: full cascade end-to-end
- [ ] Manual: webhook with valid/invalid signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)