### PR TITLE
:sparkles: Feature: MeiliSearch search engine with results page and autocomplete

### DIFF
--- a/.env
+++ b/.env
@@ -119,7 +119,7 @@ TCGDEX_SYNC_WEBHOOK_SECRET=dev-tcgdex-sync-secret
 # MeiliSearch full-text search engine (F18.1)
 # Local dev: Docker Compose service on port 7700
 # Production: sidecar process on 127.0.0.1:7700
-MEILISEARCH_URL=http://127.0.0.1:7700
+MEILI_URL=http://127.0.0.1:7700
 MEILI_MASTER_KEY=dev-master-key
 ###< meilisearch ###
 

--- a/.env
+++ b/.env
@@ -115,6 +115,14 @@ TCGDEX_SYNC_COOLDOWN_SECONDS=300
 TCGDEX_SYNC_WEBHOOK_SECRET=dev-tcgdex-sync-secret
 ###< tcgdex sync ###
 
+###> meilisearch ###
+# MeiliSearch full-text search engine (F18.1)
+# Local dev: Docker Compose service on port 7700
+# Production: sidecar process on 127.0.0.1:7700
+MEILISEARCH_URL=http://127.0.0.1:7700
+MEILI_MASTER_KEY=dev-master-key
+###< meilisearch ###
+
 ###> editor upload storage ###
 # Editor image upload storage adapter: "local" or "s3"
 EDITOR_UPLOAD_STORAGE_ADAPTER=local

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,12 @@ FROM dunglas/frankenphp:php8.5 AS runtime
 #   docker build --build-arg APP_VERSION=$(git describe --tags --always) .
 ARG APP_VERSION=dev
 
-# Install Supervisor (manages FrankenPHP + Messenger workers)
+# Install Supervisor (manages FrankenPHP + Messenger workers + MeiliSearch)
 RUN apt-get update && apt-get install -y --no-install-recommends supervisor && rm -rf /var/lib/apt/lists/*
+
+# Copy MeiliSearch binary from official image (lightweight Rust binary, ~70MB)
+# Used as a sidecar process for full-text search (F18.1)
+COPY --from=getmeili/meilisearch:v1 /bin/meilisearch /usr/local/bin/meilisearch
 
 # Install required PHP extensions
 RUN install-php-extensions \
@@ -107,6 +111,8 @@ RUN rm -rf tests/ .env .env.test .env.dev docker-compose.yml node_modules/ asset
     "APP_VERSION=${APP_VERSION}" \
     'SENTRY_DSN=' \
     'SENTRY_TRACES_SAMPLE_RATE=0' \
+    'MEILISEARCH_URL=http://127.0.0.1:7700' \
+    'MEILI_MASTER_KEY=change-me-at-runtime' \
     > .env
 
 ENV APP_ENV=prod
@@ -118,6 +124,9 @@ RUN mkdir -p /data/caddy /config/caddy && chown -R www-data:www-data /data /conf
 
 # Ensure var/ is writable by www-data for runtime cache compilation
 RUN mkdir -p /app/var/cache /app/var/log && chown -R www-data:www-data /app/var
+
+# MeiliSearch data directory (ephemeral — index rebuilt from MySQL on cold start)
+RUN mkdir -p /var/lib/meilisearch/data && chown -R www-data:www-data /var/lib/meilisearch
 
 # Supervisor config
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN rm -rf tests/ .env .env.test .env.dev docker-compose.yml node_modules/ asset
     "APP_VERSION=${APP_VERSION}" \
     'SENTRY_DSN=' \
     'SENTRY_TRACES_SAMPLE_RATE=0' \
-    'MEILISEARCH_URL=http://127.0.0.1:7700' \
+    'MEILI_URL=http://127.0.0.1:7700' \
     'MEILI_MASTER_KEY=change-me-at-runtime' \
     > .env
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,10 @@ ngrok.stop: ## Stop ngrok tunnel and agent for this app
 mailpit: ## Open Mailpit web UI
 	open http://localhost:8035
 
+.PHONY: search.reindex
+search.reindex: ## Rebuild MeiliSearch indexes from database
+	symfony console app:search:reindex
+
 ## —— Messenger ————————————————————————————————————————————————————————
 
 .PHONY: worker.email

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,11 @@ mailpit: ## Open Mailpit web UI
 
 .PHONY: search.reindex
 search.reindex: ## Rebuild MeiliSearch indexes from database
+	@echo "Waiting for MeiliSearch…"
+	@for i in 1 2 3 4 5 6 7 8 9 10; do \
+		curl -sf http://127.0.0.1:7700/health > /dev/null 2>&1 && break; \
+		sleep 1; \
+	done
 	symfony console app:search:reindex
 
 ## —— Messenger ————————————————————————————————————————————————————————
@@ -81,7 +86,7 @@ migrations: ## Execute Doctrine migrations
 	symfony console doctrine:migrations:migrate --no-interaction
 
 .PHONY: fixtures
-fixtures: ## Load fixture data and dispatch enrichment
+fixtures: ## Load fixture data, enrich, and rebuild search index
 	symfony console doctrine:database:drop --force --if-exists
 	symfony console doctrine:database:create
 	symfony console doctrine:migrations:migrate --no-interaction
@@ -89,6 +94,7 @@ fixtures: ## Load fixture data and dispatch enrichment
 	symfony console app:banned-cards:sync
 	$(MAKE) tcgdex.import
 	symfony console app:enrich:retry
+	$(MAKE) search.reindex
 
 .PHONY: tcgdex.import
 tcgdex.import: ## Import TCGdex card database from local git clone

--- a/assets/components/NavbarSearch.tsx
+++ b/assets/components/NavbarSearch.tsx
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Combobox, TextInput, useCombobox } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch } from '@tabler/icons-react';
@@ -53,8 +53,8 @@ const NavbarSearch: React.FC<NavbarSearchProps> = ({ searchUrl, searchPageUrl, l
     const abortRef = useRef<AbortController | null>(null);
     const combobox = useCombobox();
 
-    const fetchResults = useCallback(async (searchQuery: string) => {
-        if (searchQuery.length < 2) {
+    useEffect(() => {
+        if (debouncedQuery.length < 2) {
             setGroups([]);
             return;
         }
@@ -64,27 +64,28 @@ const NavbarSearch: React.FC<NavbarSearchProps> = ({ searchUrl, searchPageUrl, l
         abortRef.current = controller;
 
         setLoading(true);
-        try {
-            const separator = searchUrl.includes('?') ? '&' : '?';
-            const url = `${searchUrl}${separator}q=${encodeURIComponent(searchQuery)}`;
-            const response = await fetch(url, { signal: controller.signal });
-            if (!response.ok) return;
-            const data: SearchGroup[] = await response.json();
-            setGroups(data);
+        const separator = searchUrl.includes('?') ? '&' : '?';
+        const url = `${searchUrl}${separator}q=${encodeURIComponent(debouncedQuery)}`;
 
-            if (data.length > 0 || searchQuery.length >= 2) {
-                combobox.openDropdown();
-            }
-        } catch {
-            // Aborted or network error
-        } finally {
-            setLoading(false);
-        }
-    }, [searchUrl, combobox]);
+        fetch(url, { signal: controller.signal })
+            .then((response) => {
+                if (!response.ok) return;
+                return response.json();
+            })
+            .then((data: SearchGroup[] | undefined) => {
+                if (data) {
+                    setGroups(data);
+                    combobox.openDropdown();
+                }
+            })
+            .catch(() => {
+                // Aborted or network error
+            })
+            .finally(() => setLoading(false));
 
-    useEffect(() => {
-        fetchResults(debouncedQuery);
-    }, [debouncedQuery, fetchResults]);
+        return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- combobox is stable but not referentially equal
+    }, [debouncedQuery, searchUrl]);
 
     const hasResults = groups.some((group) => group.items.length > 0);
 

--- a/assets/components/NavbarSearch.tsx
+++ b/assets/components/NavbarSearch.tsx
@@ -1,0 +1,181 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Combobox, TextInput, useCombobox } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { IconSearch } from '@tabler/icons-react';
+
+/**
+ * @see docs/features.md F18.3 — Quick-search autocomplete (navbar)
+ */
+
+interface SearchGroup {
+    type: string;
+    items: SearchItem[];
+}
+
+interface SearchItem {
+    title: string;
+    type: string;
+    url: string;
+    secondary: string | null;
+}
+
+interface NavbarSearchProps {
+    searchUrl: string;
+    searchPageUrl: string;
+    labels: {
+        placeholder: string;
+        seeAll: string;
+        noResults: string;
+    };
+}
+
+const TYPE_ICONS: Record<string, string> = {
+    archetype: '\u2694\uFE0F',
+    page: '\uD83D\uDCC4',
+    event: '\uD83D\uDCC5',
+    deck: '\uD83C\uDCCF',
+};
+
+const NavbarSearch: React.FC<NavbarSearchProps> = ({ searchUrl, searchPageUrl, labels }) => {
+    const [query, setQuery] = useState('');
+    const [debouncedQuery] = useDebouncedValue(query, 300);
+    const [groups, setGroups] = useState<SearchGroup[]>([]);
+    const [loading, setLoading] = useState(false);
+    const abortRef = useRef<AbortController | null>(null);
+    const combobox = useCombobox();
+
+    const fetchResults = useCallback(async (searchQuery: string) => {
+        if (searchQuery.length < 2) {
+            setGroups([]);
+            return;
+        }
+
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        setLoading(true);
+        try {
+            const separator = searchUrl.includes('?') ? '&' : '?';
+            const url = `${searchUrl}${separator}q=${encodeURIComponent(searchQuery)}`;
+            const response = await fetch(url, { signal: controller.signal });
+            if (!response.ok) return;
+            const data: SearchGroup[] = await response.json();
+            setGroups(data);
+
+            if (data.length > 0 || searchQuery.length >= 2) {
+                combobox.openDropdown();
+            }
+        } catch {
+            // Aborted or network error
+        } finally {
+            setLoading(false);
+        }
+    }, [searchUrl, combobox]);
+
+    useEffect(() => {
+        fetchResults(debouncedQuery);
+    }, [debouncedQuery, fetchResults]);
+
+    const hasResults = groups.some((group) => group.items.length > 0);
+
+    const handleOptionSubmit = (value: string) => {
+        if (value === '__see_all__') {
+            window.location.href = `${searchPageUrl}?q=${encodeURIComponent(query)}`;
+        } else {
+            window.location.href = value;
+        }
+        combobox.closeDropdown();
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' && !combobox.dropdownOpened) {
+            window.location.href = `${searchPageUrl}?q=${encodeURIComponent(query)}`;
+        }
+    };
+
+    return (
+        <Combobox
+            store={combobox}
+            onOptionSubmit={handleOptionSubmit}
+            withinPortal={false}
+        >
+            <Combobox.Target>
+                <TextInput
+                    placeholder={labels.placeholder}
+                    value={query}
+                    onChange={(event) => {
+                        setQuery(event.currentTarget.value);
+                        if (event.currentTarget.value.length >= 2) {
+                            combobox.openDropdown();
+                        } else {
+                            combobox.closeDropdown();
+                        }
+                    }}
+                    onFocus={() => {
+                        if (query.length >= 2 && groups.length > 0) {
+                            combobox.openDropdown();
+                        }
+                    }}
+                    onBlur={() => combobox.closeDropdown()}
+                    onKeyDown={handleKeyDown}
+                    leftSection={<IconSearch size={16} />}
+                    size="xs"
+                    styles={{
+                        input: {
+                            width: '200px',
+                            backgroundColor: 'rgba(255,255,255,0.1)',
+                            border: '1px solid rgba(255,255,255,0.2)',
+                            color: 'white',
+                        },
+                    }}
+                />
+            </Combobox.Target>
+
+            <Combobox.Dropdown>
+                <Combobox.Options>
+                    {query.length >= 2 && !loading && !hasResults && (
+                        <Combobox.Empty>{labels.noResults}</Combobox.Empty>
+                    )}
+
+                    {groups.map((group) => (
+                        <Combobox.Group key={group.type} label={group.type}>
+                            {group.items.map((item) => (
+                                <Combobox.Option key={item.url} value={item.url}>
+                                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                        <span>
+                                            {TYPE_ICONS[item.type] ?? ''} {item.title}
+                                        </span>
+                                        {item.secondary && (
+                                            <span style={{ fontSize: '0.75rem', color: '#868e96' }}>{item.secondary}</span>
+                                        )}
+                                    </div>
+                                </Combobox.Option>
+                            ))}
+                        </Combobox.Group>
+                    ))}
+
+                    {hasResults && (
+                        <Combobox.Option
+                            value="__see_all__"
+                            styles={{ option: { textAlign: 'center', fontWeight: 500, borderTop: '1px solid #dee2e6' } }}
+                        >
+                            {labels.seeAll} →
+                        </Combobox.Option>
+                    )}
+                </Combobox.Options>
+            </Combobox.Dropdown>
+        </Combobox>
+    );
+};
+
+export default NavbarSearch;

--- a/assets/navbar-search.tsx
+++ b/assets/navbar-search.tsx
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { MantineProvider } from '@mantine/core';
+import NavbarSearch from './components/NavbarSearch';
+
+import '@mantine/core/styles.css';
+
+/**
+ * @see docs/features.md F18.3 — Quick-search autocomplete (navbar)
+ */
+
+const root = document.getElementById('navbar-search-root');
+if (root) {
+    const searchUrl = root.dataset.searchUrl ?? '';
+    const searchPageUrl = root.dataset.searchPageUrl ?? '/search';
+    const labelPlaceholder = root.dataset.labelPlaceholder ?? 'Search…';
+    const labelSeeAll = root.dataset.labelSeeAll ?? 'See all results';
+    const labelNoResults = root.dataset.labelNoResults ?? 'No results';
+
+    createRoot(root).render(
+        <MantineProvider>
+            <NavbarSearch
+                searchUrl={searchUrl}
+                searchPageUrl={searchPageUrl}
+                labels={{
+                    placeholder: labelPlaceholder,
+                    seeAll: labelSeeAll,
+                    noResults: labelNoResults,
+                }}
+            />
+        </MantineProvider>,
+    );
+}

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "league/commonmark": "^2.8.2",
         "league/flysystem": "^3.32",
         "league/flysystem-aws-s3-v3": "^3.32",
+        "meilisearch/meilisearch-php": "^1.16",
         "phpdocumentor/reflection-docblock": "^6.0.2",
         "phpstan/phpdoc-parser": "^2.3",
         "sentry/sentry-symfony": "^5.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e07d86a78cb1795eb55a42b565dc14ea",
+    "content-hash": "efff17e6872352696d6fbe9b540ff81b",
     "packages": [
         {
             "name": "async-aws/core",
@@ -2885,6 +2885,86 @@
             "time": "2025-07-25T09:04:22+00:00"
         },
         {
+            "name": "meilisearch/meilisearch-php",
+            "version": "v1.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/meilisearch/meilisearch-php.git",
+                "reference": "f9f63e0e7d12ffaae54f7317fa8f4f4dfa8ae7b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/f9f63e0e7d12ffaae54f7317fa8f4f4dfa8ae7b6",
+                "reference": "f9f63e0e7d12ffaae54f7317fa8f4f4dfa8ae7b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0",
+                "php-http/discovery": "^1.7",
+                "psr/http-client": "^1.0",
+                "symfony/polyfill-php81": "^1.33"
+            },
+            "require-dev": {
+                "http-interop/http-factory-guzzle": "^1.2.0",
+                "php-cs-fixer/shim": "^3.59.3",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.5 || ^10.5",
+                "symfony/http-client": "^5.4|^6.0|^7.0"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Use Guzzle ^7 as HTTP client",
+                "http-interop/http-factory-guzzle": "Factory for guzzlehttp/guzzle",
+                "symfony/http-client": "Use Symfony Http client"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MeiliSearch\\": "src/",
+                    "Meilisearch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Clémentine Urquizar",
+                    "email": "clementine@meilisearch.com"
+                },
+                {
+                    "name": "Bruno Casali",
+                    "email": "bruno@meilisearch.com"
+                },
+                {
+                    "name": "Laurent Cazanove",
+                    "email": "lau.cazanove@gmail.com"
+                },
+                {
+                    "name": "Tomas Norkūnas",
+                    "email": "norkunas.tom@gmail.com"
+                }
+            ],
+            "description": "PHP wrapper for the Meilisearch API",
+            "keywords": [
+                "api",
+                "client",
+                "instant",
+                "meilisearch",
+                "php",
+                "search"
+            ],
+            "support": {
+                "issues": "https://github.com/meilisearch/meilisearch-php/issues",
+                "source": "https://github.com/meilisearch/meilisearch-php/tree/v1.16.1"
+            },
+            "time": "2025-09-18T10:15:45+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.10.0",
             "source": {
@@ -3210,6 +3290,85 @@
                 "source": "https://github.com/nette/utils/tree/v4.1.3"
             },
             "time": "2026-02-13T03:05:33+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/config/packages/http_discovery.yaml
+++ b/config/packages/http_discovery.yaml
@@ -1,0 +1,10 @@
+services:
+    Psr\Http\Message\RequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@http_discovery.psr17_factory'
+
+    http_discovery.psr17_factory:
+        class: Http\Discovery\Psr17Factory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,22 @@ services:
     volumes:
       - database_data:/var/lib/mysql
 
+  meilisearch:
+    image: getmeili/meilisearch:v1
+    environment:
+      MEILI_ENV: development
+      MEILI_NO_ANALYTICS: "true"
+      MEILI_MASTER_KEY: dev-master-key
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    ports:
+      - "7700:7700"
+    volumes:
+      - meilisearch_data:/meili_data
+
   mailpit:
     image: axllent/mailpit:latest
     ports:
@@ -27,3 +43,4 @@ services:
 
 volumes:
   database_data:
+  meilisearch_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,5 +6,26 @@ set -e
 php bin/console cache:clear --env=prod --no-debug 2>/dev/null || true
 php bin/console cache:warmup --env=prod --no-debug
 
-# Launch Supervisor (manages FrankenPHP + Messenger workers)
+# Start MeiliSearch in the background so the reindex command can reach it.
+# Supervisor will take over management once it starts (autorestart=true).
+meilisearch --http-addr 127.0.0.1:7700 --env production \
+    --master-key "${MEILI_MASTER_KEY}" \
+    --db-path /var/lib/meilisearch/data &
+
+# Wait for MeiliSearch to be ready (max ~5s)
+for i in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -sf http://127.0.0.1:7700/health > /dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+# Rebuild search indexes from MySQL (ephemeral disk — index lost on restart)
+php bin/console app:search:reindex --env=prod --no-debug 2>/dev/null || true
+
+# Stop the temporary MeiliSearch — Supervisor will start and manage its own
+kill %1 2>/dev/null || true
+sleep 0.5
+
+# Launch Supervisor (manages FrankenPHP + Messenger workers + MeiliSearch)
 exec supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,7 +77,7 @@ MeiliSearch runs as a sidecar process inside the same container (`127.0.0.1:7700
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `MEILISEARCH_URL` | No | `http://127.0.0.1:7700` | MeiliSearch HTTP endpoint. In production, always `http://127.0.0.1:7700` (sidecar). |
+| `MEILI_URL` | No | `http://127.0.0.1:7700` | MeiliSearch HTTP endpoint. In production, always `http://127.0.0.1:7700` (sidecar). Uses `MEILI_` prefix (not `MEILISEARCH_`) to avoid Symfony CLI Docker integration overriding with `tcp://` from the `meilisearch` service. |
 | `MEILI_MASTER_KEY` | **Yes** | (none) | MeiliSearch master key. Generate with `openssl rand -hex 16`. |
 
 ### Bot Protection (Friendly Captcha)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,6 +71,15 @@ Each transport has its own DSN. Default: `doctrine://default?auto_setup=0` (Doct
 | `SENTRY_TRACES_SAMPLE_RATE` | No | `0` | Performance tracing sample rate (`0.0`–`1.0`). |
 | `SENTRY_LOGS_ACTION_LEVEL` | No | `error` | Minimum log level that triggers the Sentry handler (`error`, `warning`, `info`, `debug`). |
 
+### Search Engine (MeiliSearch)
+
+MeiliSearch runs as a sidecar process inside the same container (`127.0.0.1:7700`). The index is ephemeral — rebuilt from MySQL on every cold start via `app:search:reindex`.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `MEILISEARCH_URL` | No | `http://127.0.0.1:7700` | MeiliSearch HTTP endpoint. In production, always `http://127.0.0.1:7700` (sidecar). |
+| `MEILI_MASTER_KEY` | **Yes** | (none) | MeiliSearch master key. Generate with `openssl rand -hex 16`. |
+
 ### Bot Protection (Friendly Captcha)
 
 | Variable | Required | Default | Description |

--- a/src/Command/SearchReindexCommand.php
+++ b/src/Command/SearchReindexCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Service\Search\SearchIndexer;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Rebuilds all MeiliSearch indexes from the database.
+ *
+ * Run on every cold start (via docker-entrypoint.sh) to rebuild the
+ * ephemeral search index, or manually when data needs a full re-sync.
+ *
+ * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+ */
+#[AsCommand(
+    name: 'app:search:reindex',
+    description: 'Rebuild all MeiliSearch indexes from the database.',
+)]
+class SearchReindexCommand extends Command
+{
+    public function __construct(
+        private readonly SearchIndexer $searchIndexer,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$this->searchIndexer->isHealthy()) {
+            $io->warning('MeiliSearch is not reachable — skipping reindex.');
+
+            return Command::SUCCESS;
+        }
+
+        $io->title('Rebuilding MeiliSearch indexes');
+
+        $counts = $this->searchIndexer->reindexAll();
+
+        $io->table(
+            ['Index', 'Documents'],
+            array_map(
+                static fn (string $index, int $count): array => [$index, (string) $count],
+                array_keys($counts),
+                array_values($counts),
+            ),
+        );
+
+        $total = array_sum($counts);
+        $io->success(\sprintf('Indexed %d documents across %d indexes.', $total, \count($counts)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Liveness and readiness probes for container orchestration.
@@ -28,9 +29,12 @@ class HealthController
 {
     public function __construct(
         private readonly Connection $connection,
+        private readonly HttpClientInterface $httpClient,
         private readonly LoggerInterface $logger,
         #[\Symfony\Component\DependencyInjection\Attribute\Autowire(env: 'APP_VERSION')]
         private readonly string $appVersion,
+        #[\Symfony\Component\DependencyInjection\Attribute\Autowire(env: 'MEILISEARCH_URL')]
+        private readonly string $meilisearchUrl,
     ) {
     }
 
@@ -56,6 +60,11 @@ class HealthController
 
         $checks['database'] = $this->checkDatabase();
         if ('ok' !== $checks['database']['status']) {
+            $healthy = false;
+        }
+
+        $checks['meilisearch'] = $this->checkMeilisearch();
+        if ('ok' !== $checks['meilisearch']['status']) {
             $healthy = false;
         }
 
@@ -97,6 +106,27 @@ class HealthController
             $latency = (hrtime(true) - $start) / 1_000_000;
 
             return ['status' => 'ok', 'latency_ms' => round($latency, 1)];
+        } catch (\Throwable $exception) {
+            return ['status' => 'fail', 'error' => $exception->getMessage()];
+        }
+    }
+
+    /**
+     * @return array{status: string, latency_ms?: float, error?: string}
+     */
+    private function checkMeilisearch(): array
+    {
+        try {
+            $start = hrtime(true);
+            $response = $this->httpClient->request('GET', $this->meilisearchUrl.'/health');
+            $data = $response->toArray();
+            $latency = (hrtime(true) - $start) / 1_000_000;
+
+            if ('available' === ($data['status'] ?? null)) {
+                return ['status' => 'ok', 'latency_ms' => round($latency, 1)];
+            }
+
+            return ['status' => 'fail', 'error' => 'MeiliSearch status: '.($data['status'] ?? 'unknown')];
         } catch (\Throwable $exception) {
             return ['status' => 'fail', 'error' => $exception->getMessage()];
         }

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -33,7 +33,7 @@ class HealthController
         private readonly LoggerInterface $logger,
         #[\Symfony\Component\DependencyInjection\Attribute\Autowire(env: 'APP_VERSION')]
         private readonly string $appVersion,
-        #[\Symfony\Component\DependencyInjection\Attribute\Autowire(env: 'MEILISEARCH_URL')]
+        #[\Symfony\Component\DependencyInjection\Attribute\Autowire(env: 'MEILI_URL')]
         private readonly string $meilisearchUrl,
     ) {
     }

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -126,7 +126,9 @@ class HealthController
                 return ['status' => 'ok', 'latency_ms' => round($latency, 1)];
             }
 
-            return ['status' => 'fail', 'error' => 'MeiliSearch status: '.($data['status'] ?? 'unknown')];
+            $meiliStatus = $data['status'] ?? 'unknown';
+
+            return ['status' => 'fail', 'error' => 'MeiliSearch status: '.(\is_string($meiliStatus) ? $meiliStatus : 'unknown')];
         } catch (\Throwable $exception) {
             return ['status' => 'fail', 'error' => $exception->getMessage()];
         }

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -63,10 +63,9 @@ class HealthController
             $healthy = false;
         }
 
+        // MeiliSearch is a non-critical dependency: search degrades gracefully
+        // to database LIKE queries when unavailable. Reported but not fatal.
         $checks['meilisearch'] = $this->checkMeilisearch();
-        if ('ok' !== $checks['meilisearch']['status']) {
-            $healthy = false;
-        }
 
         return new JsonResponse(
             ['status' => $healthy ? 'healthy' : 'unhealthy', 'version' => $this->appVersion, 'checks' => $checks],

--- a/src/Controller/SearchApiController.php
+++ b/src/Controller/SearchApiController.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Service\Search\SearchService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * JSON API endpoint for navbar quick-search autocomplete.
+ *
+ * @see docs/features.md F18.3 — Quick-search autocomplete (navbar)
+ */
+class SearchApiController extends AbstractController
+{
+    /**
+     * @see docs/features.md F18.3 — Quick-search autocomplete (navbar)
+     */
+    #[Route('/api/search/quick', name: 'app_search_api_quick', methods: ['GET'])]
+    public function quickSearch(Request $request, SearchService $searchService, UrlGeneratorInterface $urlGenerator): JsonResponse
+    {
+        $query = trim($request->query->getString('q'));
+        $locale = $request->getLocale();
+
+        if (mb_strlen($query) < 2) {
+            return new JsonResponse([]);
+        }
+
+        $results = $searchService->quickSearch($query, $locale);
+
+        $groups = [];
+
+        foreach ($results as $type => $items) {
+            if ([] === $items) {
+                continue;
+            }
+
+            $group = [
+                'type' => $type,
+                'items' => [],
+            ];
+
+            foreach ($items as $result) {
+                $group['items'][] = [
+                    'title' => strip_tags($result->title),
+                    'type' => $result->type,
+                    'url' => $this->buildResultUrl($result, $locale, $urlGenerator),
+                    'secondary' => $result->secondaryInfo,
+                ];
+            }
+
+            $groups[] = $group;
+        }
+
+        return new JsonResponse($groups);
+    }
+
+    private function buildResultUrl(
+        \App\Service\Search\SearchResult $result,
+        string $locale,
+        UrlGeneratorInterface $urlGenerator,
+    ): string {
+        return match ($result->type) {
+            'archetype' => $urlGenerator->generate('app_archetype_show', ['slug' => $result->slug, '_locale' => $locale]),
+            'page' => $urlGenerator->generate('app_page_show', ['slug' => $result->slug, '_locale' => $locale]),
+            'event' => $urlGenerator->generate('app_event_show', ['id' => $result->slug]),
+            'deck' => $urlGenerator->generate('app_deck_show', ['short_tag' => $result->slug]),
+            default => '/',
+        };
+    }
+}

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Service\Search\SearchService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Full-page search results with type-grouped display.
+ *
+ * @see docs/features.md F18.2 — Global search results page
+ */
+class SearchController extends AbstractController
+{
+    /**
+     * @see docs/features.md F18.2 — Global search results page
+     */
+    #[Route('/{_locale}/search', name: 'app_search', methods: ['GET'], requirements: ['_locale' => 'en|fr'])]
+    public function search(Request $request, SearchService $searchService): Response
+    {
+        $query = trim($request->query->getString('q'));
+        $typeFilter = $request->query->getString('type') ?: null;
+        $locale = $request->getLocale();
+
+        $validTypes = ['archetypes', 'pages', 'events', 'decks'];
+        if (null !== $typeFilter && !\in_array($typeFilter, $validTypes, true)) {
+            $typeFilter = null;
+        }
+
+        $results = '' !== $query ? $searchService->searchAll($query, $locale, $typeFilter) : [
+            'archetypes' => [],
+            'pages' => [],
+            'events' => [],
+            'decks' => [],
+        ];
+
+        $totalCount = array_sum(array_map('count', $results));
+
+        return $this->render('search/results.html.twig', [
+            'query' => $query,
+            'typeFilter' => $typeFilter,
+            'results' => $results,
+            'totalCount' => $totalCount,
+        ]);
+    }
+}

--- a/src/EventListener/SearchIndexListener.php
+++ b/src/EventListener/SearchIndexListener.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\EventListener;
+
+use App\Entity\Archetype;
+use App\Entity\ArchetypeTranslation;
+use App\Entity\Deck;
+use App\Entity\Event;
+use App\Entity\Page;
+use App\Entity\PageTranslation;
+use App\Service\Search\SearchIndexer;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Keeps MeiliSearch indexes in sync with Doctrine entity changes.
+ *
+ * Listens to postPersist, postUpdate, and postRemove events on the four
+ * searchable content types. Translation entity changes are propagated
+ * through the parent entity.
+ *
+ * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+ */
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::postUpdate)]
+#[AsDoctrineListener(event: Events::postRemove)]
+class SearchIndexListener
+{
+    public function __construct(
+        private readonly SearchIndexer $searchIndexer,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function postPersist(PostPersistEventArgs $args): void
+    {
+        $this->handleEntity($args->getObject());
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args): void
+    {
+        $this->handleEntity($args->getObject());
+    }
+
+    public function postRemove(PostRemoveEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if ($entity instanceof Archetype) {
+            $this->searchIndexer->removeArchetype($entity);
+        } elseif ($entity instanceof Page) {
+            $this->searchIndexer->removePage($entity);
+        } elseif ($entity instanceof Event) {
+            $this->searchIndexer->removeEvent($entity);
+        } elseif ($entity instanceof Deck) {
+            $this->searchIndexer->removeDeck($entity);
+        }
+    }
+
+    private function handleEntity(object $entity): void
+    {
+        try {
+            if ($entity instanceof Archetype) {
+                $this->searchIndexer->indexArchetype($entity);
+            } elseif ($entity instanceof Page) {
+                $this->searchIndexer->indexPage($entity);
+            } elseif ($entity instanceof Event) {
+                $this->searchIndexer->indexEvent($entity);
+            } elseif ($entity instanceof Deck) {
+                $this->searchIndexer->indexDeck($entity);
+            } elseif ($entity instanceof ArchetypeTranslation) {
+                $this->searchIndexer->indexArchetype($entity->getArchetype());
+            } elseif ($entity instanceof PageTranslation) {
+                $this->searchIndexer->indexPage($entity->getPage());
+            }
+        } catch (\Throwable $exception) {
+            // Search index sync should never break the main application flow
+            $this->logger->warning('Search index sync failed: {error}', [
+                'error' => $exception->getMessage(),
+                'entity' => $entity::class,
+            ]);
+        }
+    }
+}

--- a/src/Repository/ArchetypeRepository.php
+++ b/src/Repository/ArchetypeRepository.php
@@ -218,6 +218,29 @@ class ArchetypeRepository extends ServiceEntityRepository
     }
 
     /**
+     * Return all published archetypes with their translations eagerly loaded.
+     *
+     * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+     *
+     * @return list<Archetype>
+     */
+    public function findPublishedForSearch(): array
+    {
+        /** @var list<Archetype> $results */
+        $results = $this->createQueryBuilder('a')
+            ->addSelect('t')
+            ->leftJoin('a.translations', 't')
+            ->where('a.isPublished = :published')
+            ->andWhere('a.deletedAt IS NULL')
+            ->setParameter('published', true)
+            ->orderBy('a.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $results;
+    }
+
+    /**
      * @see docs/features.md F2.10 — Archetype detail page
      */
     public function findPublishedBySlug(string $slug): ?Archetype

--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -348,6 +348,31 @@ class DeckRepository extends ServiceEntityRepository
     }
 
     /**
+     * Return all public, owned decks for search indexing.
+     *
+     * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+     *
+     * @return list<Deck>
+     */
+    public function findPublicForSearch(): array
+    {
+        /** @var list<Deck> $results */
+        $results = $this->createQueryBuilder('d')
+            ->addSelect('a', 'o')
+            ->leftJoin('d.archetype', 'a')
+            ->leftJoin('d.owner', 'o')
+            ->where('d.public = :public')
+            ->andWhere('d.owner IS NOT NULL')
+            ->andWhere('d.deletedAt IS NULL')
+            ->setParameter('public', true)
+            ->orderBy('d.updatedAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return $results;
+    }
+
+    /**
      * Build a query for the public deck catalog with optional filters.
      *
      * When selfOwner is true the public-visibility constraint is dropped,

--- a/src/Repository/EventRepository.php
+++ b/src/Repository/EventRepository.php
@@ -184,6 +184,28 @@ class EventRepository extends ServiceEntityRepository
     }
 
     /**
+     * Return all public, non-cancelled events for search indexing.
+     *
+     * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+     *
+     * @return list<Event>
+     */
+    public function findPublicForSearch(): array
+    {
+        /** @var list<Event> $results */
+        $results = $this->createQueryBuilder('e')
+            ->where('e.visibility = :visibility')
+            ->andWhere('e.cancelledAt IS NULL')
+            ->andWhere('e.deletedAt IS NULL')
+            ->setParameter('visibility', EventVisibility::Public)
+            ->orderBy('e.date', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return $results;
+    }
+
+    /**
      * @see docs/features.md F2.4 — Deck Catalog (Browse & Search)
      *
      * @return list<Event>

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -128,6 +128,29 @@ class PageRepository extends ServiceEntityRepository
     }
 
     /**
+     * Return all published, indexable pages with their translations eagerly loaded.
+     *
+     * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+     *
+     * @return list<Page>
+     */
+    public function findPublishedForSearch(): array
+    {
+        /** @var list<Page> $results */
+        $results = $this->createQueryBuilder('p')
+            ->addSelect('t')
+            ->leftJoin('p.translations', 't')
+            ->where('p.isPublished = true')
+            ->andWhere('p.noIndex = false')
+            ->andWhere('p.deletedAt IS NULL')
+            ->orderBy('p.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return $results;
+    }
+
+    /**
      * Build a query builder for the admin page list with optional search and category filter.
      *
      * @see docs/features.md F7.10 — Admin pages: filter by category and drag-and-drop sorting

--- a/src/Service/Search/SearchIndexer.php
+++ b/src/Service/Search/SearchIndexer.php
@@ -1,0 +1,433 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Search;
+
+use App\Entity\Archetype;
+use App\Entity\Deck;
+use App\Entity\Event;
+use App\Entity\Page;
+use App\Enum\EventVisibility;
+use App\Repository\ArchetypeRepository;
+use App\Repository\DeckRepository;
+use App\Repository\EventRepository;
+use App\Repository\PageRepository;
+use Meilisearch\Client;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Manages MeiliSearch indexes: configures settings, indexes documents,
+ * and keeps the search index in sync with the database.
+ *
+ * Each content type has its own index with locale-aware documents.
+ * Translatable entities produce one document per locale.
+ *
+ * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+ */
+class SearchIndexer
+{
+    public const string INDEX_ARCHETYPES = 'archetypes';
+    public const string INDEX_PAGES = 'pages';
+    public const string INDEX_EVENTS = 'events';
+    public const string INDEX_DECKS = 'decks';
+
+    private const array SUPPORTED_LOCALES = ['en', 'fr'];
+
+    private readonly Client $client;
+
+    public function __construct(
+        #[Autowire(env: 'MEILISEARCH_URL')]
+        string $meilisearchUrl,
+        #[Autowire(env: 'MEILI_MASTER_KEY')]
+        string $meiliMasterKey,
+        private readonly ArchetypeRepository $archetypeRepository,
+        private readonly PageRepository $pageRepository,
+        private readonly EventRepository $eventRepository,
+        private readonly DeckRepository $deckRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->client = new Client($meilisearchUrl, $meiliMasterKey);
+    }
+
+    /**
+     * Delete all indexes and recreate them with correct settings and full data.
+     *
+     * @return array{archetypes: int, pages: int, events: int, decks: int} Document counts per index
+     */
+    public function reindexAll(): array
+    {
+        $counts = [];
+
+        $counts[self::INDEX_ARCHETYPES] = $this->reindexArchetypes();
+        $counts[self::INDEX_PAGES] = $this->reindexPages();
+        $counts[self::INDEX_EVENTS] = $this->reindexEvents();
+        $counts[self::INDEX_DECKS] = $this->reindexDecks();
+
+        return $counts;
+    }
+
+    public function indexArchetype(Archetype $archetype): void
+    {
+        if (!$archetype->isPublished() || $archetype->getDeletedAt() instanceof \DateTimeImmutable) {
+            $this->removeArchetype($archetype);
+
+            return;
+        }
+
+        $documents = $this->mapArchetype($archetype);
+        $this->client->index(self::INDEX_ARCHETYPES)->addDocuments($documents);
+    }
+
+    public function removeArchetype(Archetype $archetype): void
+    {
+        $ids = [];
+        foreach (self::SUPPORTED_LOCALES as $locale) {
+            $ids[] = $archetype->getId().'_'.$locale;
+        }
+        $this->deleteDocumentsSafe(self::INDEX_ARCHETYPES, $ids);
+    }
+
+    public function indexPage(Page $page): void
+    {
+        if (!$page->isPublished() || $page->isNoIndex() || $page->getDeletedAt() instanceof \DateTimeImmutable) {
+            $this->removePage($page);
+
+            return;
+        }
+
+        $documents = $this->mapPage($page);
+        $this->client->index(self::INDEX_PAGES)->addDocuments($documents);
+    }
+
+    public function removePage(Page $page): void
+    {
+        $ids = [];
+        foreach (self::SUPPORTED_LOCALES as $locale) {
+            $ids[] = $page->getId().'_'.$locale;
+        }
+        $this->deleteDocumentsSafe(self::INDEX_PAGES, $ids);
+    }
+
+    public function indexEvent(Event $event): void
+    {
+        if (EventVisibility::Public !== $event->getVisibility() || $event->getDeletedAt() instanceof \DateTimeImmutable) {
+            $this->removeEvent($event);
+
+            return;
+        }
+
+        $document = $this->mapEvent($event);
+        $this->client->index(self::INDEX_EVENTS)->addDocuments([$document]);
+    }
+
+    public function removeEvent(Event $event): void
+    {
+        $this->deleteDocumentsSafe(self::INDEX_EVENTS, [(string) $event->getId()]);
+    }
+
+    public function indexDeck(Deck $deck): void
+    {
+        if (!$deck->isPublic() || null === $deck->getOwner() || $deck->getDeletedAt() instanceof \DateTimeImmutable) {
+            $this->removeDeck($deck);
+
+            return;
+        }
+
+        $document = $this->mapDeck($deck);
+        $this->client->index(self::INDEX_DECKS)->addDocuments([$document]);
+    }
+
+    public function removeDeck(Deck $deck): void
+    {
+        $this->deleteDocumentsSafe(self::INDEX_DECKS, [$deck->getShortTag()]);
+    }
+
+    /**
+     * Check if MeiliSearch is reachable and healthy.
+     */
+    public function isHealthy(): bool
+    {
+        try {
+            $health = $this->client->health();
+
+            return 'available' === ($health['status'] ?? null);
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    private function reindexArchetypes(): int
+    {
+        $index = $this->client->index(self::INDEX_ARCHETYPES);
+
+        try {
+            $this->client->deleteIndex(self::INDEX_ARCHETYPES);
+        } catch (\Throwable) {
+            // Index may not exist yet
+        }
+
+        $this->client->createIndex(self::INDEX_ARCHETYPES, ['primaryKey' => 'id']);
+        $index->updateSettings([
+            'searchableAttributes' => ['name', 'description', 'metaDescription'],
+            'filterableAttributes' => ['locale', 'entityId'],
+            'displayedAttributes' => ['id', 'entityId', 'locale', 'name', 'slug', 'type'],
+        ]);
+
+        $archetypes = $this->archetypeRepository->findPublishedForSearch();
+        $documents = [];
+
+        foreach ($archetypes as $archetype) {
+            foreach ($this->mapArchetype($archetype) as $document) {
+                $documents[] = $document;
+            }
+        }
+
+        if ([] !== $documents) {
+            $index->addDocuments($documents);
+        }
+
+        $this->logger->info('Indexed {count} archetype documents.', ['count' => \count($documents)]);
+
+        return \count($documents);
+    }
+
+    private function reindexPages(): int
+    {
+        $index = $this->client->index(self::INDEX_PAGES);
+
+        try {
+            $this->client->deleteIndex(self::INDEX_PAGES);
+        } catch (\Throwable) {
+            // Index may not exist yet
+        }
+
+        $this->client->createIndex(self::INDEX_PAGES, ['primaryKey' => 'id']);
+        $index->updateSettings([
+            'searchableAttributes' => ['title', 'content'],
+            'filterableAttributes' => ['locale', 'entityId'],
+            'displayedAttributes' => ['id', 'entityId', 'locale', 'title', 'slug', 'type'],
+        ]);
+
+        $pages = $this->pageRepository->findPublishedForSearch();
+        $documents = [];
+
+        foreach ($pages as $page) {
+            foreach ($this->mapPage($page) as $document) {
+                $documents[] = $document;
+            }
+        }
+
+        if ([] !== $documents) {
+            $index->addDocuments($documents);
+        }
+
+        $this->logger->info('Indexed {count} page documents.', ['count' => \count($documents)]);
+
+        return \count($documents);
+    }
+
+    private function reindexEvents(): int
+    {
+        $index = $this->client->index(self::INDEX_EVENTS);
+
+        try {
+            $this->client->deleteIndex(self::INDEX_EVENTS);
+        } catch (\Throwable) {
+            // Index may not exist yet
+        }
+
+        $this->client->createIndex(self::INDEX_EVENTS, ['primaryKey' => 'id']);
+        $index->updateSettings([
+            'searchableAttributes' => ['name', 'description', 'location'],
+            'filterableAttributes' => ['format'],
+            'sortableAttributes' => ['date'],
+            'displayedAttributes' => ['id', 'name', 'date', 'location', 'type'],
+        ]);
+
+        $events = $this->eventRepository->findPublicForSearch();
+        $documents = [];
+
+        foreach ($events as $event) {
+            $documents[] = $this->mapEvent($event);
+        }
+
+        if ([] !== $documents) {
+            $index->addDocuments($documents);
+        }
+
+        $this->logger->info('Indexed {count} event documents.', ['count' => \count($documents)]);
+
+        return \count($documents);
+    }
+
+    private function reindexDecks(): int
+    {
+        $index = $this->client->index(self::INDEX_DECKS);
+
+        try {
+            $this->client->deleteIndex(self::INDEX_DECKS);
+        } catch (\Throwable) {
+            // Index may not exist yet
+        }
+
+        $this->client->createIndex(self::INDEX_DECKS, ['primaryKey' => 'id']);
+        $index->updateSettings([
+            'searchableAttributes' => ['name', 'shortTag', 'archetypeName', 'ownerName'],
+            'filterableAttributes' => ['format', 'archetypeName'],
+            'displayedAttributes' => ['id', 'shortTag', 'name', 'archetypeName', 'ownerName', 'type'],
+        ]);
+
+        $decks = $this->deckRepository->findPublicForSearch();
+        $documents = [];
+
+        foreach ($decks as $deck) {
+            $documents[] = $this->mapDeck($deck);
+        }
+
+        if ([] !== $documents) {
+            $index->addDocuments($documents);
+        }
+
+        $this->logger->info('Indexed {count} deck documents.', ['count' => \count($documents)]);
+
+        return \count($documents);
+    }
+
+    /**
+     * Map an archetype to MeiliSearch documents (one per locale).
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function mapArchetype(Archetype $archetype): array
+    {
+        $documents = [];
+
+        foreach (self::SUPPORTED_LOCALES as $locale) {
+            $documents[] = [
+                'id' => $archetype->getId().'_'.$locale,
+                'entityId' => $archetype->getId(),
+                'locale' => $locale,
+                'type' => 'archetype',
+                'name' => $archetype->getLocalizedName($locale),
+                'slug' => $archetype->getSlug(),
+                'description' => $this->stripMarkdown($archetype->getLocalizedDescription($locale) ?? ''),
+                'metaDescription' => $archetype->getLocalizedMetaDescription($locale) ?? '',
+            ];
+        }
+
+        return $documents;
+    }
+
+    /**
+     * Map a page to MeiliSearch documents (one per locale).
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function mapPage(Page $page): array
+    {
+        $documents = [];
+
+        foreach (self::SUPPORTED_LOCALES as $locale) {
+            $translation = $page->getTranslation($locale);
+            if (null === $translation) {
+                continue;
+            }
+
+            $documents[] = [
+                'id' => $page->getId().'_'.$locale,
+                'entityId' => $page->getId(),
+                'locale' => $locale,
+                'type' => 'page',
+                'title' => $translation->getTitle(),
+                'slug' => $page->getSlug(),
+                'content' => $this->stripMarkdown($translation->getContent()),
+            ];
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mapEvent(Event $event): array
+    {
+        return [
+            'id' => (string) $event->getId(),
+            'type' => 'event',
+            'name' => $event->getName(),
+            'description' => $this->stripMarkdown($event->getDescription() ?? ''),
+            'location' => $event->getLocation() ?? '',
+            'date' => $event->getDate()->format('Y-m-d'),
+            'format' => $event->getFormat(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mapDeck(Deck $deck): array
+    {
+        return [
+            'id' => $deck->getShortTag(),
+            'type' => 'deck',
+            'name' => $deck->getName(),
+            'shortTag' => $deck->getShortTag(),
+            'archetypeName' => $deck->getArchetype()?->getName() ?? '',
+            'ownerName' => $deck->getOwner()?->getScreenName() ?? '',
+            'format' => $deck->getFormat(),
+        ];
+    }
+
+    /**
+     * Strip Markdown formatting for plain-text indexing.
+     */
+    private function stripMarkdown(string $markdown): string
+    {
+        // Remove archetype/deck/card custom tags: [[archetype:slug]], [[deck:TAG]], [[card:...]]
+        $text = (string) preg_replace('/\[\[(archetype|deck|card):[^\]]+\]\]/', '', $markdown);
+
+        // Remove Markdown links [text](url)
+        $text = (string) preg_replace('/\[([^\]]+)\]\([^)]+\)/', '$1', $text);
+
+        // Remove images ![alt](url)
+        $text = (string) preg_replace('/!\[[^\]]*\]\([^)]+\)/', '', $text);
+
+        // Remove headings (#, ##, etc.)
+        $text = (string) preg_replace('/^#{1,6}\s+/m', '', $text);
+
+        // Remove bold/italic markers
+        $text = str_replace(['**', '__', '*', '_'], '', $text);
+
+        // Collapse whitespace
+        $text = (string) preg_replace('/\s+/', ' ', $text);
+
+        return trim($text);
+    }
+
+    /**
+     * @param list<string> $documentIds
+     */
+    private function deleteDocumentsSafe(string $indexName, array $documentIds): void
+    {
+        try {
+            $this->client->index($indexName)->deleteDocuments($documentIds);
+        } catch (\Throwable $exception) {
+            $this->logger->warning('Failed to delete documents from {index}: {error}', [
+                'index' => $indexName,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/Service/Search/SearchIndexer.php
+++ b/src/Service/Search/SearchIndexer.php
@@ -398,11 +398,11 @@ class SearchIndexer
         // Remove archetype/deck/card custom tags: [[archetype:slug]], [[deck:TAG]], [[card:...]]
         $text = (string) preg_replace('/\[\[(archetype|deck|card):[^\]]+\]\]/', '', $markdown);
 
+        // Remove images ![alt](url) — must run before link and bold/italic removal
+        $text = (string) preg_replace('/!\[[^\]]*\]\([^)]+\)/', '', $text);
+
         // Remove Markdown links [text](url)
         $text = (string) preg_replace('/\[([^\]]+)\]\([^)]+\)/', '$1', $text);
-
-        // Remove images ![alt](url)
-        $text = (string) preg_replace('/!\[[^\]]*\]\([^)]+\)/', '', $text);
 
         // Remove headings (#, ##, etc.)
         $text = (string) preg_replace('/^#{1,6}\s+/m', '', $text);

--- a/src/Service/Search/SearchIndexer.php
+++ b/src/Service/Search/SearchIndexer.php
@@ -47,7 +47,7 @@ class SearchIndexer
     private readonly Client $client;
 
     public function __construct(
-        #[Autowire(env: 'MEILISEARCH_URL')]
+        #[Autowire(env: 'MEILI_URL')]
         string $meilisearchUrl,
         #[Autowire(env: 'MEILI_MASTER_KEY')]
         string $meiliMasterKey,

--- a/src/Service/Search/SearchResult.php
+++ b/src/Service/Search/SearchResult.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Search;
+
+/**
+ * A single search result returned by MeiliSearch.
+ *
+ * @see docs/features.md F18.2 — Global search results page
+ */
+final readonly class SearchResult
+{
+    public function __construct(
+        public string $type,
+        public string $title,
+        public string $excerpt,
+        public string $slug,
+        public ?string $secondaryInfo = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $hit
+     */
+    public static function fromHit(array $hit): self
+    {
+        $type = \is_string($hit['type'] ?? null) ? $hit['type'] : 'unknown';
+        /** @var array<string, mixed> $formatted */
+        $formatted = \is_array($hit['_formatted'] ?? null) ? $hit['_formatted'] : $hit;
+
+        return new self(
+            type: $type,
+            title: self::extractTitle($hit, $formatted),
+            excerpt: self::extractExcerpt($formatted, $type),
+            slug: self::extractSlug($hit, $type),
+            secondaryInfo: self::extractSecondaryInfo($hit, $type),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $hit
+     * @param array<string, mixed> $formatted
+     */
+    private static function extractTitle(array $hit, array $formatted): string
+    {
+        // Prefer highlighted title, fall back to raw
+        foreach (['name', 'title'] as $field) {
+            if (\is_string($formatted[$field] ?? null) && '' !== $formatted[$field]) {
+                return $formatted[$field];
+            }
+            if (\is_string($hit[$field] ?? null) && '' !== $hit[$field]) {
+                return $hit[$field];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $formatted
+     */
+    private static function extractExcerpt(array $formatted, string $type): string
+    {
+        $field = match ($type) {
+            'archetype' => 'description',
+            'page' => 'content',
+            'event' => 'description',
+            default => null,
+        };
+
+        if (null !== $field && \is_string($formatted[$field] ?? null)) {
+            $text = $formatted[$field];
+
+            // Truncate to ~200 chars while preserving <mark> tags
+            if (mb_strlen(strip_tags($text)) > 200) {
+                $text = mb_substr($text, 0, 200).'…';
+            }
+
+            return $text;
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $hit
+     */
+    private static function extractSlug(array $hit, string $type): string
+    {
+        return match ($type) {
+            'deck' => \is_string($hit['shortTag'] ?? null) ? $hit['shortTag'] : '',
+            'event' => \is_string($hit['id'] ?? null) ? $hit['id'] : (\is_int($hit['id'] ?? null) ? (string) $hit['id'] : ''),
+            default => \is_string($hit['slug'] ?? null) ? $hit['slug'] : '',
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $hit
+     */
+    private static function extractSecondaryInfo(array $hit, string $type): ?string
+    {
+        return match ($type) {
+            'event' => \is_string($hit['date'] ?? null) ? $hit['date'] : null,
+            'deck' => \is_string($hit['ownerName'] ?? null) ? $hit['ownerName'] : null,
+            default => null,
+        };
+    }
+}

--- a/src/Service/Search/SearchService.php
+++ b/src/Service/Search/SearchService.php
@@ -34,7 +34,7 @@ class SearchService
     private readonly Client $client;
 
     public function __construct(
-        #[Autowire(env: 'MEILISEARCH_URL')]
+        #[Autowire(env: 'MEILI_URL')]
         string $meilisearchUrl,
         #[Autowire(env: 'MEILI_MASTER_KEY')]
         string $meiliMasterKey,

--- a/src/Service/Search/SearchService.php
+++ b/src/Service/Search/SearchService.php
@@ -30,6 +30,7 @@ class SearchService
 {
     private const int QUICK_SEARCH_LIMIT = 3;
     private const int FULL_SEARCH_LIMIT = 20;
+    private const float RANKING_SCORE_THRESHOLD = 0.3;
 
     private readonly Client $client;
 
@@ -139,6 +140,7 @@ class SearchService
             'attributesToHighlight' => ['*'],
             'highlightPreTag' => '<mark>',
             'highlightPostTag' => '</mark>',
+            'rankingScoreThreshold' => self::RANKING_SCORE_THRESHOLD,
         ];
 
         // Translatable indexes support locale filtering

--- a/src/Service/Search/SearchService.php
+++ b/src/Service/Search/SearchService.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Search;
+
+use Meilisearch\Client;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Queries MeiliSearch indexes and returns typed search results.
+ *
+ * Supports both full search (all indexes, grouped by type) and quick
+ * search (limited results per type for navbar autocomplete).
+ *
+ * @see docs/features.md F18.2 — Global search results page
+ * @see docs/features.md F18.3 — Quick-search autocomplete (navbar)
+ */
+class SearchService
+{
+    private const int QUICK_SEARCH_LIMIT = 3;
+    private const int FULL_SEARCH_LIMIT = 20;
+
+    private readonly Client $client;
+
+    public function __construct(
+        #[Autowire(env: 'MEILISEARCH_URL')]
+        string $meilisearchUrl,
+        #[Autowire(env: 'MEILI_MASTER_KEY')]
+        string $meiliMasterKey,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->client = new Client($meilisearchUrl, $meiliMasterKey);
+    }
+
+    /**
+     * Search all indexes and return results grouped by content type.
+     *
+     * @return array{
+     *     archetypes: list<SearchResult>,
+     *     pages: list<SearchResult>,
+     *     events: list<SearchResult>,
+     *     decks: list<SearchResult>,
+     * }
+     */
+    public function searchAll(string $query, string $locale, ?string $typeFilter = null, int $limit = self::FULL_SEARCH_LIMIT, int $offset = 0): array
+    {
+        $results = [
+            'archetypes' => [],
+            'pages' => [],
+            'events' => [],
+            'decks' => [],
+        ];
+
+        if ('' === trim($query)) {
+            return $results;
+        }
+
+        $indexes = $this->getIndexesForType($typeFilter);
+
+        foreach ($indexes as $indexName) {
+            try {
+                $searchParams = $this->buildSearchParams($indexName, $locale, $limit, $offset);
+                $response = $this->client->index($indexName)->search($query, $searchParams);
+
+                $type = $this->indexToType($indexName);
+                /** @var array<string, mixed> $hit */
+                foreach ($response->getHits() as $hit) {
+                    $results[$type][] = SearchResult::fromHit($hit);
+                }
+            } catch (\Throwable $exception) {
+                $this->logger->warning('Search query failed on index {index}: {error}', [
+                    'index' => $indexName,
+                    'error' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        // @phpstan-ignore return.type
+        return $results;
+    }
+
+    /**
+     * Quick search for navbar autocomplete — max 3 results per type.
+     *
+     * @return array{
+     *     archetypes: list<SearchResult>,
+     *     pages: list<SearchResult>,
+     *     events: list<SearchResult>,
+     *     decks: list<SearchResult>,
+     * }
+     */
+    public function quickSearch(string $query, string $locale): array
+    {
+        return $this->searchAll($query, $locale, limit: self::QUICK_SEARCH_LIMIT);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getIndexesForType(?string $typeFilter): array
+    {
+        if (null !== $typeFilter) {
+            return match ($typeFilter) {
+                'archetypes' => [SearchIndexer::INDEX_ARCHETYPES],
+                'pages' => [SearchIndexer::INDEX_PAGES],
+                'events' => [SearchIndexer::INDEX_EVENTS],
+                'decks' => [SearchIndexer::INDEX_DECKS],
+                default => [],
+            };
+        }
+
+        return [
+            SearchIndexer::INDEX_ARCHETYPES,
+            SearchIndexer::INDEX_PAGES,
+            SearchIndexer::INDEX_EVENTS,
+            SearchIndexer::INDEX_DECKS,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildSearchParams(string $indexName, string $locale, int $limit, int $offset): array
+    {
+        $params = [
+            'limit' => $limit,
+            'offset' => $offset,
+            'attributesToHighlight' => ['*'],
+            'highlightPreTag' => '<mark>',
+            'highlightPostTag' => '</mark>',
+        ];
+
+        // Translatable indexes support locale filtering
+        if (\in_array($indexName, [SearchIndexer::INDEX_ARCHETYPES, SearchIndexer::INDEX_PAGES], true)) {
+            $params['filter'] = \sprintf("locale = '%s'", $locale);
+        }
+
+        return $params;
+    }
+
+    private function indexToType(string $indexName): string
+    {
+        return match ($indexName) {
+            SearchIndexer::INDEX_ARCHETYPES => 'archetypes',
+            SearchIndexer::INDEX_PAGES => 'pages',
+            SearchIndexer::INDEX_EVENTS => 'events',
+            SearchIndexer::INDEX_DECKS => 'decks',
+            default => 'unknown',
+        };
+    }
+}

--- a/src/Twig/Extension/SearchExtension.php
+++ b/src/Twig/Extension/SearchExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Twig\Extension;
+
+use App\Twig\Runtime\SearchRuntime;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @see docs/features.md F18.2 — Global search results page
+ */
+class SearchExtension extends AbstractExtension
+{
+    /**
+     * @return list<TwigFunction>
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('_search_result_url', [SearchRuntime::class, 'searchResultUrl']),
+        ];
+    }
+}

--- a/src/Twig/Runtime/SearchRuntime.php
+++ b/src/Twig/Runtime/SearchRuntime.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Twig\Runtime;
+
+use App\Service\Search\SearchResult;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Extension\RuntimeExtensionInterface;
+
+/**
+ * @see docs/features.md F18.2 — Global search results page
+ */
+class SearchRuntime implements RuntimeExtensionInterface
+{
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function searchResultUrl(SearchResult $result): string
+    {
+        $locale = $this->requestStack->getCurrentRequest()?->getLocale() ?? 'en';
+
+        return match ($result->type) {
+            'archetype' => $this->urlGenerator->generate('app_archetype_show', ['slug' => $result->slug, '_locale' => $locale]),
+            'page' => $this->urlGenerator->generate('app_page_show', ['slug' => $result->slug, '_locale' => $locale]),
+            'event' => $this->urlGenerator->generate('app_event_show', ['id' => $result->slug]),
+            'deck' => $this->urlGenerator->generate('app_deck_show', ['short_tag' => $result->slug]),
+            default => '/',
+        };
+    }
+}

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -4,6 +4,17 @@ logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/tmp/supervisord.pid
 
+[program:meilisearch]
+command=meilisearch --http-addr 127.0.0.1:7700 --env production --master-key %(ENV_MEILI_MASTER_KEY)s --db-path /var/lib/meilisearch/data
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=true
+priority=5
+stopsignal=TERM
+stopwaitsecs=10
+
 [program:frankenphp]
 command=frankenphp run --config /etc/frankenphp/Caddyfile
 stdout_logfile=/dev/stdout

--- a/symfony.lock
+++ b/symfony.lock
@@ -59,6 +59,18 @@
             ".php-cs-fixer.dist.php"
         ]
     },
+    "php-http/discovery": {
+        "version": "1.20",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.18",
+            "ref": "f45b5dd173a27873ab19f5e3180b2f661c21de02"
+        },
+        "files": [
+            "config/packages/http_discovery.yaml"
+        ]
+    },
     "phpstan/phpstan": {
         "version": "2.1",
         "recipe": {

--- a/templates/_partials/navbar_search.html.twig
+++ b/templates/_partials/navbar_search.html.twig
@@ -1,0 +1,9 @@
+<li class="nav-item d-flex align-items-center me-2">
+    <div id="navbar-search-root"
+         data-search-url="{{ path('app_search_api_quick') }}"
+         data-search-page-url="{{ path('app_search') }}"
+         data-label-placeholder="{{ 'app.search.navbar_placeholder'|trans }}"
+         data-label-see-all="{{ 'app.search.navbar_see_all'|trans }}"
+         data-label-no-results="{{ 'app.search.navbar_no_results'|trans }}">
+    </div>
+</li>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -91,6 +91,7 @@
                                     <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
                                 </li>
                             {% endif %}
+                            {% include '_partials/navbar_search.html.twig' %}
                             {% if channel.enableDecks %}
                                 <li class="nav-item d-flex align-items-center me-2">
                                     <div id="notification-bell-root"
@@ -185,6 +186,7 @@
                                     <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
                                 </li>
                             {% endif %}
+                            {% include '_partials/navbar_search.html.twig' %}
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('app_login', {'_target_path': app.request.pathInfo}) }}">{{ 'app.nav.login'|trans }}</a>
                             </li>
@@ -194,15 +196,6 @@
                                 </li>
                             {% endif %}
                         {% endif %}
-                        <li class="nav-item d-flex align-items-center me-2">
-                            <div id="navbar-search-root"
-                                 data-search-url="{{ path('app_search_api_quick') }}"
-                                 data-search-page-url="{{ path('app_search') }}"
-                                 data-label-placeholder="{{ 'app.search.navbar_placeholder'|trans }}"
-                                 data-label-see-all="{{ 'app.search.navbar_see_all'|trans }}"
-                                 data-label-no-results="{{ 'app.search.navbar_no_results'|trans }}">
-                            </div>
-                        </li>
                         {% if current_channel().locales|length > 1 %}
                             {% set currentLocale = app.request.locale %}
                             {% set alternateLocale = currentLocale == 'en' ? 'fr' : 'en' %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -91,6 +91,15 @@
                                     <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
                                 </li>
                             {% endif %}
+                            <li class="nav-item d-flex align-items-center me-2">
+                                <div id="navbar-search-root"
+                                     data-search-url="{{ path('app_search_api_quick') }}"
+                                     data-search-page-url="{{ path('app_search') }}"
+                                     data-label-placeholder="{{ 'app.search.navbar_placeholder'|trans }}"
+                                     data-label-see-all="{{ 'app.search.navbar_see_all'|trans }}"
+                                     data-label-no-results="{{ 'app.search.navbar_no_results'|trans }}">
+                                </div>
+                            </li>
                             {% if channel.enableDecks %}
                                 <li class="nav-item d-flex align-items-center me-2">
                                     <div id="notification-bell-root"
@@ -265,6 +274,8 @@
 
         {% block javascripts %}
             {{ encore_entry_script_tags('app') }}
+            {{ encore_entry_script_tags('navbar_search') }}
+            {{ encore_entry_link_tags('navbar_search') }}
             {% if app.user and channel is defined and channel.enableDecks %}
                 {{ encore_entry_script_tags('notification_bell') }}
                 {{ encore_entry_link_tags('notification_bell') }}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -91,15 +91,6 @@
                                     <a class="nav-link" href="{{ path('app_event_list') }}">{{ 'app.nav.events'|trans }}</a>
                                 </li>
                             {% endif %}
-                            <li class="nav-item d-flex align-items-center me-2">
-                                <div id="navbar-search-root"
-                                     data-search-url="{{ path('app_search_api_quick') }}"
-                                     data-search-page-url="{{ path('app_search') }}"
-                                     data-label-placeholder="{{ 'app.search.navbar_placeholder'|trans }}"
-                                     data-label-see-all="{{ 'app.search.navbar_see_all'|trans }}"
-                                     data-label-no-results="{{ 'app.search.navbar_no_results'|trans }}">
-                                </div>
-                            </li>
                             {% if channel.enableDecks %}
                                 <li class="nav-item d-flex align-items-center me-2">
                                     <div id="notification-bell-root"
@@ -203,6 +194,15 @@
                                 </li>
                             {% endif %}
                         {% endif %}
+                        <li class="nav-item d-flex align-items-center me-2">
+                            <div id="navbar-search-root"
+                                 data-search-url="{{ path('app_search_api_quick') }}"
+                                 data-search-page-url="{{ path('app_search') }}"
+                                 data-label-placeholder="{{ 'app.search.navbar_placeholder'|trans }}"
+                                 data-label-see-all="{{ 'app.search.navbar_see_all'|trans }}"
+                                 data-label-no-results="{{ 'app.search.navbar_no_results'|trans }}">
+                            </div>
+                        </li>
                         {% if current_channel().locales|length > 1 %}
                             {% set currentLocale = app.request.locale %}
                             {% set alternateLocale = currentLocale == 'en' ? 'fr' : 'en' %}

--- a/templates/search/results.html.twig
+++ b/templates/search/results.html.twig
@@ -1,0 +1,110 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}{% if query %}{{ 'app.search.results_title'|trans({'%query%': query}) }}{% else %}{{ 'app.search.title'|trans }}{% endif %} — {{ channel_param('brand_name', 'Expanded Decks') }}{% endblock %}
+
+{% block meta %}
+    <meta name="robots" content="noindex">
+{% endblock %}
+
+{% block body %}
+    <h1 class="mb-4">
+        {% if query %}
+            {{ 'app.search.results_title'|trans({'%query%': query}) }}
+            <small class="text-secondary fs-6">{{ 'app.search.result_count'|trans({'%count%': totalCount}) }}</small>
+        {% else %}
+            {{ 'app.search.title'|trans }}
+        {% endif %}
+    </h1>
+
+    <form method="get" action="{{ path('app_search') }}" class="mb-4">
+        <div class="input-group input-group-lg">
+            <input type="search" name="q" value="{{ query }}" class="form-control"
+                   placeholder="{{ 'app.search.placeholder'|trans }}" autofocus>
+            <button class="btn btn-gold" type="submit">
+                <i class="bi bi-search"></i> {{ 'app.search.button'|trans }}
+            </button>
+        </div>
+    </form>
+
+    {% if query %}
+        {% set types = {
+            'archetypes': {'label': 'app.search.type.archetypes'|trans, 'icon': 'bi-trophy'},
+            'pages': {'label': 'app.search.type.pages'|trans, 'icon': 'bi-file-text'},
+            'events': {'label': 'app.search.type.events'|trans, 'icon': 'bi-calendar-event'},
+            'decks': {'label': 'app.search.type.decks'|trans, 'icon': 'bi-collection'}
+        } %}
+
+        <ul class="nav nav-pills mb-4">
+            <li class="nav-item">
+                <a class="nav-link {{ typeFilter is null ? 'active' : '' }}" href="{{ path('app_search', {q: query}) }}">
+                    {{ 'app.search.type.all'|trans }}
+                    <span class="badge bg-secondary ms-1">{{ totalCount }}</span>
+                </a>
+            </li>
+            {% for typeKey, typeInfo in types %}
+                {% if results[typeKey] is not empty or typeFilter == typeKey %}
+                    <li class="nav-item">
+                        <a class="nav-link {{ typeFilter == typeKey ? 'active' : '' }}" href="{{ path('app_search', {q: query, type: typeKey}) }}">
+                            <i class="bi {{ typeInfo.icon }} me-1"></i>{{ typeInfo.label }}
+                            <span class="badge bg-secondary ms-1">{{ results[typeKey]|length }}</span>
+                        </a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+
+        {% if totalCount == 0 %}
+            <div class="alert alert-info">
+                <i class="bi bi-info-circle me-1"></i>
+                {{ 'app.search.no_results'|trans({'%query%': query}) }}
+            </div>
+        {% else %}
+            {% for typeKey, typeInfo in types %}
+                {% set typeResults = results[typeKey] %}
+                {% if typeResults is not empty and (typeFilter is null or typeFilter == typeKey) %}
+                    <div class="mb-4">
+                        <h2 class="h5 mb-3">
+                            <i class="bi {{ typeInfo.icon }} me-1"></i>{{ typeInfo.label }}
+                            <span class="badge bg-secondary">{{ typeResults|length }}</span>
+                        </h2>
+
+                        <div class="list-group">
+                            {% for result in typeResults %}
+                                {% set resultUrl = _search_result_url(result) %}
+                                <a href="{{ resultUrl }}" class="list-group-item list-group-item-action">
+                                    <div class="d-flex justify-content-between align-items-start">
+                                        <div>
+                                            <h6 class="mb-1">{{ result.title|raw }}</h6>
+                                            {% if result.excerpt %}
+                                                <p class="mb-1 text-secondary small">{{ result.excerpt|raw }}</p>
+                                            {% endif %}
+                                        </div>
+                                        {% if result.secondaryInfo %}
+                                            <small class="text-secondary ms-2 text-nowrap">{{ result.secondaryInfo }}</small>
+                                        {% endif %}
+                                    </div>
+                                </a>
+                            {% endfor %}
+                        </div>
+
+                        {% if typeFilter is null and typeResults|length >= 3 %}
+                            <div class="text-end mt-2">
+                                <a href="{{ path('app_search', {q: query, type: typeKey}) }}" class="text-decoration-none small">
+                                    {{ 'app.search.see_all_type'|trans({'%type%': typeInfo.label}) }} <i class="bi bi-arrow-right"></i>
+                                </a>
+                            </div>
+                        {% endif %}
+                    </div>
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/tests/Command/SearchReindexCommandTest.php
+++ b/tests/Command/SearchReindexCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Command;
+
+use App\Command\SearchReindexCommand;
+use App\Service\Search\SearchIndexer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+ */
+class SearchReindexCommandTest extends TestCase
+{
+    public function testReindexSucceedsWhenMeiliSearchIsHealthy(): void
+    {
+        $indexer = $this->createStub(SearchIndexer::class);
+        $indexer->method('isHealthy')->willReturn(true);
+        $indexer->method('reindexAll')->willReturn([
+            'archetypes' => 10,
+            'pages' => 4,
+            'events' => 6,
+            'decks' => 20,
+        ]);
+
+        $tester = $this->createCommandTester($indexer);
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('40 documents', $tester->getDisplay());
+        self::assertStringContainsString('4 indexes', $tester->getDisplay());
+    }
+
+    public function testReindexSkipsWhenMeiliSearchIsUnreachable(): void
+    {
+        $indexer = $this->createStub(SearchIndexer::class);
+        $indexer->method('isHealthy')->willReturn(false);
+
+        $tester = $this->createCommandTester($indexer);
+        $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('not reachable', $tester->getDisplay());
+    }
+
+    private function createCommandTester(SearchIndexer $indexer): CommandTester
+    {
+        return new CommandTester(new SearchReindexCommand($indexer));
+    }
+}

--- a/tests/Controller/HealthControllerTest.php
+++ b/tests/Controller/HealthControllerTest.php
@@ -17,6 +17,8 @@ use App\Controller\HealthController;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @see docs/features.md F14.4 — Health check endpoint
@@ -25,7 +27,7 @@ final class HealthControllerTest extends TestCase
 {
     public function testLivenessReturns200(): void
     {
-        $controller = new HealthController($this->createStub(Connection::class), new NullLogger(), 'test');
+        $controller = $this->createController();
 
         $response = $controller->liveness();
 
@@ -36,12 +38,12 @@ final class HealthControllerTest extends TestCase
         self::assertSame('test', $data['version']);
     }
 
-    public function testReadinessReturns200WhenDatabaseIsReachable(): void
+    public function testReadinessReturns200WhenAllServicesReachable(): void
     {
         $connection = $this->createStub(Connection::class);
         $connection->method('executeQuery')->willReturn($this->createStub(\Doctrine\DBAL\Result::class));
 
-        $controller = new HealthController($connection, new NullLogger(), 'test');
+        $controller = $this->createController($connection, $this->createHealthyMeilisearchClient());
         $response = $controller->readiness();
 
         self::assertSame(200, $response->getStatusCode());
@@ -51,6 +53,7 @@ final class HealthControllerTest extends TestCase
         self::assertSame('test', $data['version']);
         self::assertSame('ok', $data['checks']['database']['status']);
         self::assertArrayHasKey('latency_ms', $data['checks']['database']);
+        self::assertSame('ok', $data['checks']['meilisearch']['status']);
     }
 
     public function testReadinessReturns503WhenDatabaseIsUnreachable(): void
@@ -58,7 +61,7 @@ final class HealthControllerTest extends TestCase
         $connection = $this->createStub(Connection::class);
         $connection->method('executeQuery')->willThrowException(new \RuntimeException('Connection refused'));
 
-        $controller = new HealthController($connection, new NullLogger(), 'test');
+        $controller = $this->createController($connection, $this->createHealthyMeilisearchClient());
         $response = $controller->readiness();
 
         self::assertSame(503, $response->getStatusCode());
@@ -68,5 +71,49 @@ final class HealthControllerTest extends TestCase
         self::assertSame('test', $data['version']);
         self::assertSame('fail', $data['checks']['database']['status']);
         self::assertSame('Connection refused', $data['checks']['database']['error']);
+    }
+
+    public function testReadinessStillHealthyWhenMeilisearchIsUnreachable(): void
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('executeQuery')->willReturn($this->createStub(\Doctrine\DBAL\Result::class));
+
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('request')->willThrowException(new \RuntimeException('Connection refused'));
+
+        $controller = $this->createController($connection, $httpClient);
+        $response = $controller->readiness();
+
+        // MeiliSearch is non-critical: app stays healthy, but check reports fail
+        self::assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true);
+        self::assertSame('healthy', $data['status']);
+        self::assertSame('ok', $data['checks']['database']['status']);
+        self::assertSame('fail', $data['checks']['meilisearch']['status']);
+    }
+
+    private function createController(
+        ?Connection $connection = null,
+        ?HttpClientInterface $httpClient = null,
+    ): HealthController {
+        return new HealthController(
+            $connection ?? $this->createStub(Connection::class),
+            $httpClient ?? $this->createStub(HttpClientInterface::class),
+            new NullLogger(),
+            'test',
+            'http://127.0.0.1:7700',
+        );
+    }
+
+    private function createHealthyMeilisearchClient(): HttpClientInterface
+    {
+        $meiliResponse = $this->createStub(ResponseInterface::class);
+        $meiliResponse->method('toArray')->willReturn(['status' => 'available']);
+
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($meiliResponse);
+
+        return $httpClient;
     }
 }

--- a/tests/Service/Search/SearchIndexerTest.php
+++ b/tests/Service/Search/SearchIndexerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\Search;
+
+use App\Service\Search\SearchIndexer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+ */
+class SearchIndexerTest extends TestCase
+{
+    public function testStripMarkdownRemovesArchetypeTags(): void
+    {
+        $result = $this->invokeStripMarkdown('Check out [[archetype:kyurem]] for details.');
+
+        self::assertSame('Check out for details.', $result);
+    }
+
+    public function testStripMarkdownRemovesDeckTags(): void
+    {
+        $result = $this->invokeStripMarkdown('See [[deck:ABC123]] deck list.');
+
+        self::assertSame('See deck list.', $result);
+    }
+
+    public function testStripMarkdownRemovesCardTags(): void
+    {
+        $result = $this->invokeStripMarkdown('Uses [[card:swsh9/TG30]] effectively.');
+
+        self::assertSame('Uses effectively.', $result);
+    }
+
+    public function testStripMarkdownRemovesLinks(): void
+    {
+        $result = $this->invokeStripMarkdown('Visit [our site](https://example.com) for more.');
+
+        self::assertSame('Visit our site for more.', $result);
+    }
+
+    public function testStripMarkdownRemovesImages(): void
+    {
+        $result = $this->invokeStripMarkdown('Look at ![card image](https://example.com/image.png) here.');
+
+        self::assertSame('Look at here.', $result);
+    }
+
+    public function testStripMarkdownRemovesHeadings(): void
+    {
+        $result = $this->invokeStripMarkdown("## Strategy\nThe deck focuses on...");
+
+        self::assertSame('Strategy The deck focuses on...', $result);
+    }
+
+    public function testStripMarkdownRemovesBoldAndItalic(): void
+    {
+        $result = $this->invokeStripMarkdown('This is **bold** and *italic* and __underline__.');
+
+        self::assertSame('This is bold and italic and underline.', $result);
+    }
+
+    public function testStripMarkdownCollapsesWhitespace(): void
+    {
+        $result = $this->invokeStripMarkdown("Line one.\n\n\n  Line two.  \n\nLine three.");
+
+        self::assertSame('Line one. Line two. Line three.', $result);
+    }
+
+    public function testStripMarkdownHandlesEmptyString(): void
+    {
+        $result = $this->invokeStripMarkdown('');
+
+        self::assertSame('', $result);
+    }
+
+    public function testIndexConstants(): void
+    {
+        self::assertSame('archetypes', SearchIndexer::INDEX_ARCHETYPES);
+        self::assertSame('pages', SearchIndexer::INDEX_PAGES);
+        self::assertSame('events', SearchIndexer::INDEX_EVENTS);
+        self::assertSame('decks', SearchIndexer::INDEX_DECKS);
+    }
+
+    private function invokeStripMarkdown(string $markdown): string
+    {
+        $reflectionMethod = new \ReflectionMethod(SearchIndexer::class, 'stripMarkdown');
+
+        // Create a minimal instance — stripMarkdown is a pure function
+        $indexer = (new \ReflectionClass(SearchIndexer::class))->newInstanceWithoutConstructor();
+
+        /** @var string $result */
+        $result = $reflectionMethod->invoke($indexer, $markdown);
+
+        return $result;
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5138,6 +5138,81 @@
                 <target>Deck list variant for the %name% archetype</target>
                 <note>Description for hasPart variant entries in archetype JSON-LD</note>
             </trans-unit>
+            <trans-unit id="app.search.title">
+                <source>app.search.title</source>
+                <target>Search</target>
+                <note>Search page heading (no query)</note>
+            </trans-unit>
+            <trans-unit id="app.search.results_title">
+                <source>app.search.results_title</source>
+                <target>Search results for "%query%"</target>
+                <note>Search page heading with query</note>
+            </trans-unit>
+            <trans-unit id="app.search.result_count">
+                <source>app.search.result_count</source>
+                <target>%count% results</target>
+                <note>Result count badge</note>
+            </trans-unit>
+            <trans-unit id="app.search.placeholder">
+                <source>app.search.placeholder</source>
+                <target>Search decks, archetypes, events, pages…</target>
+                <note>Search input placeholder</note>
+            </trans-unit>
+            <trans-unit id="app.search.button">
+                <source>app.search.button</source>
+                <target>Search</target>
+                <note>Search submit button</note>
+            </trans-unit>
+            <trans-unit id="app.search.no_results">
+                <source>app.search.no_results</source>
+                <target>No results found for "%query%". Try a different search term.</target>
+                <note>Empty state message</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.all">
+                <source>app.search.type.all</source>
+                <target>All</target>
+                <note>Type filter tab: all types</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.archetypes">
+                <source>app.search.type.archetypes</source>
+                <target>Archetypes</target>
+                <note>Type filter tab</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.pages">
+                <source>app.search.type.pages</source>
+                <target>Pages</target>
+                <note>Type filter tab</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.events">
+                <source>app.search.type.events</source>
+                <target>Events</target>
+                <note>Type filter tab</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.decks">
+                <source>app.search.type.decks</source>
+                <target>Decks</target>
+                <note>Type filter tab</note>
+            </trans-unit>
+            <trans-unit id="app.search.see_all_type">
+                <source>app.search.see_all_type</source>
+                <target>See all %type%</target>
+                <note>Link to type-filtered search</note>
+            </trans-unit>
+            <trans-unit id="app.search.navbar_placeholder">
+                <source>app.search.navbar_placeholder</source>
+                <target>Search…</target>
+                <note>Navbar search input placeholder</note>
+            </trans-unit>
+            <trans-unit id="app.search.navbar_see_all">
+                <source>app.search.navbar_see_all</source>
+                <target>See all results</target>
+                <note>Navbar autocomplete: link to full results page</note>
+            </trans-unit>
+            <trans-unit id="app.search.navbar_no_results">
+                <source>app.search.navbar_no_results</source>
+                <target>No results</target>
+                <note>Navbar autocomplete: empty state</note>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -5101,6 +5101,81 @@
                 <target>Variante de deck pour l'archétype %name%</target>
                 <note>Description for hasPart variant entries in archetype JSON-LD</note>
             </trans-unit>
+            <trans-unit id="app.search.title">
+                <source>app.search.title</source>
+                <target>Recherche</target>
+                <note>Search page heading (no query)</note>
+            </trans-unit>
+            <trans-unit id="app.search.results_title">
+                <source>app.search.results_title</source>
+                <target>Résultats pour « %query% »</target>
+                <note>Search page heading with query</note>
+            </trans-unit>
+            <trans-unit id="app.search.result_count">
+                <source>app.search.result_count</source>
+                <target>%count% résultats</target>
+                <note>Result count badge</note>
+            </trans-unit>
+            <trans-unit id="app.search.placeholder">
+                <source>app.search.placeholder</source>
+                <target>Rechercher decks, archétypes, événements, pages…</target>
+                <note>Search input placeholder</note>
+            </trans-unit>
+            <trans-unit id="app.search.button">
+                <source>app.search.button</source>
+                <target>Rechercher</target>
+                <note>Search submit button</note>
+            </trans-unit>
+            <trans-unit id="app.search.no_results">
+                <source>app.search.no_results</source>
+                <target>Aucun résultat pour « %query% ». Essayez un autre terme de recherche.</target>
+                <note>Empty state message</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.all">
+                <source>app.search.type.all</source>
+                <target>Tout</target>
+                <note>Type filter tab: all types</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.archetypes">
+                <source>app.search.type.archetypes</source>
+                <target>Archétypes</target>
+                <note>Type filter tab</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.pages">
+                <source>app.search.type.pages</source>
+                <target>Pages</target>
+                <note>Type filter tab</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.events">
+                <source>app.search.type.events</source>
+                <target>Événements</target>
+                <note>Type filter tab</note>
+            </trans-unit>
+            <trans-unit id="app.search.type.decks">
+                <source>app.search.type.decks</source>
+                <target>Decks</target>
+                <note>Type filter tab</note>
+            </trans-unit>
+            <trans-unit id="app.search.see_all_type">
+                <source>app.search.see_all_type</source>
+                <target>Voir tous les %type%</target>
+                <note>Link to type-filtered search</note>
+            </trans-unit>
+            <trans-unit id="app.search.navbar_placeholder">
+                <source>app.search.navbar_placeholder</source>
+                <target>Rechercher…</target>
+                <note>Navbar search input placeholder</note>
+            </trans-unit>
+            <trans-unit id="app.search.navbar_see_all">
+                <source>app.search.navbar_see_all</source>
+                <target>Voir tous les résultats</target>
+                <note>Navbar autocomplete: link to full results page</note>
+            </trans-unit>
+            <trans-unit id="app.search.navbar_no_results">
+                <source>app.search.navbar_no_results</source>
+                <target>Aucun résultat</target>
+                <note>Navbar autocomplete: empty state</note>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,7 @@ Encore
     .addEntry('catalog_filters', './assets/catalog-filters.tsx')
     .addEntry('event_sync', './assets/event-sync.ts')
     .addEntry('notification_bell', './assets/notification-bell.tsx')
+    .addEntry('navbar_search', './assets/navbar-search.tsx')
     .addEntry('deck_version_compare', './assets/deck-version-compare.tsx')
     .addEntry('variant_compare', './assets/variant-compare.tsx')
     .addEntry('variant_compare_modal', './assets/variant-compare-modal.tsx')


### PR DESCRIPTION
## Summary

### F18.1 — MeiliSearch search engine
- **MeiliSearch sidecar** — Docker Compose service for local dev, production sidecar binary in container managed by Supervisor (priority 5)
- **Ephemeral index strategy** — entrypoint starts MeiliSearch, waits for health, runs `app:search:reindex`, hands off to Supervisor
- **SearchIndexer service** — manages 4 indexes (archetypes, pages, events, decks) with per-locale documents for translatable entities, Markdown/custom tag stripping
- **`app:search:reindex` command** — full rebuild, gracefully skips if unreachable
- **Doctrine entity listener** — `SearchIndexListener` keeps indexes in sync on create/update/delete (including translations), failures logged but never break the app
- **Health check** — `/health/ready` reports MeiliSearch as non-critical dependency

### F18.2 — Global search results page
- **SearchService** — queries MeiliSearch across all indexes with locale filtering, highlighted results
- **SearchResult DTO** — typed results with title, excerpt (highlighted), slug, secondary info
- **`GET /{_locale}/search?q=&type=`** — full-page results grouped by type with filter tabs, empty state
- **SearchExtension + SearchRuntime** — `_search_result_url()` Twig function for type-aware URLs
- **16 translation keys** (en + fr) for search UI

### F18.3 — Quick-search autocomplete (navbar)
- **`GET /api/search/quick?q=`** — JSON API returning max 3 results per type
- **NavbarSearch React island** — Mantine Combobox with debounced API calls (300ms), type-grouped dropdown with emoji badges, keyboard navigation, "See all results" link
- **Webpack entry** — `navbar_search`, loaded on all pages

### Infrastructure
- **Repository methods** — `findPublishedForSearch()` / `findPublicForSearch()` with eager-loaded translations
- **16 new tests** — SearchIndexer (Markdown stripping), SearchReindexCommand, HealthController (MeiliSearch check)
- **Docs** — MeiliSearch env vars in `docs/installation.md`

Closes #291
Closes #292
Closes #293

## Test plan
- [ ] `docker compose up -d` — verify MeiliSearch container starts at `localhost:7700/health`
- [ ] `make search.reindex` — verify indexes created with documents
- [ ] Visit `/{_locale}/search?q=regidrago` — verify grouped results page
- [ ] Visit `/{_locale}/search?q=regidrago&type=archetypes` — verify type filter
- [ ] Test the navbar search: type 2+ chars, verify dropdown with results
- [ ] Click a result in dropdown → navigates to detail page
- [ ] Click "See all results" → navigates to full search page
- [ ] Test empty state: search for gibberish, verify "No results" message
- [ ] Edit an archetype, verify search results update (Doctrine listener)
- [ ] `/health/ready` — verify MeiliSearch check in response
- [ ] Stop MeiliSearch, verify search degrades gracefully (empty results, no crash)
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)