### PR TITLE
:bug: Fix: channel-aware search results

### DIFF
--- a/src/Controller/SearchApiController.php
+++ b/src/Controller/SearchApiController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\Channel;
 use App\Service\Search\SearchService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -40,7 +41,10 @@ class SearchApiController extends AbstractController
             return new JsonResponse([]);
         }
 
-        $results = $searchService->quickSearch($query, $locale);
+        $channel = $request->attributes->get('_channel');
+        $enabledTypes = $channel instanceof Channel ? self::getEnabledTypes($channel) : null;
+
+        $results = $searchService->quickSearch($query, $locale, $enabledTypes);
 
         $groups = [];
 
@@ -82,5 +86,25 @@ class SearchApiController extends AbstractController
             'deck' => $urlGenerator->generate('app_deck_show', ['short_tag' => $result->slug]),
             default => '/',
         };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function getEnabledTypes(Channel $channel): array
+    {
+        $types = ['pages'];
+
+        if ($channel->getEnableArchetypes()) {
+            $types[] = 'archetypes';
+        }
+        if ($channel->getEnableDecks()) {
+            $types[] = 'decks';
+        }
+        if ($channel->getEnableEvents()) {
+            $types[] = 'events';
+        }
+
+        return $types;
     }
 }

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\Channel;
 use App\Service\Search\SearchService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -41,8 +42,12 @@ class SearchController extends AbstractController
             $typeFilter = null;
         }
 
-        $results = '' !== $query ? $searchService->searchAll($query, $locale, $typeFilter) : [
+        $channel = $request->attributes->get('_channel');
+        $enabledTypes = $channel instanceof Channel ? self::getEnabledTypes($channel) : null;
+
+        $results = '' !== $query ? $searchService->searchAll($query, $locale, $typeFilter, $enabledTypes) : [
             'archetypes' => [],
+            'variants' => [],
             'pages' => [],
             'events' => [],
             'decks' => [],
@@ -56,5 +61,27 @@ class SearchController extends AbstractController
             'results' => $results,
             'totalCount' => $totalCount,
         ]);
+    }
+
+    /**
+     * Build the list of content types enabled on the current channel.
+     *
+     * @return list<string>
+     */
+    private static function getEnabledTypes(Channel $channel): array
+    {
+        $types = ['pages']; // pages always enabled
+
+        if ($channel->getEnableArchetypes()) {
+            $types[] = 'archetypes';
+        }
+        if ($channel->getEnableDecks()) {
+            $types[] = 'decks';
+        }
+        if ($channel->getEnableEvents()) {
+            $types[] = 'events';
+        }
+
+        return $types;
     }
 }

--- a/src/Service/Search/SearchService.php
+++ b/src/Service/Search/SearchService.php
@@ -47,6 +47,9 @@ class SearchService
     /**
      * Search all indexes and return results grouped by content type.
      *
+     * @param list<string>|null $enabledTypes Content types enabled on the current channel (null = all).
+     *                                        Supported values: 'archetypes', 'variants', 'pages', 'events', 'decks'.
+     *
      * @return array{
      *     archetypes: list<SearchResult>,
      *     variants: list<SearchResult>,
@@ -55,7 +58,7 @@ class SearchService
      *     decks: list<SearchResult>,
      * }
      */
-    public function searchAll(string $query, string $locale, ?string $typeFilter = null, int $limit = self::FULL_SEARCH_LIMIT, int $offset = 0): array
+    public function searchAll(string $query, string $locale, ?string $typeFilter = null, ?array $enabledTypes = null, int $limit = self::FULL_SEARCH_LIMIT, int $offset = 0): array
     {
         $results = [
             'archetypes' => [],
@@ -69,7 +72,7 @@ class SearchService
             return $results;
         }
 
-        $indexes = $this->getIndexesForType($typeFilter);
+        $indexes = $this->getIndexesForType($typeFilter, $enabledTypes);
 
         foreach ($indexes as $indexName) {
             try {
@@ -96,6 +99,8 @@ class SearchService
     /**
      * Quick search for navbar autocomplete — max 3 results per type.
      *
+     * @param list<string>|null $enabledTypes content types enabled on the current channel (null = all)
+     *
      * @return array{
      *     archetypes: list<SearchResult>,
      *     variants: list<SearchResult>,
@@ -104,18 +109,20 @@ class SearchService
      *     decks: list<SearchResult>,
      * }
      */
-    public function quickSearch(string $query, string $locale): array
+    public function quickSearch(string $query, string $locale, ?array $enabledTypes = null): array
     {
-        return $this->searchAll($query, $locale, limit: self::QUICK_SEARCH_LIMIT);
+        return $this->searchAll($query, $locale, enabledTypes: $enabledTypes, limit: self::QUICK_SEARCH_LIMIT);
     }
 
     /**
+     * @param list<string>|null $enabledTypes
+     *
      * @return list<string>
      */
-    private function getIndexesForType(?string $typeFilter): array
+    private function getIndexesForType(?string $typeFilter, ?array $enabledTypes): array
     {
         if (null !== $typeFilter) {
-            return match ($typeFilter) {
+            $indexes = match ($typeFilter) {
                 'archetypes' => [SearchIndexer::INDEX_ARCHETYPES, SearchIndexer::INDEX_VARIANTS],
                 'variants' => [SearchIndexer::INDEX_VARIANTS],
                 'pages' => [SearchIndexer::INDEX_PAGES],
@@ -123,15 +130,33 @@ class SearchService
                 'decks' => [SearchIndexer::INDEX_DECKS],
                 default => [],
             };
+        } else {
+            $indexes = [
+                SearchIndexer::INDEX_ARCHETYPES,
+                SearchIndexer::INDEX_VARIANTS,
+                SearchIndexer::INDEX_PAGES,
+                SearchIndexer::INDEX_EVENTS,
+                SearchIndexer::INDEX_DECKS,
+            ];
         }
 
-        return [
-            SearchIndexer::INDEX_ARCHETYPES,
-            SearchIndexer::INDEX_VARIANTS,
-            SearchIndexer::INDEX_PAGES,
-            SearchIndexer::INDEX_EVENTS,
-            SearchIndexer::INDEX_DECKS,
+        if (null === $enabledTypes) {
+            return $indexes;
+        }
+
+        // Map index names to their parent type for channel filtering
+        $indexTypeMap = [
+            SearchIndexer::INDEX_ARCHETYPES => 'archetypes',
+            SearchIndexer::INDEX_VARIANTS => 'archetypes',
+            SearchIndexer::INDEX_PAGES => 'pages',
+            SearchIndexer::INDEX_EVENTS => 'events',
+            SearchIndexer::INDEX_DECKS => 'decks',
         ];
+
+        return array_values(array_filter(
+            $indexes,
+            static fn (string $index): bool => \in_array($indexTypeMap[$index], $enabledTypes, true),
+        ));
     }
 
     /**

--- a/templates/search/results.html.twig
+++ b/templates/search/results.html.twig
@@ -35,13 +35,27 @@
     </form>
 
     {% if query %}
-        {% set types = {
-            'archetypes': {'label': 'app.search.type.archetypes'|trans, 'icon': 'bi-trophy'},
-            'variants': {'label': 'app.search.type.variants'|trans, 'icon': 'bi-layers'},
-            'pages': {'label': 'app.search.type.pages'|trans, 'icon': 'bi-file-text'},
-            'events': {'label': 'app.search.type.events'|trans, 'icon': 'bi-calendar-event'},
-            'decks': {'label': 'app.search.type.decks'|trans, 'icon': 'bi-collection'}
-        } %}
+        {% set channel = current_channel() %}
+        {% set types = {} %}
+        {% if channel.enableArchetypes %}
+            {% set types = types|merge({
+                'archetypes': {'label': 'app.search.type.archetypes'|trans, 'icon': 'bi-trophy'},
+                'variants': {'label': 'app.search.type.variants'|trans, 'icon': 'bi-layers'}
+            }) %}
+        {% endif %}
+        {% set types = types|merge({
+            'pages': {'label': 'app.search.type.pages'|trans, 'icon': 'bi-file-text'}
+        }) %}
+        {% if channel.enableEvents %}
+            {% set types = types|merge({
+                'events': {'label': 'app.search.type.events'|trans, 'icon': 'bi-calendar-event'}
+            }) %}
+        {% endif %}
+        {% if channel.enableDecks %}
+            {% set types = types|merge({
+                'decks': {'label': 'app.search.type.decks'|trans, 'icon': 'bi-collection'}
+            }) %}
+        {% endif %}
 
         <ul class="nav nav-pills mb-4">
             <li class="nav-item">

--- a/tests/EventListener/SearchIndexListenerTest.php
+++ b/tests/EventListener/SearchIndexListenerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\EventListener;
+
+use App\Entity\Archetype;
+use App\Entity\ArchetypeTranslation;
+use App\Entity\Deck;
+use App\Entity\Event;
+use App\Entity\Page;
+use App\Entity\PageTranslation;
+use App\Entity\User;
+use App\EventListener\SearchIndexListener;
+use App\Service\Search\SearchIndexer;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+ */
+class SearchIndexListenerTest extends TestCase
+{
+    public function testPostPersistIndexesArchetype(): void
+    {
+        $archetype = new Archetype();
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('indexArchetype')->with($archetype);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postPersist($this->createPostPersistArgs($archetype));
+    }
+
+    public function testPostUpdateIndexesPage(): void
+    {
+        $page = new Page();
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('indexPage')->with($page);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postUpdate($this->createPostUpdateArgs($page));
+    }
+
+    public function testPostPersistIndexesEvent(): void
+    {
+        $event = new Event();
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('indexEvent')->with($event);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postPersist($this->createPostPersistArgs($event));
+    }
+
+    public function testPostPersistIndexesOwnedDeck(): void
+    {
+        $deck = new Deck();
+        $deck->setOwner(new User());
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('indexDeck')->with($deck);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postPersist($this->createPostPersistArgs($deck));
+    }
+
+    public function testPostPersistIndexesVariantDeck(): void
+    {
+        $deck = new Deck();
+        // No owner = variant
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('indexVariant')->with($deck);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postPersist($this->createPostPersistArgs($deck));
+    }
+
+    public function testPostPersistIndexesArchetypeTranslation(): void
+    {
+        $archetype = new Archetype();
+        $translation = new ArchetypeTranslation();
+        $translation->setArchetype($archetype);
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('indexArchetype')->with($archetype);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postPersist($this->createPostPersistArgs($translation));
+    }
+
+    public function testPostPersistIndexesPageTranslation(): void
+    {
+        $page = new Page();
+        $translation = new PageTranslation();
+        $translation->setPage($page);
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('indexPage')->with($page);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postPersist($this->createPostPersistArgs($translation));
+    }
+
+    public function testPostRemoveRemovesArchetype(): void
+    {
+        $archetype = new Archetype();
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('removeArchetype')->with($archetype);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postRemove($this->createPostRemoveArgs($archetype));
+    }
+
+    public function testPostRemoveRemovesVariantDeck(): void
+    {
+        $deck = new Deck();
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('removeVariant')->with($deck);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postRemove($this->createPostRemoveArgs($deck));
+    }
+
+    public function testPostRemoveRemovesOwnedDeck(): void
+    {
+        $deck = new Deck();
+        $deck->setOwner(new User());
+
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::once())->method('removeDeck')->with($deck);
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postRemove($this->createPostRemoveArgs($deck));
+    }
+
+    public function testIndexerFailureIsLoggedNotThrown(): void
+    {
+        $archetype = new Archetype();
+
+        $indexer = $this->createStub(SearchIndexer::class);
+        $indexer->method('indexArchetype')->willThrowException(new \RuntimeException('Connection refused'));
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+
+        // Should not throw
+        $listener->postPersist($this->createPostPersistArgs($archetype));
+        self::assertTrue(true);
+    }
+
+    public function testUnrelatedEntityIsIgnored(): void
+    {
+        $indexer = $this->createMock(SearchIndexer::class);
+        $indexer->expects(self::never())->method(self::anything());
+
+        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener->postPersist($this->createPostPersistArgs(new \stdClass()));
+    }
+
+    private function createPostPersistArgs(object $entity): PostPersistEventArgs
+    {
+        return new PostPersistEventArgs($entity, $this->createStub(EntityManagerInterface::class));
+    }
+
+    private function createPostUpdateArgs(object $entity): PostUpdateEventArgs
+    {
+        return new PostUpdateEventArgs($entity, $this->createStub(EntityManagerInterface::class));
+    }
+
+    private function createPostRemoveArgs(object $entity): PostRemoveEventArgs
+    {
+        return new PostRemoveEventArgs($entity, $this->createStub(EntityManagerInterface::class));
+    }
+}

--- a/tests/Functional/SearchApiControllerTest.php
+++ b/tests/Functional/SearchApiControllerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+/**
+ * @see docs/features.md F18.3 — Quick-search autocomplete (navbar)
+ */
+class SearchApiControllerTest extends AbstractFunctionalTest
+{
+    public function testQuickSearchReturnsJsonArray(): void
+    {
+        $this->client->request('GET', '/api/search/quick?q=test');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json');
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+    }
+
+    public function testQuickSearchRejectsShortQuery(): void
+    {
+        $this->client->request('GET', '/api/search/quick?q=a');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertSame([], $data);
+    }
+
+    public function testQuickSearchRejectsEmptyQuery(): void
+    {
+        $this->client->request('GET', '/api/search/quick?q=');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertSame([], $data);
+    }
+
+    public function testQuickSearchAccessibleAnonymously(): void
+    {
+        $this->client->request('GET', '/api/search/quick?q=regidrago');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testQuickSearchOnContentChannel(): void
+    {
+        $this->client->request('GET', '/api/search/quick?q=test', server: ['HTTP_HOST' => 'expandedtalks.wip']);
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json');
+    }
+}

--- a/tests/Functional/SearchControllerTest.php
+++ b/tests/Functional/SearchControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+/**
+ * @see docs/features.md F18.2 — Global search results page
+ */
+class SearchControllerTest extends AbstractFunctionalTest
+{
+    public function testSearchPageAccessibleAnonymously(): void
+    {
+        $this->client->request('GET', '/en/search');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('input[name="q"]');
+    }
+
+    public function testSearchPageWithQuery(): void
+    {
+        $this->client->request('GET', '/en/search?q=test');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'test');
+    }
+
+    public function testSearchPageWithEmptyQuery(): void
+    {
+        $this->client->request('GET', '/en/search?q=');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testSearchPageWithTypeFilter(): void
+    {
+        $this->client->request('GET', '/en/search?q=test&type=archetypes');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testSearchPageWithInvalidTypeFilterIgnored(): void
+    {
+        $this->client->request('GET', '/en/search?q=test&type=invalid');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testSearchPageHasNoIndexMeta(): void
+    {
+        $crawler = $this->client->request('GET', '/en/search?q=test');
+
+        self::assertResponseIsSuccessful();
+        $meta = $crawler->filter('meta[name="robots"]');
+        self::assertSame('noindex', $meta->attr('content'));
+    }
+
+    public function testSearchPageFrenchLocale(): void
+    {
+        $this->client->request('GET', '/fr/search?q=test');
+
+        self::assertResponseIsSuccessful();
+    }
+}

--- a/tests/Service/Search/SearchIndexerIntegrationTest.php
+++ b/tests/Service/Search/SearchIndexerIntegrationTest.php
@@ -1,0 +1,435 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\Search;
+
+use App\Entity\Archetype;
+use App\Entity\ArchetypeTranslation;
+use App\Entity\Deck;
+use App\Entity\Event;
+use App\Entity\Page;
+use App\Entity\PageTranslation;
+use App\Entity\User;
+use App\Enum\EventVisibility;
+use App\Repository\ArchetypeRepository;
+use App\Repository\DeckRepository;
+use App\Repository\EventRepository;
+use App\Repository\PageRepository;
+use App\Service\Search\SearchIndexer;
+use Meilisearch\Client;
+use Meilisearch\Endpoints\Indexes;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests SearchIndexer orchestration with a mocked MeiliSearch client.
+ *
+ * Verifies that the indexer creates indexes with correct settings,
+ * maps entities to documents, and calls addDocuments/deleteDocuments
+ * at the right times.
+ *
+ * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+ */
+class SearchIndexerIntegrationTest extends TestCase
+{
+    // ── reindexAll ──────────────────────────────────────────────────────
+
+    public function testReindexAllCreatesAllFiveIndexes(): void
+    {
+        $createdIndexes = [];
+
+        $client = $this->createMock(Client::class);
+        $client->method('deleteIndex'); // swallow
+        $client->expects(self::exactly(5))
+            ->method('createIndex')
+            ->willReturnCallback(static function (string $uid) use (&$createdIndexes): array {
+                $createdIndexes[] = $uid;
+
+                return ['taskUid' => 1];
+            });
+        $client->method('index')->willReturn($this->createStubIndex());
+
+        $indexer = $this->createIndexer($client);
+        $counts = $indexer->reindexAll();
+
+        self::assertSame(['archetypes', 'variants', 'pages', 'events', 'decks'], $createdIndexes);
+        self::assertArrayHasKey('archetypes', $counts);
+        self::assertArrayHasKey('variants', $counts);
+        self::assertArrayHasKey('pages', $counts);
+        self::assertArrayHasKey('events', $counts);
+        self::assertArrayHasKey('decks', $counts);
+    }
+
+    public function testReindexAllIndexesArchetypeDocuments(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setName('Regidrago');
+        $this->setProperty($archetype, 'slug', 'regidrago');
+        $this->setProperty($archetype, 'isPublished', true);
+
+        $translation = new ArchetypeTranslation();
+        $translation->setLocale('en');
+        $translation->setName('Regidrago');
+        $translation->setArchetype($archetype);
+        $archetype->addTranslation($translation);
+
+        $addedDocuments = [];
+        $index = $this->createStub(Indexes::class);
+        $index->method('updateSettings')->willReturn(['taskUid' => 1]);
+        $index->method('addDocuments')
+            ->willReturnCallback(static function (array $documents) use (&$addedDocuments): array {
+                $addedDocuments = array_merge($addedDocuments, $documents);
+
+                return ['taskUid' => 1];
+            });
+        $index->method('deleteDocuments')->willReturn(['taskUid' => 1]);
+
+        $client = $this->createStub(Client::class);
+        $client->method('deleteIndex')->willReturn(['taskUid' => 1]);
+        $client->method('createIndex')->willReturn(['taskUid' => 1]);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client, archetypes: [$archetype]);
+        $indexer->reindexAll();
+
+        // At least one archetype document should have been added
+        $archetypeDocs = array_filter($addedDocuments, static fn (array $document): bool => 'archetype' === ($document['type'] ?? null));
+        self::assertNotEmpty($archetypeDocs);
+    }
+
+    // ── indexArchetype ──────────────────────────────────────────────────
+
+    public function testIndexArchetypeAddsDocumentsWhenPublished(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setName('Regidrago');
+        $this->setProperty($archetype, 'id', 42);
+        $this->setProperty($archetype, 'slug', 'regidrago');
+        $this->setProperty($archetype, 'isPublished', true);
+
+        $translation = new ArchetypeTranslation();
+        $translation->setLocale('en');
+        $translation->setName('Regidrago');
+        $translation->setArchetype($archetype);
+        $archetype->addTranslation($translation);
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexArchetype($archetype);
+    }
+
+    public function testIndexArchetypeRemovesDocumentsWhenUnpublished(): void
+    {
+        $archetype = new Archetype();
+        $this->setProperty($archetype, 'id', 42);
+        $this->setProperty($archetype, 'isPublished', false);
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('deleteDocuments');
+        $index->expects(self::never())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexArchetype($archetype);
+    }
+
+    public function testIndexArchetypeRemovesDocumentsWhenDeleted(): void
+    {
+        $archetype = new Archetype();
+        $this->setProperty($archetype, 'id', 42);
+        $this->setProperty($archetype, 'isPublished', true);
+        $archetype->setDeletedAt(new \DateTimeImmutable());
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('deleteDocuments');
+        $index->expects(self::never())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexArchetype($archetype);
+    }
+
+    // ── indexPage ────────────────────────────────────────────────────────
+
+    public function testIndexPageAddsDocumentsWhenPublished(): void
+    {
+        $page = new Page();
+        $page->setSlug('welcome');
+        $this->setProperty($page, 'id', 10);
+        $this->setProperty($page, 'isPublished', true);
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Welcome');
+        $translation->setContent('Content');
+        $translation->setPage($page);
+        $page->addTranslation($translation);
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexPage($page);
+    }
+
+    public function testIndexPageRemovesWhenNoIndex(): void
+    {
+        $page = new Page();
+        $this->setProperty($page, 'id', 10);
+        $this->setProperty($page, 'isPublished', true);
+        $page->setNoIndex(true);
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('deleteDocuments');
+        $index->expects(self::never())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexPage($page);
+    }
+
+    // ── indexEvent ───────────────────────────────────────────────────────
+
+    public function testIndexEventAddsDocumentWhenPublic(): void
+    {
+        $event = new Event();
+        $event->setName('League');
+        $event->setDate(new \DateTimeImmutable());
+        $event->setOrganizer(new User());
+        $this->setProperty($event, 'id', 5);
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexEvent($event);
+    }
+
+    public function testIndexEventRemovesWhenPrivate(): void
+    {
+        $event = new Event();
+        $event->setVisibility(EventVisibility::Private);
+        $this->setProperty($event, 'id', 5);
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('deleteDocuments');
+        $index->expects(self::never())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexEvent($event);
+    }
+
+    // ── indexDeck ────────────────────────────────────────────────────────
+
+    public function testIndexDeckAddsDocumentWhenPublicAndOwned(): void
+    {
+        $deck = new Deck();
+        $deck->setName('My Deck');
+        $deck->setOwner(new User());
+        $this->setProperty($deck, 'public', true);
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexDeck($deck);
+    }
+
+    public function testIndexDeckRemovesWhenPrivate(): void
+    {
+        $deck = new Deck();
+        $deck->setOwner(new User());
+        $this->setProperty($deck, 'public', false);
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('deleteDocuments');
+        $index->expects(self::never())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexDeck($deck);
+    }
+
+    // ── indexVariant ────────────────────────────────────────────────────
+
+    public function testIndexVariantAddsDocumentWhenArchetypePublished(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setName('Regidrago');
+        $this->setProperty($archetype, 'slug', 'regidrago');
+        $this->setProperty($archetype, 'isPublished', true);
+
+        $variant = new Deck();
+        $variant->setName('Turbo Regidrago');
+        $variant->setArchetype($archetype);
+        // No owner = variant
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexVariant($variant);
+    }
+
+    public function testIndexVariantRemovesWhenArchetypeUnpublished(): void
+    {
+        $archetype = new Archetype();
+        $this->setProperty($archetype, 'isPublished', false);
+
+        $variant = new Deck();
+        $variant->setArchetype($archetype);
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('deleteDocuments');
+        $index->expects(self::never())->method('addDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexVariant($variant);
+    }
+
+    public function testIndexVariantRemovesWhenHasOwner(): void
+    {
+        $variant = new Deck();
+        $variant->setOwner(new User());
+
+        $index = $this->createMock(Indexes::class);
+        $index->expects(self::once())->method('deleteDocuments');
+
+        $client = $this->createStub(Client::class);
+        $client->method('index')->willReturn($index);
+
+        $indexer = $this->createIndexer($client);
+        $indexer->indexVariant($variant);
+    }
+
+    // ── isHealthy ───────────────────────────────────────────────────────
+
+    public function testIsHealthyReturnsTrueWhenAvailable(): void
+    {
+        $client = $this->createStub(Client::class);
+        $client->method('health')->willReturn(['status' => 'available']);
+
+        $indexer = $this->createIndexer($client);
+
+        self::assertTrue($indexer->isHealthy());
+    }
+
+    public function testIsHealthyReturnsFalseWhenUnreachable(): void
+    {
+        $client = $this->createStub(Client::class);
+        $client->method('health')->willThrowException(new \RuntimeException('Connection refused'));
+
+        $indexer = $this->createIndexer($client);
+
+        self::assertFalse($indexer->isHealthy());
+    }
+
+    public function testIsHealthyReturnsFalseWhenStatusNotAvailable(): void
+    {
+        $client = $this->createStub(Client::class);
+        $client->method('health')->willReturn(['status' => 'maintenance']);
+
+        $indexer = $this->createIndexer($client);
+
+        self::assertFalse($indexer->isHealthy());
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * @param list<Archetype> $archetypes
+     * @param list<Page>      $pages
+     * @param list<Event>     $events
+     * @param list<Deck>      $decks
+     * @param list<Deck>      $variants
+     */
+    private function createIndexer(
+        Client $client,
+        array $archetypes = [],
+        array $pages = [],
+        array $events = [],
+        array $decks = [],
+        array $variants = [],
+    ): SearchIndexer {
+        $archetypeRepository = $this->createStub(ArchetypeRepository::class);
+        $archetypeRepository->method('findPublishedForSearch')->willReturn($archetypes);
+
+        $pageRepository = $this->createStub(PageRepository::class);
+        $pageRepository->method('findPublishedForSearch')->willReturn($pages);
+
+        $eventRepository = $this->createStub(EventRepository::class);
+        $eventRepository->method('findPublicForSearch')->willReturn($events);
+
+        $deckRepository = $this->createStub(DeckRepository::class);
+        $deckRepository->method('findPublicForSearch')->willReturn($decks);
+        $deckRepository->method('findVariantsForSearch')->willReturn($variants);
+
+        $indexer = (new \ReflectionClass(SearchIndexer::class))->newInstanceWithoutConstructor();
+
+        $this->setProperty($indexer, 'client', $client);
+        $this->setProperty($indexer, 'archetypeRepository', $archetypeRepository);
+        $this->setProperty($indexer, 'pageRepository', $pageRepository);
+        $this->setProperty($indexer, 'eventRepository', $eventRepository);
+        $this->setProperty($indexer, 'deckRepository', $deckRepository);
+        $this->setProperty($indexer, 'logger', new NullLogger());
+
+        return $indexer;
+    }
+
+    private function createStubIndex(): Indexes
+    {
+        $index = $this->createStub(Indexes::class);
+        $index->method('updateSettings')->willReturn(['taskUid' => 1]);
+        $index->method('addDocuments')->willReturn(['taskUid' => 1]);
+        $index->method('deleteDocuments')->willReturn(['taskUid' => 1]);
+
+        return $index;
+    }
+
+    private function setProperty(object $entity, string $property, mixed $value): void
+    {
+        $reflectionProperty = new \ReflectionProperty($entity, $property);
+        $reflectionProperty->setValue($entity, $value);
+    }
+}

--- a/tests/Service/Search/SearchIndexerTest.php
+++ b/tests/Service/Search/SearchIndexerTest.php
@@ -13,6 +13,15 @@ declare(strict_types=1);
 
 namespace App\Tests\Service\Search;
 
+use App\Entity\Archetype;
+use App\Entity\ArchetypeTranslation;
+use App\Entity\Deck;
+use App\Entity\DeckCard;
+use App\Entity\DeckVersion;
+use App\Entity\Event;
+use App\Entity\Page;
+use App\Entity\PageTranslation;
+use App\Entity\User;
 use App\Service\Search\SearchIndexer;
 use PHPUnit\Framework\TestCase;
 
@@ -87,9 +96,155 @@ class SearchIndexerTest extends TestCase
     public function testIndexConstants(): void
     {
         self::assertSame('archetypes', SearchIndexer::INDEX_ARCHETYPES);
+        self::assertSame('variants', SearchIndexer::INDEX_VARIANTS);
         self::assertSame('pages', SearchIndexer::INDEX_PAGES);
         self::assertSame('events', SearchIndexer::INDEX_EVENTS);
         self::assertSame('decks', SearchIndexer::INDEX_DECKS);
+    }
+
+    // ── Mapper tests (via reflection) ──────────────────────────────────
+
+    public function testMapArchetypeProducesDocumentsPerLocale(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setName('Regidrago');
+        $this->setProperty($archetype, 'slug', 'regidrago');
+
+        $translationEn = new ArchetypeTranslation();
+        $translationEn->setLocale('en');
+        $translationEn->setName('Regidrago');
+        $translationEn->setDescription('A **dragon** archetype.');
+        $translationEn->setArchetype($archetype);
+        $archetype->addTranslation($translationEn);
+
+        $translationFr = new ArchetypeTranslation();
+        $translationFr->setLocale('fr');
+        $translationFr->setName('Regidrago');
+        $translationFr->setDescription('Un archétype **dragon**.');
+        $translationFr->setArchetype($archetype);
+        $archetype->addTranslation($translationFr);
+
+        /** @var list<array<string, mixed>> $documents */
+        $documents = $this->invokeMapper('mapArchetype', $archetype);
+
+        self::assertCount(2, $documents);
+        self::assertSame('archetype', $documents[0]['type']);
+        self::assertSame('regidrago', $documents[0]['slug']);
+        self::assertSame('en', $documents[0]['locale']);
+        self::assertSame('fr', $documents[1]['locale']);
+        // Bold markers should be stripped
+        self::assertStringNotContainsString('**', $documents[0]['description']);
+    }
+
+    public function testMapPageProducesDocumentsPerLocale(): void
+    {
+        $page = new Page();
+        $page->setSlug('welcome');
+
+        $translationEn = new PageTranslation();
+        $translationEn->setLocale('en');
+        $translationEn->setTitle('Welcome');
+        $translationEn->setContent('Welcome to the site.');
+        $translationEn->setPage($page);
+        $page->addTranslation($translationEn);
+
+        /** @var list<array<string, mixed>> $documents */
+        $documents = $this->invokeMapper('mapPage', $page);
+
+        self::assertGreaterThanOrEqual(1, \count($documents));
+        self::assertSame('page', $documents[0]['type']);
+        self::assertSame('welcome', $documents[0]['slug']);
+        self::assertSame('Welcome', $documents[0]['title']);
+    }
+
+    public function testMapEventProducesSingleDocument(): void
+    {
+        $event = new Event();
+        $event->setName('Paris League');
+        $event->setDate(new \DateTimeImmutable('2026-05-01'));
+        $event->setLocation('Paris');
+        $event->setDescription('Monthly **league** event.');
+        $event->setOrganizer(new User());
+
+        /** @var array<string, mixed> $document */
+        $document = $this->invokeMapper('mapEvent', $event);
+
+        self::assertSame('event', $document['type']);
+        self::assertSame('Paris League', $document['name']);
+        self::assertSame('2026-05-01', $document['date']);
+        self::assertSame('Paris', $document['location']);
+        self::assertStringNotContainsString('**', $document['description']);
+    }
+
+    public function testMapDeckProducesSingleDocument(): void
+    {
+        $deck = new Deck();
+        $deck->setName('My Regidrago');
+
+        $archetype = new Archetype();
+        $archetype->setName('Regidrago');
+        $deck->setArchetype($archetype);
+
+        $owner = new User();
+        $owner->setScreenName('Julien');
+        $deck->setOwner($owner);
+
+        /** @var array<string, mixed> $document */
+        $document = $this->invokeMapper('mapDeck', $deck);
+
+        self::assertSame('deck', $document['type']);
+        self::assertSame('My Regidrago', $document['name']);
+        self::assertSame('Regidrago', $document['archetypeName']);
+        self::assertSame('Julien', $document['ownerName']);
+    }
+
+    public function testMapVariantIncludesCardNames(): void
+    {
+        $variant = new Deck();
+        $variant->setName('Turbo Regidrago');
+
+        $archetype = new Archetype();
+        $archetype->setName('Regidrago');
+        $this->setProperty($archetype, 'slug', 'regidrago');
+        $variant->setArchetype($archetype);
+
+        $version = new DeckVersion();
+        $card1 = new DeckCard();
+        $card1->setCardName('Regidrago VSTAR');
+        $card1->setQuantity(2);
+        $version->addCard($card1);
+
+        $card2 = new DeckCard();
+        $card2->setCardName('Dragonite V');
+        $card2->setQuantity(1);
+        $version->addCard($card2);
+
+        $variant->setCurrentVersion($version);
+
+        /** @var array<string, mixed> $document */
+        $document = $this->invokeMapper('mapVariant', $variant);
+
+        self::assertSame('variant', $document['type']);
+        self::assertSame('Turbo Regidrago', $document['name']);
+        self::assertSame('regidrago', $document['archetypeSlug']);
+        self::assertStringContainsString('Regidrago VSTAR', $document['cardNames']);
+        self::assertStringContainsString('Dragonite V', $document['cardNames']);
+    }
+
+    public function testMapVariantWithNoVersionHasEmptyCardNames(): void
+    {
+        $variant = new Deck();
+        $variant->setName('Empty Variant');
+
+        $archetype = new Archetype();
+        $archetype->setName('Test');
+        $this->setProperty($archetype, 'slug', 'test');
+        $variant->setArchetype($archetype);
+
+        /** @var array<string, mixed> $document */
+        $document = $this->invokeMapper('mapVariant', $variant);
+
+        self::assertSame('', $document['cardNames']);
     }
 
     private function invokeStripMarkdown(string $markdown): string
@@ -103,5 +258,19 @@ class SearchIndexerTest extends TestCase
         $result = $reflectionMethod->invoke($indexer, $markdown);
 
         return $result;
+    }
+
+    private function invokeMapper(string $methodName, object $entity): mixed
+    {
+        $method = new \ReflectionMethod(SearchIndexer::class, $methodName);
+        $indexer = (new \ReflectionClass(SearchIndexer::class))->newInstanceWithoutConstructor();
+
+        return $method->invoke($indexer, $entity);
+    }
+
+    private function setProperty(object $entity, string $property, mixed $value): void
+    {
+        $reflectionProperty = new \ReflectionProperty($entity, $property);
+        $reflectionProperty->setValue($entity, $value);
     }
 }

--- a/tests/Service/Search/SearchResultTest.php
+++ b/tests/Service/Search/SearchResultTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\Search;
+
+use App\Service\Search\SearchResult;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F18.2 — Global search results page
+ */
+class SearchResultTest extends TestCase
+{
+    public function testFromHitArchetype(): void
+    {
+        $hit = [
+            'id' => '42_en',
+            'type' => 'archetype',
+            'name' => 'Regidrago',
+            'slug' => 'regidrago',
+            'description' => 'A powerful dragon archetype.',
+            '_formatted' => [
+                'name' => '<mark>Regidrago</mark>',
+                'description' => 'A powerful <mark>dragon</mark> archetype.',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertSame('archetype', $result->type);
+        self::assertSame('<mark>Regidrago</mark>', $result->title);
+        self::assertSame('A powerful <mark>dragon</mark> archetype.', $result->excerpt);
+        self::assertSame('regidrago', $result->slug);
+        self::assertNull($result->secondaryInfo);
+        self::assertNull($result->archetypeSlug);
+    }
+
+    public function testFromHitPage(): void
+    {
+        $hit = [
+            'type' => 'page',
+            'title' => 'Welcome',
+            'slug' => 'welcome',
+            'content' => 'Welcome to the site.',
+            '_formatted' => [
+                'title' => '<mark>Welcome</mark>',
+                'content' => '<mark>Welcome</mark> to the site.',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertSame('page', $result->type);
+        self::assertSame('<mark>Welcome</mark>', $result->title);
+        self::assertStringContainsString('Welcome', $result->excerpt);
+        self::assertSame('welcome', $result->slug);
+    }
+
+    public function testFromHitEvent(): void
+    {
+        $hit = [
+            'id' => '7',
+            'type' => 'event',
+            'name' => 'Paris League',
+            'description' => 'Monthly league event.',
+            'date' => '2026-05-01',
+            '_formatted' => [
+                'name' => '<mark>Paris</mark> League',
+                'description' => 'Monthly league event.',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertSame('event', $result->type);
+        self::assertSame('<mark>Paris</mark> League', $result->title);
+        self::assertSame('7', $result->slug);
+        self::assertSame('2026-05-01', $result->secondaryInfo);
+    }
+
+    public function testFromHitDeck(): void
+    {
+        $hit = [
+            'id' => 'ABC123',
+            'type' => 'deck',
+            'name' => 'My Regidrago',
+            'shortTag' => 'ABC123',
+            'ownerName' => 'Julien',
+            '_formatted' => [
+                'name' => 'My <mark>Regidrago</mark>',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertSame('deck', $result->type);
+        self::assertSame('My <mark>Regidrago</mark>', $result->title);
+        self::assertSame('ABC123', $result->slug);
+        self::assertSame('Julien', $result->secondaryInfo);
+    }
+
+    public function testFromHitVariant(): void
+    {
+        $hit = [
+            'id' => 'XYZ789',
+            'type' => 'variant',
+            'name' => 'Turbo Regidrago',
+            'shortTag' => 'XYZ789',
+            'archetypeName' => 'Regidrago',
+            'archetypeSlug' => 'regidrago',
+            '_formatted' => [
+                'name' => 'Turbo <mark>Regidrago</mark>',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertSame('variant', $result->type);
+        self::assertSame('Turbo <mark>Regidrago</mark>', $result->title);
+        self::assertSame('XYZ789', $result->slug);
+        self::assertSame('Regidrago', $result->secondaryInfo);
+        self::assertSame('regidrago', $result->archetypeSlug);
+    }
+
+    public function testFromHitEventWithNumericId(): void
+    {
+        $hit = [
+            'id' => 42,
+            'type' => 'event',
+            'name' => 'Test Event',
+            '_formatted' => ['name' => 'Test Event'],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertSame('42', $result->slug);
+    }
+
+    public function testFromHitWithMissingFields(): void
+    {
+        $hit = [
+            'type' => 'archetype',
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertSame('archetype', $result->type);
+        self::assertSame('', $result->title);
+        self::assertSame('', $result->excerpt);
+        self::assertSame('', $result->slug);
+    }
+
+    public function testFromHitWithMissingType(): void
+    {
+        $hit = [
+            'name' => 'Something',
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertSame('unknown', $result->type);
+    }
+
+    public function testExcerptTruncatesLongContent(): void
+    {
+        $longText = str_repeat('word ', 100);
+        $hit = [
+            'type' => 'page',
+            'title' => 'Long Page',
+            'slug' => 'long',
+            'content' => $longText,
+            '_formatted' => [
+                'title' => 'Long Page',
+                'content' => $longText,
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertStringEndsWith('…', $result->excerpt);
+        self::assertLessThanOrEqual(210, mb_strlen($result->excerpt));
+    }
+}

--- a/tests/Service/Search/SearchServiceTest.php
+++ b/tests/Service/Search/SearchServiceTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\Search;
+
+use App\Service\Search\SearchIndexer;
+use App\Service\Search\SearchService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F18.2 — Global search results page
+ */
+class SearchServiceTest extends TestCase
+{
+    // ── getIndexesForType (via reflection) ──────────────────────────────
+
+    public function testGetIndexesForTypeReturnsAllWhenNoFilter(): void
+    {
+        $indexes = $this->invokeGetIndexesForType(null, null);
+
+        self::assertCount(5, $indexes);
+        self::assertContains(SearchIndexer::INDEX_ARCHETYPES, $indexes);
+        self::assertContains(SearchIndexer::INDEX_VARIANTS, $indexes);
+        self::assertContains(SearchIndexer::INDEX_PAGES, $indexes);
+        self::assertContains(SearchIndexer::INDEX_EVENTS, $indexes);
+        self::assertContains(SearchIndexer::INDEX_DECKS, $indexes);
+    }
+
+    public function testGetIndexesForTypeFiltersArchetypes(): void
+    {
+        $indexes = $this->invokeGetIndexesForType('archetypes', null);
+
+        self::assertCount(2, $indexes);
+        self::assertContains(SearchIndexer::INDEX_ARCHETYPES, $indexes);
+        self::assertContains(SearchIndexer::INDEX_VARIANTS, $indexes);
+    }
+
+    public function testGetIndexesForTypeFiltersVariants(): void
+    {
+        $indexes = $this->invokeGetIndexesForType('variants', null);
+
+        self::assertCount(1, $indexes);
+        self::assertContains(SearchIndexer::INDEX_VARIANTS, $indexes);
+    }
+
+    public function testGetIndexesForTypeFiltersPages(): void
+    {
+        $indexes = $this->invokeGetIndexesForType('pages', null);
+
+        self::assertSame([SearchIndexer::INDEX_PAGES], $indexes);
+    }
+
+    public function testGetIndexesForTypeFiltersEvents(): void
+    {
+        $indexes = $this->invokeGetIndexesForType('events', null);
+
+        self::assertSame([SearchIndexer::INDEX_EVENTS], $indexes);
+    }
+
+    public function testGetIndexesForTypeFiltersDecks(): void
+    {
+        $indexes = $this->invokeGetIndexesForType('decks', null);
+
+        self::assertSame([SearchIndexer::INDEX_DECKS], $indexes);
+    }
+
+    public function testGetIndexesForTypeReturnsEmptyForUnknownFilter(): void
+    {
+        $indexes = $this->invokeGetIndexesForType('unknown', null);
+
+        self::assertSame([], $indexes);
+    }
+
+    // ── Channel-aware filtering ────────────────────────────────────────
+
+    public function testEnabledTypesFiltersOutArchetypes(): void
+    {
+        $indexes = $this->invokeGetIndexesForType(null, ['pages', 'decks', 'events']);
+
+        self::assertNotContains(SearchIndexer::INDEX_ARCHETYPES, $indexes);
+        self::assertNotContains(SearchIndexer::INDEX_VARIANTS, $indexes);
+        self::assertContains(SearchIndexer::INDEX_PAGES, $indexes);
+        self::assertContains(SearchIndexer::INDEX_EVENTS, $indexes);
+        self::assertContains(SearchIndexer::INDEX_DECKS, $indexes);
+    }
+
+    public function testEnabledTypesFiltersOutDecksAndEvents(): void
+    {
+        $indexes = $this->invokeGetIndexesForType(null, ['pages', 'archetypes']);
+
+        self::assertContains(SearchIndexer::INDEX_ARCHETYPES, $indexes);
+        self::assertContains(SearchIndexer::INDEX_VARIANTS, $indexes);
+        self::assertContains(SearchIndexer::INDEX_PAGES, $indexes);
+        self::assertNotContains(SearchIndexer::INDEX_EVENTS, $indexes);
+        self::assertNotContains(SearchIndexer::INDEX_DECKS, $indexes);
+    }
+
+    public function testEnabledTypesOnlyPages(): void
+    {
+        $indexes = $this->invokeGetIndexesForType(null, ['pages']);
+
+        self::assertSame([SearchIndexer::INDEX_PAGES], $indexes);
+    }
+
+    public function testEnabledTypesWithTypeFilterCombined(): void
+    {
+        // Type filter asks for archetypes, but channel only has pages
+        $indexes = $this->invokeGetIndexesForType('archetypes', ['pages']);
+
+        self::assertSame([], $indexes);
+    }
+
+    public function testNullEnabledTypesReturnsAll(): void
+    {
+        $indexes = $this->invokeGetIndexesForType(null, null);
+
+        self::assertCount(5, $indexes);
+    }
+
+    // ── indexToType ────────────────────────────────────────────────────
+
+    public function testIndexToTypeMapping(): void
+    {
+        self::assertSame('archetypes', $this->invokeIndexToType(SearchIndexer::INDEX_ARCHETYPES));
+        self::assertSame('variants', $this->invokeIndexToType(SearchIndexer::INDEX_VARIANTS));
+        self::assertSame('pages', $this->invokeIndexToType(SearchIndexer::INDEX_PAGES));
+        self::assertSame('events', $this->invokeIndexToType(SearchIndexer::INDEX_EVENTS));
+        self::assertSame('decks', $this->invokeIndexToType(SearchIndexer::INDEX_DECKS));
+        self::assertSame('unknown', $this->invokeIndexToType('nonexistent'));
+    }
+
+    // ── buildSearchParams ──────────────────────────────────────────────
+
+    public function testBuildSearchParamsForArchetypesIncludesLocaleFilter(): void
+    {
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_ARCHETYPES, 'fr', 10, 0);
+
+        self::assertSame("locale = 'fr'", $params['filter']);
+        self::assertSame(10, $params['limit']);
+        self::assertSame(0, $params['offset']);
+        self::assertSame('<mark>', $params['highlightPreTag']);
+    }
+
+    public function testBuildSearchParamsForPagesIncludesLocaleFilter(): void
+    {
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_PAGES, 'en', 20, 5);
+
+        self::assertSame("locale = 'en'", $params['filter']);
+    }
+
+    public function testBuildSearchParamsForEventsHasNoLocaleFilter(): void
+    {
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_EVENTS, 'fr', 10, 0);
+
+        self::assertArrayNotHasKey('filter', $params);
+    }
+
+    public function testBuildSearchParamsForDecksHasNoLocaleFilter(): void
+    {
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_DECKS, 'en', 10, 0);
+
+        self::assertArrayNotHasKey('filter', $params);
+    }
+
+    public function testBuildSearchParamsIncludesRankingScoreThreshold(): void
+    {
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_DECKS, 'en', 10, 0);
+
+        self::assertArrayHasKey('rankingScoreThreshold', $params);
+        self::assertIsFloat($params['rankingScoreThreshold']);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private function createService(): SearchService
+    {
+        return (new \ReflectionClass(SearchService::class))->newInstanceWithoutConstructor();
+    }
+
+    /**
+     * @param list<string>|null $enabledTypes
+     *
+     * @return list<string>
+     */
+    private function invokeGetIndexesForType(?string $typeFilter, ?array $enabledTypes): array
+    {
+        $method = new \ReflectionMethod(SearchService::class, 'getIndexesForType');
+
+        /** @var list<string> $result */
+        $result = $method->invoke($this->createService(), $typeFilter, $enabledTypes);
+
+        return $result;
+    }
+
+    private function invokeIndexToType(string $indexName): string
+    {
+        $method = new \ReflectionMethod(SearchService::class, 'indexToType');
+
+        /** @var string $result */
+        $result = $method->invoke($this->createService(), $indexName);
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function invokeBuildSearchParams(string $indexName, string $locale, int $limit, int $offset): array
+    {
+        $method = new \ReflectionMethod(SearchService::class, 'buildSearchParams');
+
+        /** @var array<string, mixed> $result */
+        $result = $method->invoke($this->createService(), $indexName, $locale, $limit, $offset);
+
+        return $result;
+    }
+}

--- a/tests/Twig/Runtime/SearchRuntimeTest.php
+++ b/tests/Twig/Runtime/SearchRuntimeTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Twig\Runtime;
+
+use App\Service\Search\SearchResult;
+use App\Twig\Runtime\SearchRuntime;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @see docs/features.md F18.2 — Global search results page
+ */
+class SearchRuntimeTest extends TestCase
+{
+    public function testSearchResultUrlForArchetype(): void
+    {
+        $runtime = $this->createRuntime('/en/archetypes/regidrago');
+
+        $result = new SearchResult('archetype', 'Regidrago', '', 'regidrago');
+        $url = $runtime->searchResultUrl($result);
+
+        self::assertSame('/en/archetypes/regidrago', $url);
+    }
+
+    public function testSearchResultUrlForVariant(): void
+    {
+        $runtime = $this->createRuntime('/en/archetypes/regidrago');
+
+        $result = new SearchResult('variant', 'Turbo Regidrago', '', 'XYZ789', archetypeSlug: 'regidrago');
+        $url = $runtime->searchResultUrl($result);
+
+        self::assertSame('/en/archetypes/regidrago#XYZ789', $url);
+    }
+
+    public function testSearchResultUrlForPage(): void
+    {
+        $runtime = $this->createRuntime('/en/pages/welcome');
+
+        $result = new SearchResult('page', 'Welcome', '', 'welcome');
+        $url = $runtime->searchResultUrl($result);
+
+        self::assertSame('/en/pages/welcome', $url);
+    }
+
+    public function testSearchResultUrlForEvent(): void
+    {
+        $runtime = $this->createRuntime('/event/7');
+
+        $result = new SearchResult('event', 'Paris League', '', '7', '2026-05-01');
+        $url = $runtime->searchResultUrl($result);
+
+        self::assertSame('/event/7', $url);
+    }
+
+    public function testSearchResultUrlForDeck(): void
+    {
+        $runtime = $this->createRuntime('/deck/ABC123');
+
+        $result = new SearchResult('deck', 'My Deck', '', 'ABC123', 'Julien');
+        $url = $runtime->searchResultUrl($result);
+
+        self::assertSame('/deck/ABC123', $url);
+    }
+
+    public function testSearchResultUrlForUnknownType(): void
+    {
+        $runtime = $this->createRuntime('/');
+
+        $result = new SearchResult('unknown', 'Something', '', 'slug');
+        $url = $runtime->searchResultUrl($result);
+
+        self::assertSame('/', $url);
+    }
+
+    private function createRuntime(string $expectedUrl): SearchRuntime
+    {
+        $request = Request::create('/');
+        $request->setLocale('en');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn($expectedUrl);
+
+        return new SearchRuntime($urlGenerator, $requestStack);
+    }
+}


### PR DESCRIPTION
## Summary

- Search results are now filtered by the current channel's feature flags
- On the content channel (archetypes enabled, no decks/events): only archetypes, variants, and pages appear
- On the app channel (decks/events enabled, no archetypes): only decks, events, and pages appear
- Pages always appear (enabled on all channels)
- Both the full search page and navbar autocomplete API respect channel features
- Template conditionally renders type filter tabs based on channel config
- **51 new tests** covering the full search stack: SearchResult, SearchService, SearchIndexListener, SearchController, SearchApiController

## Test plan
- [ ] On the content channel: search for a deck name — verify no deck results
- [ ] On the app channel: search for an archetype name — verify no archetype results
- [ ] On a channel with all features: verify all types appear
- [ ] Verify type filter tabs only show for enabled content types

🤖 Generated with [Claude Code](https://claude.com/claude-code)