### PR TITLE
:ambulance: Hotfix: add TCGdex sync worker to supervisor config

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,7 +55,12 @@ Each transport has its own DSN. Default: `doctrine://default?auto_setup=0` (Doct
 | `MESSENGER_TRANSPORT_DECK_ENRICHMENT_DSN` | No | `doctrine://default?auto_setup=0` | TCGdex card enrichment + mosaic generation queue. |
 | `MESSENGER_TRANSPORT_NOTIFICATION_DSN` | No | `doctrine://default?auto_setup=0` | Push notification dispatch queue. |
 | `MESSENGER_TRANSPORT_BORROW_LIFECYCLE_DSN` | No | `doctrine://default?auto_setup=0` | Borrow state transition queue. |
+| `MESSENGER_TRANSPORT_TCGDEX_SYNC_DSN` | No | `doctrine://default?auto_setup=0` | TCGdex incremental sync queue. |
 | `MESSENGER_TRANSPORT_FAILED_DSN` | No | `doctrine://default?queue_name=failed` | Dead-letter queue for failed messages (all transports). |
+| `TCGDEX_SYNC_DELAY_MS` | No | `200` | Minimum delay (ms) between TCGdex API calls. |
+| `TCGDEX_SYNC_FAILURE_THRESHOLD` | No | `3` | Consecutive API failures before cooldown. |
+| `TCGDEX_SYNC_COOLDOWN_SECONDS` | No | `300` | Cooldown duration (seconds) after threshold reached. |
+| `TCGDEX_SYNC_WEBHOOK_SECRET` | No | *(empty = disabled)* | HMAC-SHA256 secret for the sync webhook endpoint. |
 | `MESSENGER_WEBHOOK_SECRET` | No | (empty) | Shared secret for webhook-based message consumption. Leave empty to disable. |
 
 ### Error Tracking (Sentry)
@@ -97,10 +102,11 @@ The application uses Symfony Messenger for async processing. In production, cons
 
 ```bash
 # Consume all transports
-php bin/console messenger:consume transactional_email deck_enrichment notification borrow_lifecycle --time-limit=300
+php bin/console messenger:consume transactional_email deck_enrichment notification borrow_lifecycle tcgdex_sync_series tcgdex_sync_serie tcgdex_sync_set tcgdex_sync_card --time-limit=300
 
 # Or consume specific transports individually
 php bin/console messenger:consume deck_enrichment --time-limit=300
+php bin/console messenger:consume tcgdex_sync_series tcgdex_sync_serie tcgdex_sync_set tcgdex_sync_card --time-limit=300
 ```
 
 ### Transports
@@ -111,6 +117,10 @@ php bin/console messenger:consume deck_enrichment --time-limit=300
 | `deck_enrichment` | `deck_enrichment` | TCGdex card enrichment, mosaic image generation |
 | `notification` | `notification` | Push notifications (Notifier) |
 | `borrow_lifecycle` | `borrow_lifecycle` | Borrow state transitions, competing borrow declining |
+| `tcgdex_sync_series` | `tcgdex_sync_series` | TCGdex sync: series level |
+| `tcgdex_sync_serie` | `tcgdex_sync_serie` | TCGdex sync: serie level |
+| `tcgdex_sync_set` | `tcgdex_sync_set` | TCGdex sync: set level |
+| `tcgdex_sync_card` | `tcgdex_sync_card` | TCGdex sync: card level |
 | `failed` | `failed` | Dead-letter queue (retry 3×, multiplier ×2) |
 
 ---

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -62,3 +62,15 @@ autorestart=true
 priority=20
 stopsignal=TERM
 stopwaitsecs=30
+
+[program:worker-tcgdex-sync]
+command=php bin/console messenger:consume tcgdex_sync_series tcgdex_sync_serie tcgdex_sync_set tcgdex_sync_card --time-limit=3600 --memory-limit=256 --sleep=20 --env=prod --no-debug
+directory=/app
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=true
+priority=20
+stopsignal=TERM
+stopwaitsecs=30


### PR DESCRIPTION
## Summary

- Add `worker-tcgdex-sync` supervisor program consuming all 4 sync transports (`tcgdex_sync_series`, `tcgdex_sync_serie`, `tcgdex_sync_set`, `tcgdex_sync_card`)
- Document new env vars (`TCGDEX_SYNC_*`) in installation docs
- Add sync transports to the installation docs transport table and consume commands

Without this, the production Docker image has no worker consuming sync messages — dispatched syncs would queue up indefinitely.

## Test plan
- [ ] Rebuild Docker image, verify `supervisorctl status` shows `worker-tcgdex-sync`
- [ ] Trigger sync via webhook or admin, verify worker processes messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)