### PR TITLE
:rocket: Release: 1.8.8

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,16 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.8.8] — 2026-04-26
+
+Channel-scoped page search results.
+
+### Bug Fixes
+
+- **Channel-aware page search** — CMS pages from other channels no longer leak into search results. Added `channelCode` as a filterable attribute on the MeiliSearch pages index; both `SearchController` and `SearchApiController` now pass the current channel code so MeiliSearch filters pages by channel.
+
+---
+
 ## [1.8.7] — 2026-04-26
 
 Channel-aware search filtering and comprehensive search test coverage.

--- a/src/Controller/SearchApiController.php
+++ b/src/Controller/SearchApiController.php
@@ -43,8 +43,9 @@ class SearchApiController extends AbstractController
 
         $channel = $request->attributes->get('_channel');
         $enabledTypes = $channel instanceof Channel ? self::getEnabledTypes($channel) : null;
+        $channelCode = $channel instanceof Channel ? $channel->getCode() : null;
 
-        $results = $searchService->quickSearch($query, $locale, $enabledTypes);
+        $results = $searchService->quickSearch($query, $locale, $enabledTypes, $channelCode);
 
         $groups = [];
 

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -44,8 +44,9 @@ class SearchController extends AbstractController
 
         $channel = $request->attributes->get('_channel');
         $enabledTypes = $channel instanceof Channel ? self::getEnabledTypes($channel) : null;
+        $channelCode = $channel instanceof Channel ? $channel->getCode() : null;
 
-        $results = '' !== $query ? $searchService->searchAll($query, $locale, $typeFilter, $enabledTypes) : [
+        $results = '' !== $query ? $searchService->searchAll($query, $locale, $typeFilter, $enabledTypes, $channelCode) : [
             'archetypes' => [],
             'variants' => [],
             'pages' => [],

--- a/src/Service/Search/SearchIndexer.php
+++ b/src/Service/Search/SearchIndexer.php
@@ -278,8 +278,8 @@ class SearchIndexer
         $this->client->createIndex(self::INDEX_PAGES, ['primaryKey' => 'id']);
         $index->updateSettings([
             'searchableAttributes' => ['title', 'content'],
-            'filterableAttributes' => ['locale', 'entityId'],
-            'displayedAttributes' => ['id', 'entityId', 'locale', 'title', 'slug', 'type'],
+            'filterableAttributes' => ['locale', 'entityId', 'channelCode'],
+            'displayedAttributes' => ['id', 'entityId', 'locale', 'title', 'slug', 'type', 'channelCode'],
         ]);
 
         $pages = $this->pageRepository->findPublishedForSearch();
@@ -415,6 +415,7 @@ class SearchIndexer
                 'title' => $translation->getTitle(),
                 'slug' => $page->getSlug(),
                 'content' => $this->stripMarkdown($translation->getContent()),
+                'channelCode' => $page->getChannel()?->getCode(),
             ];
         }
 

--- a/src/Service/Search/SearchService.php
+++ b/src/Service/Search/SearchService.php
@@ -58,7 +58,7 @@ class SearchService
      *     decks: list<SearchResult>,
      * }
      */
-    public function searchAll(string $query, string $locale, ?string $typeFilter = null, ?array $enabledTypes = null, int $limit = self::FULL_SEARCH_LIMIT, int $offset = 0): array
+    public function searchAll(string $query, string $locale, ?string $typeFilter = null, ?array $enabledTypes = null, ?string $channelCode = null, int $limit = self::FULL_SEARCH_LIMIT, int $offset = 0): array
     {
         $results = [
             'archetypes' => [],
@@ -76,7 +76,7 @@ class SearchService
 
         foreach ($indexes as $indexName) {
             try {
-                $searchParams = $this->buildSearchParams($indexName, $locale, $limit, $offset);
+                $searchParams = $this->buildSearchParams($indexName, $locale, $channelCode, $limit, $offset);
                 $response = $this->client->index($indexName)->search($query, $searchParams);
 
                 $type = $this->indexToType($indexName);
@@ -109,9 +109,9 @@ class SearchService
      *     decks: list<SearchResult>,
      * }
      */
-    public function quickSearch(string $query, string $locale, ?array $enabledTypes = null): array
+    public function quickSearch(string $query, string $locale, ?array $enabledTypes = null, ?string $channelCode = null): array
     {
-        return $this->searchAll($query, $locale, enabledTypes: $enabledTypes, limit: self::QUICK_SEARCH_LIMIT);
+        return $this->searchAll($query, $locale, enabledTypes: $enabledTypes, channelCode: $channelCode, limit: self::QUICK_SEARCH_LIMIT);
     }
 
     /**
@@ -162,7 +162,7 @@ class SearchService
     /**
      * @return array<string, mixed>
      */
-    private function buildSearchParams(string $indexName, string $locale, int $limit, int $offset): array
+    private function buildSearchParams(string $indexName, string $locale, ?string $channelCode, int $limit, int $offset): array
     {
         $params = [
             'limit' => $limit,
@@ -174,8 +174,18 @@ class SearchService
         ];
 
         // Translatable indexes support locale filtering
+        $filters = [];
         if (\in_array($indexName, [SearchIndexer::INDEX_ARCHETYPES, SearchIndexer::INDEX_PAGES], true)) {
-            $params['filter'] = \sprintf("locale = '%s'", $locale);
+            $filters[] = \sprintf("locale = '%s'", $locale);
+        }
+
+        // Pages are channel-scoped — only return pages belonging to the current channel
+        if (SearchIndexer::INDEX_PAGES === $indexName && null !== $channelCode) {
+            $filters[] = \sprintf("channelCode = '%s'", $channelCode);
+        }
+
+        if ([] !== $filters) {
+            $params['filter'] = implode(' AND ', $filters);
         }
 
         return $params;

--- a/tests/Service/Search/SearchServiceTest.php
+++ b/tests/Service/Search/SearchServiceTest.php
@@ -143,7 +143,7 @@ class SearchServiceTest extends TestCase
 
     public function testBuildSearchParamsForArchetypesIncludesLocaleFilter(): void
     {
-        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_ARCHETYPES, 'fr', 10, 0);
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_ARCHETYPES, 'fr', null, 10, 0);
 
         self::assertSame("locale = 'fr'", $params['filter']);
         self::assertSame(10, $params['limit']);
@@ -153,28 +153,42 @@ class SearchServiceTest extends TestCase
 
     public function testBuildSearchParamsForPagesIncludesLocaleFilter(): void
     {
-        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_PAGES, 'en', 20, 5);
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_PAGES, 'en', null, 20, 5);
 
         self::assertSame("locale = 'en'", $params['filter']);
     }
 
     public function testBuildSearchParamsForEventsHasNoLocaleFilter(): void
     {
-        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_EVENTS, 'fr', 10, 0);
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_EVENTS, 'fr', null, 10, 0);
 
         self::assertArrayNotHasKey('filter', $params);
     }
 
     public function testBuildSearchParamsForDecksHasNoLocaleFilter(): void
     {
-        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_DECKS, 'en', 10, 0);
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_DECKS, 'en', null, 10, 0);
 
         self::assertArrayNotHasKey('filter', $params);
     }
 
+    public function testBuildSearchParamsForPagesWithChannelCodeIncludesBothFilters(): void
+    {
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_PAGES, 'en', 'content', 10, 0);
+
+        self::assertSame("locale = 'en' AND channelCode = 'content'", $params['filter']);
+    }
+
+    public function testBuildSearchParamsChannelCodeIgnoredForNonPageIndexes(): void
+    {
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_ARCHETYPES, 'fr', 'content', 10, 0);
+
+        self::assertSame("locale = 'fr'", $params['filter']);
+    }
+
     public function testBuildSearchParamsIncludesRankingScoreThreshold(): void
     {
-        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_DECKS, 'en', 10, 0);
+        $params = $this->invokeBuildSearchParams(SearchIndexer::INDEX_DECKS, 'en', null, 10, 0);
 
         self::assertArrayHasKey('rankingScoreThreshold', $params);
         self::assertIsFloat($params['rankingScoreThreshold']);
@@ -215,12 +229,12 @@ class SearchServiceTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private function invokeBuildSearchParams(string $indexName, string $locale, int $limit, int $offset): array
+    private function invokeBuildSearchParams(string $indexName, string $locale, ?string $channelCode, int $limit, int $offset): array
     {
         $method = new \ReflectionMethod(SearchService::class, 'buildSearchParams');
 
         /** @var array<string, mixed> $result */
-        $result = $method->invoke($this->createService(), $indexName, $locale, $limit, $offset);
+        $result = $method->invoke($this->createService(), $indexName, $locale, $channelCode, $limit, $offset);
 
         return $result;
     }


### PR DESCRIPTION
## Summary
- Release 1.8.8 — channel-scoped page search results
- Fix: CMS pages from other channels no longer leak into MeiliSearch search results
- See `docs/changelog.md` for details

🤖 Generated with [Claude Code](https://claude.com/claude-code)