### PR TITLE
:sparkles: Feature: index archetype variants with card names

### DIFF
--- a/assets/components/NavbarSearch.tsx
+++ b/assets/components/NavbarSearch.tsx
@@ -40,6 +40,7 @@ interface NavbarSearchProps {
 
 const TYPE_ICONS: Record<string, string> = {
     archetype: '\u2694\uFE0F',
+    variant: '\uD83C\uDCCF',
     page: '\uD83D\uDCC4',
     event: '\uD83D\uDCC5',
     deck: '\uD83C\uDCCF',

--- a/src/Controller/SearchApiController.php
+++ b/src/Controller/SearchApiController.php
@@ -76,6 +76,7 @@ class SearchApiController extends AbstractController
     ): string {
         return match ($result->type) {
             'archetype' => $urlGenerator->generate('app_archetype_show', ['slug' => $result->slug, '_locale' => $locale]),
+            'variant' => $urlGenerator->generate('app_archetype_show', ['slug' => $result->archetypeSlug ?? '', '_locale' => $locale]).'#'.$result->slug,
             'page' => $urlGenerator->generate('app_page_show', ['slug' => $result->slug, '_locale' => $locale]),
             'event' => $urlGenerator->generate('app_event_show', ['id' => $result->slug]),
             'deck' => $urlGenerator->generate('app_deck_show', ['short_tag' => $result->slug]),

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -36,7 +36,7 @@ class SearchController extends AbstractController
         $typeFilter = $request->query->getString('type') ?: null;
         $locale = $request->getLocale();
 
-        $validTypes = ['archetypes', 'pages', 'events', 'decks'];
+        $validTypes = ['archetypes', 'variants', 'pages', 'events', 'decks'];
         if (null !== $typeFilter && !\in_array($typeFilter, $validTypes, true)) {
             $typeFilter = null;
         }

--- a/src/EventListener/SearchIndexListener.php
+++ b/src/EventListener/SearchIndexListener.php
@@ -68,7 +68,11 @@ class SearchIndexListener
         } elseif ($entity instanceof Event) {
             $this->searchIndexer->removeEvent($entity);
         } elseif ($entity instanceof Deck) {
-            $this->searchIndexer->removeDeck($entity);
+            if (null === $entity->getOwner()) {
+                $this->searchIndexer->removeVariant($entity);
+            } else {
+                $this->searchIndexer->removeDeck($entity);
+            }
         }
     }
 
@@ -82,7 +86,11 @@ class SearchIndexListener
             } elseif ($entity instanceof Event) {
                 $this->searchIndexer->indexEvent($entity);
             } elseif ($entity instanceof Deck) {
-                $this->searchIndexer->indexDeck($entity);
+                if (null === $entity->getOwner()) {
+                    $this->searchIndexer->indexVariant($entity);
+                } else {
+                    $this->searchIndexer->indexDeck($entity);
+                }
             } elseif ($entity instanceof ArchetypeTranslation) {
                 $this->searchIndexer->indexArchetype($entity->getArchetype());
             } elseif ($entity instanceof PageTranslation) {

--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -373,6 +373,35 @@ class DeckRepository extends ServiceEntityRepository
     }
 
     /**
+     * Return all archetype variant decks (no owner) with cards eagerly loaded.
+     *
+     * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+     *
+     * @return list<Deck>
+     */
+    public function findVariantsForSearch(): array
+    {
+        /** @var list<Deck> $results */
+        $results = $this->createQueryBuilder('d')
+            ->addSelect('a', 'cv', 'c')
+            ->leftJoin('d.archetype', 'a')
+            ->leftJoin('d.currentVersion', 'cv')
+            ->leftJoin('cv.cards', 'c')
+            ->where('d.owner IS NULL')
+            ->andWhere('d.archetype IS NOT NULL')
+            ->andWhere('d.deletedAt IS NULL')
+            ->andWhere('a.isPublished = true')
+            ->andWhere('a.deletedAt IS NULL')
+            ->orderBy('a.name', 'ASC')
+            ->addOrderBy('d.canonical', 'DESC')
+            ->addOrderBy('d.position', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $results;
+    }
+
+    /**
      * Build a query for the public deck catalog with optional filters.
      *
      * When selfOwner is true the public-visibility constraint is dropped,

--- a/src/Service/Search/SearchIndexer.php
+++ b/src/Service/Search/SearchIndexer.php
@@ -38,6 +38,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 class SearchIndexer
 {
     public const string INDEX_ARCHETYPES = 'archetypes';
+    public const string INDEX_VARIANTS = 'variants';
     public const string INDEX_PAGES = 'pages';
     public const string INDEX_EVENTS = 'events';
     public const string INDEX_DECKS = 'decks';
@@ -63,13 +64,14 @@ class SearchIndexer
     /**
      * Delete all indexes and recreate them with correct settings and full data.
      *
-     * @return array{archetypes: int, pages: int, events: int, decks: int} Document counts per index
+     * @return array{archetypes: int, variants: int, pages: int, events: int, decks: int} Document counts per index
      */
     public function reindexAll(): array
     {
         $counts = [];
 
         $counts[self::INDEX_ARCHETYPES] = $this->reindexArchetypes();
+        $counts[self::INDEX_VARIANTS] = $this->reindexVariants();
         $counts[self::INDEX_PAGES] = $this->reindexPages();
         $counts[self::INDEX_EVENTS] = $this->reindexEvents();
         $counts[self::INDEX_DECKS] = $this->reindexDecks();
@@ -96,6 +98,34 @@ class SearchIndexer
             $ids[] = $archetype->getId().'_'.$locale;
         }
         $this->deleteDocumentsSafe(self::INDEX_ARCHETYPES, $ids);
+    }
+
+    /**
+     * Index a single archetype variant (deck with no owner).
+     * Includes all card names from the current version for card-based search.
+     */
+    public function indexVariant(Deck $variant): void
+    {
+        if (null !== $variant->getOwner() || $variant->getDeletedAt() instanceof \DateTimeImmutable) {
+            $this->removeVariant($variant);
+
+            return;
+        }
+
+        $archetype = $variant->getArchetype();
+        if (null === $archetype || !$archetype->isPublished()) {
+            $this->removeVariant($variant);
+
+            return;
+        }
+
+        $document = $this->mapVariant($variant);
+        $this->client->index(self::INDEX_VARIANTS)->addDocuments([$document]);
+    }
+
+    public function removeVariant(Deck $variant): void
+    {
+        $this->deleteDocumentsSafe(self::INDEX_VARIANTS, [$variant->getShortTag()]);
     }
 
     public function indexPage(Page $page): void
@@ -198,6 +228,39 @@ class SearchIndexer
         }
 
         $this->logger->info('Indexed {count} archetype documents.', ['count' => \count($documents)]);
+
+        return \count($documents);
+    }
+
+    private function reindexVariants(): int
+    {
+        $index = $this->client->index(self::INDEX_VARIANTS);
+
+        try {
+            $this->client->deleteIndex(self::INDEX_VARIANTS);
+        } catch (\Throwable) {
+            // Index may not exist yet
+        }
+
+        $this->client->createIndex(self::INDEX_VARIANTS, ['primaryKey' => 'id']);
+        $index->updateSettings([
+            'searchableAttributes' => ['name', 'archetypeName', 'cardNames'],
+            'filterableAttributes' => ['archetypeSlug'],
+            'displayedAttributes' => ['id', 'name', 'shortTag', 'archetypeName', 'archetypeSlug', 'type'],
+        ]);
+
+        $variants = $this->deckRepository->findVariantsForSearch();
+        $documents = [];
+
+        foreach ($variants as $variant) {
+            $documents[] = $this->mapVariant($variant);
+        }
+
+        if ([] !== $documents) {
+            $index->addDocuments($documents);
+        }
+
+        $this->logger->info('Indexed {count} variant documents.', ['count' => \count($documents)]);
 
         return \count($documents);
     }
@@ -387,6 +450,30 @@ class SearchIndexer
             'archetypeName' => $deck->getArchetype()?->getName() ?? '',
             'ownerName' => $deck->getOwner()?->getScreenName() ?? '',
             'format' => $deck->getFormat(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mapVariant(Deck $variant): array
+    {
+        $cardNames = [];
+        $currentVersion = $variant->getCurrentVersion();
+        if (null !== $currentVersion) {
+            foreach ($currentVersion->getCards() as $card) {
+                $cardNames[] = $card->getCardName();
+            }
+        }
+
+        return [
+            'id' => $variant->getShortTag(),
+            'type' => 'variant',
+            'name' => $variant->getName(),
+            'shortTag' => $variant->getShortTag(),
+            'archetypeName' => $variant->getArchetype()?->getName() ?? '',
+            'archetypeSlug' => $variant->getArchetype()?->getSlug() ?? '',
+            'cardNames' => implode(' ', array_unique($cardNames)),
         ];
     }
 

--- a/src/Service/Search/SearchResult.php
+++ b/src/Service/Search/SearchResult.php
@@ -26,6 +26,7 @@ final readonly class SearchResult
         public string $excerpt,
         public string $slug,
         public ?string $secondaryInfo = null,
+        public ?string $archetypeSlug = null,
     ) {
     }
 
@@ -44,6 +45,7 @@ final readonly class SearchResult
             excerpt: self::extractExcerpt($formatted, $type),
             slug: self::extractSlug($hit, $type),
             secondaryInfo: self::extractSecondaryInfo($hit, $type),
+            archetypeSlug: \is_string($hit['archetypeSlug'] ?? null) ? $hit['archetypeSlug'] : null,
         );
     }
 
@@ -98,7 +100,7 @@ final readonly class SearchResult
     private static function extractSlug(array $hit, string $type): string
     {
         return match ($type) {
-            'deck' => \is_string($hit['shortTag'] ?? null) ? $hit['shortTag'] : '',
+            'deck', 'variant' => \is_string($hit['shortTag'] ?? null) ? $hit['shortTag'] : '',
             'event' => \is_string($hit['id'] ?? null) ? $hit['id'] : (\is_int($hit['id'] ?? null) ? (string) $hit['id'] : ''),
             default => \is_string($hit['slug'] ?? null) ? $hit['slug'] : '',
         };
@@ -112,6 +114,7 @@ final readonly class SearchResult
         return match ($type) {
             'event' => \is_string($hit['date'] ?? null) ? $hit['date'] : null,
             'deck' => \is_string($hit['ownerName'] ?? null) ? $hit['ownerName'] : null,
+            'variant' => \is_string($hit['archetypeName'] ?? null) ? $hit['archetypeName'] : null,
             default => null,
         };
     }

--- a/src/Service/Search/SearchService.php
+++ b/src/Service/Search/SearchService.php
@@ -49,6 +49,7 @@ class SearchService
      *
      * @return array{
      *     archetypes: list<SearchResult>,
+     *     variants: list<SearchResult>,
      *     pages: list<SearchResult>,
      *     events: list<SearchResult>,
      *     decks: list<SearchResult>,
@@ -58,6 +59,7 @@ class SearchService
     {
         $results = [
             'archetypes' => [],
+            'variants' => [],
             'pages' => [],
             'events' => [],
             'decks' => [],
@@ -96,6 +98,7 @@ class SearchService
      *
      * @return array{
      *     archetypes: list<SearchResult>,
+     *     variants: list<SearchResult>,
      *     pages: list<SearchResult>,
      *     events: list<SearchResult>,
      *     decks: list<SearchResult>,
@@ -113,7 +116,8 @@ class SearchService
     {
         if (null !== $typeFilter) {
             return match ($typeFilter) {
-                'archetypes' => [SearchIndexer::INDEX_ARCHETYPES],
+                'archetypes' => [SearchIndexer::INDEX_ARCHETYPES, SearchIndexer::INDEX_VARIANTS],
+                'variants' => [SearchIndexer::INDEX_VARIANTS],
                 'pages' => [SearchIndexer::INDEX_PAGES],
                 'events' => [SearchIndexer::INDEX_EVENTS],
                 'decks' => [SearchIndexer::INDEX_DECKS],
@@ -123,6 +127,7 @@ class SearchService
 
         return [
             SearchIndexer::INDEX_ARCHETYPES,
+            SearchIndexer::INDEX_VARIANTS,
             SearchIndexer::INDEX_PAGES,
             SearchIndexer::INDEX_EVENTS,
             SearchIndexer::INDEX_DECKS,
@@ -155,6 +160,7 @@ class SearchService
     {
         return match ($indexName) {
             SearchIndexer::INDEX_ARCHETYPES => 'archetypes',
+            SearchIndexer::INDEX_VARIANTS => 'variants',
             SearchIndexer::INDEX_PAGES => 'pages',
             SearchIndexer::INDEX_EVENTS => 'events',
             SearchIndexer::INDEX_DECKS => 'decks',

--- a/src/Twig/Runtime/SearchRuntime.php
+++ b/src/Twig/Runtime/SearchRuntime.php
@@ -35,6 +35,7 @@ class SearchRuntime implements RuntimeExtensionInterface
 
         return match ($result->type) {
             'archetype' => $this->urlGenerator->generate('app_archetype_show', ['slug' => $result->slug, '_locale' => $locale]),
+            'variant' => $this->urlGenerator->generate('app_archetype_show', ['slug' => $result->archetypeSlug ?? '', '_locale' => $locale]).'#'.$result->slug,
             'page' => $this->urlGenerator->generate('app_page_show', ['slug' => $result->slug, '_locale' => $locale]),
             'event' => $this->urlGenerator->generate('app_event_show', ['id' => $result->slug]),
             'deck' => $this->urlGenerator->generate('app_deck_show', ['short_tag' => $result->slug]),

--- a/templates/search/results.html.twig
+++ b/templates/search/results.html.twig
@@ -37,6 +37,7 @@
     {% if query %}
         {% set types = {
             'archetypes': {'label': 'app.search.type.archetypes'|trans, 'icon': 'bi-trophy'},
+            'variants': {'label': 'app.search.type.variants'|trans, 'icon': 'bi-layers'},
             'pages': {'label': 'app.search.type.pages'|trans, 'icon': 'bi-file-text'},
             'events': {'label': 'app.search.type.events'|trans, 'icon': 'bi-calendar-event'},
             'decks': {'label': 'app.search.type.decks'|trans, 'icon': 'bi-collection'}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5188,6 +5188,11 @@
                 <target>Events</target>
                 <note>Type filter tab</note>
             </trans-unit>
+            <trans-unit id="app.search.type.variants">
+                <source>app.search.type.variants</source>
+                <target>Deck Lists</target>
+                <note>Type filter tab for archetype variants</note>
+            </trans-unit>
             <trans-unit id="app.search.type.decks">
                 <source>app.search.type.decks</source>
                 <target>Decks</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -5151,6 +5151,11 @@
                 <target>Événements</target>
                 <note>Type filter tab</note>
             </trans-unit>
+            <trans-unit id="app.search.type.variants">
+                <source>app.search.type.variants</source>
+                <target>Listes de deck</target>
+                <note>Type filter tab for archetype variants</note>
+            </trans-unit>
             <trans-unit id="app.search.type.decks">
                 <source>app.search.type.decks</source>
                 <target>Decks</target>


### PR DESCRIPTION
## Summary

Extends the MeiliSearch search engine (#469) with archetype variant indexing:

- **New `variants` index** — archetype variant decks (decks with no owner) are indexed separately, with variant name, parent archetype name/slug, and all card names from the current deck version as searchable text
- **Card-based search** — searching for a card name (e.g. "Regidrago VSTAR") finds the archetype variants that play that card
- **Variant results** link to the archetype page with `#{shortTag}` anchor, landing on the variant selector
- **SearchIndexListener** routes variant decks (owner IS NULL) to `indexVariant`/`removeVariant`
- **Deck Lists tab** in search results page and navbar autocomplete
- **`findVariantsForSearch()`** repository method with eager-loaded archetype, currentVersion, and cards

Index stats: 51 documents across 5 indexes (14 archetypes, 3 variants, 26 pages, 4 events, 4 decks).

## Test plan
- [ ] `make search.reindex` — verify `variants` index appears with documents
- [ ] Search for a card name (e.g. "Regidrago VSTAR") — verify variant results appear
- [ ] Click a variant result — verify navigation to archetype page with variant anchor
- [ ] Verify "Deck Lists" tab in search results page
- [ ] Edit a variant deck, verify search index updates via Doctrine listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)