### PR TITLE
:sparkles: Feature: Printable A4 decklist PDF (F5.13)

### DIFF
--- a/migrations/Version20260426210000.php
+++ b/migrations/Version20260426210000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add year_of_birth to user entity for tournament decklist PDF.
+ *
+ * @see docs/features.md F5.13 — Printable A4 decklist PDF
+ */
+final class Version20260426210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add year_of_birth column to user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `user` ADD year_of_birth INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `user` DROP year_of_birth');
+    }
+}

--- a/src/Controller/DeckShowController.php
+++ b/src/Controller/DeckShowController.php
@@ -28,6 +28,7 @@ use App\Service\DeckList\MinifiedCardView;
 use App\Service\DeckList\MinifiedCardViewBuilder;
 use App\Service\DeckList\OriginalListFormatter;
 use App\Service\DeckListParser;
+use App\Service\Label\PdfDecklistGenerator;
 use App\Service\Label\PdfLabelGenerator;
 use App\Service\Tcgdex\TcgdexApiClient;
 use Doctrine\ORM\EntityManagerInterface;
@@ -270,6 +271,38 @@ class DeckShowController extends AbstractAppController
         return new Response($pdf, 200, [
             'Content-Type' => 'application/pdf',
             'Content-Disposition' => \sprintf('inline; filename="deck-%s-label-foldable.pdf"', $deck->getShortTag()),
+        ]);
+    }
+
+    /**
+     * @see docs/features.md F5.13 — Printable A4 decklist PDF
+     */
+    #[Route('/deck/{short_tag}/decklist.pdf', name: 'app_deck_decklist_pdf', methods: ['GET'], requirements: ['short_tag' => '[A-HJ-NP-Z0-9]{6}'])]
+    public function decklistPdf(
+        #[MapEntity(mapping: ['short_tag' => 'shortTag'])] Deck $deck,
+        PdfDecklistGenerator $decklistGenerator,
+        Request $request,
+    ): Response {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($deck->getOwner()?->getId() !== $user->getId()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if (null === $deck->getCurrentVersion()) {
+            throw $this->createNotFoundException('This deck has no version.');
+        }
+
+        $anonymous = $request->query->getBoolean('anonymous', false);
+
+        $pdf = $anonymous
+            ? $decklistGenerator->generateAnonymous($deck)
+            : $decklistGenerator->generatePersonal($deck, $user);
+
+        return new Response($pdf, 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => \sprintf('inline; filename="deck-%s-decklist.pdf"', $deck->getShortTag()),
         ]);
     }
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -232,6 +232,7 @@ class ProfileController extends AbstractAppController
                 'lastName' => $user->getLastName(),
                 'playerId' => $user->getPlayerId(),
                 'discordUsername' => $user->getDiscordUsername(),
+                'yearOfBirth' => $user->getYearOfBirth(),
                 'preferredLocale' => $user->getPreferredLocale(),
                 'timezone' => $user->getTimezone(),
                 'createdAt' => $user->getCreatedAt()->format('c'),

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -65,6 +65,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[Assert\Length(max: 30)]
     private ?string $playerId = null;
 
+    /**
+     * @see docs/features.md F5.13 — Printable A4 decklist PDF
+     */
+    #[ORM\Column(nullable: true)]
+    #[Assert\Range(min: 1920, max: 2020)]
+    private ?int $yearOfBirth = null;
+
     #[ORM\Column]
     private string $password = '';
 
@@ -229,6 +236,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setPlayerId(?string $playerId): static
     {
         $this->playerId = $playerId;
+
+        return $this;
+    }
+
+    public function getYearOfBirth(): ?int
+    {
+        return $this->yearOfBirth;
+    }
+
+    public function setYearOfBirth(?int $yearOfBirth): static
+    {
+        $this->yearOfBirth = $yearOfBirth;
 
         return $this;
     }
@@ -439,6 +458,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->firstName = 'Anonymous';
         $this->lastName = 'User';
         $this->playerId = null;
+        $this->yearOfBirth = null;
         $this->discordUsername = null;
         $this->password = '';
         $this->roles = [];

--- a/src/Form/ProfileFormType.php
+++ b/src/Form/ProfileFormType.php
@@ -17,6 +17,7 @@ use App\Entity\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -44,6 +45,11 @@ class ProfileFormType extends AbstractType
             ->add('playerId', TextType::class, [
                 'label' => 'app.form.label.player_id',
                 'required' => false,
+            ])
+            ->add('yearOfBirth', IntegerType::class, [
+                'label' => 'app.form.label.year_of_birth',
+                'required' => false,
+                'help' => 'app.form.help.year_of_birth',
             ])
             ->add('discordUsername', TextType::class, [
                 'label' => 'app.form.label.discord_username',

--- a/src/Service/Label/PdfDecklistGenerator.php
+++ b/src/Service/Label/PdfDecklistGenerator.php
@@ -18,6 +18,7 @@ use App\Entity\DeckCard;
 use App\Entity\DeckVersion;
 use App\Entity\TcgdexCard;
 use App\Entity\User;
+use App\Repository\TcgdexCardRepository;
 use Dompdf\Dompdf;
 use Dompdf\Options;
 use Endroid\QrCode\Builder\Builder;
@@ -41,11 +42,15 @@ class PdfDecklistGenerator
     /** @var array<string, string> cached set symbol data URIs within one request */
     private array $symbolCache = [];
 
+    /** @var array<string, ?TcgdexCard> cached TcgdexCard lookups by tcgdexId */
+    private array $tcgdexCardCache = [];
+
     public function __construct(
         private readonly Environment $twig,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly HttpClientInterface $httpClient,
         private readonly TranslatorInterface $translator,
+        private readonly TcgdexCardRepository $tcgdexCardRepository,
     ) {
     }
 
@@ -164,7 +169,7 @@ class PdfDecklistGenerator
         $urls = [];
 
         foreach ($pokemonCards as $card) {
-            $symbolUrl = $card->getCardPrinting()?->getTcgdexCard()?->getSet()?->getSymbolUrl();
+            $symbolUrl = $this->resolveTcgdexCard($card)?->getSet()?->getSymbolUrl();
             if (null !== $symbolUrl && !isset($urls[$symbolUrl])) {
                 $urls[$symbolUrl] = true;
             }
@@ -192,7 +197,9 @@ class PdfDecklistGenerator
             }
 
             try {
-                $response = $this->httpClient->request('GET', $url, ['timeout' => 3]);
+                // TCGdex symbol URLs are base paths — append .png for the actual image
+                $fetchUrl = str_ends_with($url, '.png') || str_ends_with($url, '.svg') ? $url : $url.'.png';
+                $response = $this->httpClient->request('GET', $fetchUrl, ['timeout' => 3]);
                 $contentType = $response->getHeaders()['content-type'][0] ?? 'image/png';
                 $content = $response->getContent();
 
@@ -318,7 +325,7 @@ class PdfDecklistGenerator
         $rows = [];
 
         foreach ($cards as $card) {
-            $tcgdexCard = $card->getCardPrinting()?->getTcgdexCard();
+            $tcgdexCard = $this->resolveTcgdexCard($card);
 
             // Resolve the display name in the user's locale
             $displayName = $card->getCardName();
@@ -341,11 +348,11 @@ class PdfDecklistGenerator
             $symbolDataUri = null;
             $ptcgCode = $card->getSetCode();
             if ($includeSetInfo) {
-                $symbolUrl = $card->getCardPrinting()?->getTcgdexCard()?->getSet()?->getSymbolUrl();
+                $symbolUrl = $this->resolveTcgdexCard($card)?->getSet()?->getSymbolUrl();
                 if (null !== $symbolUrl) {
                     $symbolDataUri = $setSymbolDataUris[$symbolUrl] ?? null;
                 }
-                $ptcgCode = $card->getCardPrinting()?->getTcgdexCard()?->getSet()?->getPtcgCode() ?? $card->getSetCode();
+                $ptcgCode = $this->resolveTcgdexCard($card)?->getSet()?->getPtcgCode() ?? $card->getSetCode();
             }
 
             $rows[] = [
@@ -461,23 +468,44 @@ class PdfDecklistGenerator
     }
 
     /**
+     * Resolve the TcgdexCard for a DeckCard, using the entity relation first,
+     * then falling back to a repository lookup via the tcgdexId string.
+     */
+    private function resolveTcgdexCard(DeckCard $card): ?TcgdexCard
+    {
+        $tcgdexCard = $card->getCardPrinting()?->getTcgdexCard();
+        if (null !== $tcgdexCard) {
+            return $tcgdexCard;
+        }
+
+        $tcgdexId = $card->getCardPrinting()?->getTcgdexId();
+        if (null === $tcgdexId) {
+            return null;
+        }
+
+        if (\array_key_exists($tcgdexId, $this->tcgdexCardCache)) {
+            return $this->tcgdexCardCache[$tcgdexId];
+        }
+
+        $this->tcgdexCardCache[$tcgdexId] = $this->tcgdexCardRepository->find($tcgdexId);
+
+        return $this->tcgdexCardCache[$tcgdexId];
+    }
+
+    /**
      * Get the card name in the user's locale from TCGdex data.
      *
-     * Returns null if no localized name is available for the requested locale,
+     * Reads directly from the JSON name field for the specific locale key.
+     * Returns null only if no entry exists for the requested locale,
      * letting the caller fall back to the original DeckCard.cardName.
      */
     private function getLocalizedCardName(TcgdexCard $tcgdexCard, string $locale): ?string
     {
-        $localizedName = $tcgdexCard->getLocalizedName($locale);
+        // Access the raw name array to check if the locale key exists explicitly
+        $names = $tcgdexCard->getName();
+        $localizedName = $names[$locale] ?? null;
 
-        // getLocalizedName falls back to English — only return if we got the requested locale
-        $nameEn = $tcgdexCard->getNameEn();
-        if (null !== $localizedName && $localizedName !== $nameEn) {
-            return $localizedName;
-        }
-
-        // If the localized name equals English, the translation doesn't exist for this locale
-        return null;
+        return \is_string($localizedName) ? $localizedName : null;
     }
 
     private function generateQrCode(string $content): string

--- a/src/Service/Label/PdfDecklistGenerator.php
+++ b/src/Service/Label/PdfDecklistGenerator.php
@@ -381,23 +381,17 @@ class PdfDecklistGenerator
      */
     private function computeFontSize(array $pokemonRows, array $trainerSections, array $energyRows): float
     {
-        // Count lines: each card = 1 line, each card with English subline = 1.5 lines
+        // Count lines: each card = 1 line (English name is inline, not a subline)
         $totalLines = 0.0;
 
-        foreach ($pokemonRows as $row) {
-            $totalLines += null !== $row['englishName'] ? 1.5 : 1.0;
-        }
+        $totalLines += \count($pokemonRows);
 
         foreach ($trainerSections as $section) {
             $totalLines += 0.5; // subtype header
-            foreach ($section['rows'] as $row) {
-                $totalLines += null !== $row['englishName'] ? 1.5 : 1.0;
-            }
+            $totalLines += \count($section['rows']);
         }
 
-        foreach ($energyRows as $row) {
-            $totalLines += null !== $row['englishName'] ? 1.5 : 1.0;
-        }
+        $totalLines += \count($energyRows);
 
         // Add section headers (Pokemon, Trainer, Energy = 3 headers)
         $sectionHeaderLines = 3.0;

--- a/src/Service/Label/PdfDecklistGenerator.php
+++ b/src/Service/Label/PdfDecklistGenerator.php
@@ -1,0 +1,476 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Label;
+
+use App\Entity\Deck;
+use App\Entity\DeckCard;
+use App\Entity\DeckVersion;
+use App\Entity\User;
+use Dompdf\Dompdf;
+use Dompdf\Options;
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\ErrorCorrectionLevel;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+/**
+ * Generates a tournament-ready A4 decklist PDF from a deck's card list.
+ *
+ * Two modes: personal (auto-filled player info) and anonymous (blank fields).
+ *
+ * @see docs/features.md F5.13 — Printable A4 decklist PDF
+ */
+class PdfDecklistGenerator
+{
+    private const int QR_CODE_SIZE_PX = 200;
+
+    /** @var array<string, string> cached set symbol data URIs within one request */
+    private array $symbolCache = [];
+
+    public function __construct(
+        private readonly Environment $twig,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly HttpClientInterface $httpClient,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * Generate a personal decklist PDF with player info filled from the User entity.
+     *
+     * @see docs/features.md F5.13 — Printable A4 decklist PDF
+     *
+     * @return string the raw PDF binary content
+     */
+    public function generatePersonal(Deck $deck, User $user): string
+    {
+        return $this->generate($deck, $user);
+    }
+
+    /**
+     * Generate an anonymous decklist PDF with blank player fields.
+     *
+     * @see docs/features.md F5.13 — Printable A4 decklist PDF
+     *
+     * @return string the raw PDF binary content
+     */
+    public function generateAnonymous(Deck $deck): string
+    {
+        return $this->generate($deck, null);
+    }
+
+    private function generate(Deck $deck, ?User $user): string
+    {
+        $currentVersion = $deck->getCurrentVersion();
+        $locale = $user?->getPreferredLocale() ?? 'en';
+
+        $deckUrl = $this->urlGenerator->generate(
+            'app_deck_show',
+            ['short_tag' => $deck->getShortTag()],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        $groupedCards = null !== $currentVersion
+            ? $this->groupCardsForDecklist($currentVersion)
+            : ['pokemon' => [], 'trainerGroups' => [], 'energy' => []];
+
+        $setSymbolDataUris = $this->fetchSetSymbolDataUris($this->collectSetSymbolUrls($groupedCards['pokemon']));
+        $gravatarDataUri = null !== $user ? $this->fetchGravatarDataUri($user->getEmail()) : null;
+        $qrCodeDataUri = $this->generateQrCode($deckUrl);
+
+        $templateData = $this->buildTemplateData($deck, $user, $groupedCards, $setSymbolDataUris, $gravatarDataUri, $qrCodeDataUri, $locale);
+
+        $html = $this->twig->render('label/pdf_decklist.html.twig', $templateData);
+
+        return $this->renderPdf($html);
+    }
+
+    /**
+     * Group cards into three top-level sections: pokemon, trainer (sub-grouped by subtype), energy.
+     *
+     * @return array{pokemon: list<DeckCard>, trainerGroups: array<string, list<DeckCard>>, energy: list<DeckCard>}
+     */
+    private function groupCardsForDecklist(DeckVersion $version): array
+    {
+        $pokemon = [];
+        $trainerGroups = [];
+        $energy = [];
+
+        foreach ($version->getCards() as $card) {
+            match ($card->getCardType()) {
+                'pokemon' => $pokemon[] = $card,
+                'trainer' => $trainerGroups[$this->resolveTrainerSubtype($card)][] = $card,
+                'energy' => $energy[] = $card,
+                default => $trainerGroups['trainer'][] = $card,
+            };
+        }
+
+        $sortFunction = static function (DeckCard $a, DeckCard $b): int {
+            if ($a->getQuantity() !== $b->getQuantity()) {
+                return $b->getQuantity() - $a->getQuantity();
+            }
+
+            return strcmp($a->getCardName(), $b->getCardName());
+        };
+
+        usort($pokemon, $sortFunction);
+        usort($energy, $sortFunction);
+
+        $orderedTrainerGroups = [];
+        foreach (['supporter', 'item', 'tool', 'stadium', 'technical machine', 'trainer'] as $subtype) {
+            if (isset($trainerGroups[$subtype])) {
+                usort($trainerGroups[$subtype], $sortFunction);
+                $orderedTrainerGroups[$subtype] = $trainerGroups[$subtype];
+            }
+        }
+
+        return [
+            'pokemon' => $pokemon,
+            'trainerGroups' => $orderedTrainerGroups,
+            'energy' => $energy,
+        ];
+    }
+
+    private function resolveTrainerSubtype(DeckCard $card): string
+    {
+        $subtype = $card->getTrainerSubtype();
+
+        return null !== $subtype ? strtolower($subtype) : 'trainer';
+    }
+
+    /**
+     * Collect unique set symbol URLs from Pokemon cards.
+     *
+     * @param list<DeckCard> $pokemonCards
+     *
+     * @return list<string>
+     */
+    private function collectSetSymbolUrls(array $pokemonCards): array
+    {
+        $urls = [];
+
+        foreach ($pokemonCards as $card) {
+            $symbolUrl = $card->getCardPrinting()?->getTcgdexCard()?->getSet()?->getSymbolUrl();
+            if (null !== $symbolUrl && !isset($urls[$symbolUrl])) {
+                $urls[$symbolUrl] = true;
+            }
+        }
+
+        return array_keys($urls);
+    }
+
+    /**
+     * Fetch remote set symbol images and base64-encode them for Dompdf.
+     *
+     * @param list<string> $urls
+     *
+     * @return array<string, string> map of URL to base64 data URI
+     */
+    private function fetchSetSymbolDataUris(array $urls): array
+    {
+        $result = [];
+
+        foreach ($urls as $url) {
+            if (isset($this->symbolCache[$url])) {
+                $result[$url] = $this->symbolCache[$url];
+
+                continue;
+            }
+
+            try {
+                $response = $this->httpClient->request('GET', $url, ['timeout' => 3]);
+                $contentType = $response->getHeaders()['content-type'][0] ?? 'image/png';
+                $content = $response->getContent();
+
+                // Normalize content type (remove charset etc.)
+                if (str_contains($contentType, 'svg')) {
+                    $contentType = 'image/svg+xml';
+                } elseif (str_contains($contentType, 'png')) {
+                    $contentType = 'image/png';
+                }
+
+                $dataUri = \sprintf('data:%s;base64,%s', $contentType, base64_encode($content));
+                $this->symbolCache[$url] = $dataUri;
+                $result[$url] = $dataUri;
+            } catch (\Throwable) {
+                // Graceful degradation: no symbol image, text-only fallback
+            }
+        }
+
+        return $result;
+    }
+
+    private function fetchGravatarDataUri(string $email): ?string
+    {
+        $hash = md5(strtolower(trim($email)));
+        $url = \sprintf('https://www.gravatar.com/avatar/%s?s=80&d=404', $hash);
+
+        try {
+            $response = $this->httpClient->request('GET', $url, ['timeout' => 3]);
+
+            if (200 !== $response->getStatusCode()) {
+                return null;
+            }
+
+            $content = $response->getContent();
+            $contentType = $response->getHeaders()['content-type'][0] ?? 'image/jpeg';
+
+            return \sprintf('data:%s;base64,%s', $contentType, base64_encode($content));
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Build all template variables for the decklist PDF.
+     *
+     * @param array{pokemon: list<DeckCard>, trainerGroups: array<string, list<DeckCard>>, energy: list<DeckCard>} $groupedCards
+     * @param array<string, string>                                                                                $setSymbolDataUris
+     *
+     * @return array<string, mixed>
+     */
+    private function buildTemplateData(
+        Deck $deck,
+        ?User $user,
+        array $groupedCards,
+        array $setSymbolDataUris,
+        ?string $gravatarDataUri,
+        string $qrCodeDataUri,
+        string $locale,
+    ): array {
+        $pokemonCards = $groupedCards['pokemon'];
+        $trainerGroups = $groupedCards['trainerGroups'];
+        $energyCards = $groupedCards['energy'];
+
+        // Count totals
+        $pokemonCount = $this->sumQuantities($pokemonCards);
+        $trainerCount = 0;
+        foreach ($trainerGroups as $cards) {
+            $trainerCount += $this->sumQuantities($cards);
+        }
+        $energyCount = $this->sumQuantities($energyCards);
+        $totalCardCount = $pokemonCount + $trainerCount + $energyCount;
+
+        // Build card view data with English name resolution
+        $pokemonRows = $this->buildCardRows($pokemonCards, $locale, true, $setSymbolDataUris);
+        $trainerSections = [];
+        foreach ($trainerGroups as $subtype => $cards) {
+            $trainerSections[] = [
+                'subtype' => $subtype,
+                'label' => $this->translateSubtype($subtype, $locale),
+                'rows' => $this->buildCardRows($cards, $locale, false, []),
+            ];
+        }
+        $energyRows = $this->buildCardRows($energyCards, $locale, false, []);
+
+        // Compute adapt-to-fit font size
+        $fontSize = $this->computeFontSize($pokemonRows, $trainerSections, $energyRows);
+
+        // Player trigram
+        $trigram = null !== $user ? $this->buildTrigram($user) : null;
+
+        return [
+            'mode' => null !== $user ? 'personal' : 'anonymous',
+            'playerName' => null !== $user ? $user->getFirstName().' '.$user->getLastName() : null,
+            'playerId' => $user?->getPlayerId(),
+            'yearOfBirth' => $user?->getYearOfBirth(),
+            'trigram' => $trigram,
+            'gravatarDataUri' => $gravatarDataUri,
+            'qrCodeDataUri' => $qrCodeDataUri,
+            'format' => ucfirst($deck->getFormat()->value),
+            'deckName' => $deck->getName(),
+            'totalCardCount' => $totalCardCount,
+            'pokemonCount' => $pokemonCount,
+            'pokemonRows' => $pokemonRows,
+            'trainerCount' => $trainerCount,
+            'trainerSections' => $trainerSections,
+            'energyCount' => $energyCount,
+            'energyRows' => $energyRows,
+            'fontSize' => $fontSize,
+            'labels' => $this->buildLabels($locale),
+        ];
+    }
+
+    /**
+     * Build card row data for the template.
+     *
+     * @param list<DeckCard>        $cards
+     * @param array<string, string> $setSymbolDataUris
+     *
+     * @return list<array{name: string, englishName: ?string, quantity: int, setCode: string, cardNumber: string, symbolDataUri: ?string}>
+     */
+    private function buildCardRows(array $cards, string $locale, bool $includeSetInfo, array $setSymbolDataUris): array
+    {
+        $rows = [];
+
+        foreach ($cards as $card) {
+            $englishName = null;
+            if ('en' !== $locale && 'en' !== $card->getCardLocale()) {
+                $nameEn = $card->getCardPrinting()?->getTcgdexCard()?->getNameEn();
+                if (null !== $nameEn && $nameEn !== $card->getCardName()) {
+                    $englishName = $nameEn;
+                }
+            }
+
+            $symbolDataUri = null;
+            $ptcgCode = $card->getSetCode();
+            if ($includeSetInfo) {
+                $symbolUrl = $card->getCardPrinting()?->getTcgdexCard()?->getSet()?->getSymbolUrl();
+                if (null !== $symbolUrl) {
+                    $symbolDataUri = $setSymbolDataUris[$symbolUrl] ?? null;
+                }
+                $ptcgCode = $card->getCardPrinting()?->getTcgdexCard()?->getSet()?->getPtcgCode() ?? $card->getSetCode();
+            }
+
+            $rows[] = [
+                'name' => $card->getCardName(),
+                'englishName' => $englishName,
+                'quantity' => $card->getQuantity(),
+                'setCode' => $ptcgCode,
+                'cardNumber' => $card->getCardNumber(),
+                'symbolDataUri' => $includeSetInfo ? $symbolDataUri : null,
+                'includeSetInfo' => $includeSetInfo,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Compute font size to fit all cards on one A4 page.
+     *
+     * A4 usable height ≈ 277mm (297 - 2×10mm margins). Header ≈ 35mm.
+     * Available for cards ≈ 242mm. Each section header ≈ 5mm. Each subtype header ≈ 4mm.
+     *
+     * @param list<array{englishName: ?string}>                    $pokemonRows
+     * @param list<array{rows: list<array{englishName: ?string}>}> $trainerSections
+     * @param list<array{englishName: ?string}>                    $energyRows
+     */
+    private function computeFontSize(array $pokemonRows, array $trainerSections, array $energyRows): float
+    {
+        // Count lines: each card = 1 line, each card with English subline = 1.5 lines
+        $totalLines = 0.0;
+
+        foreach ($pokemonRows as $row) {
+            $totalLines += null !== $row['englishName'] ? 1.5 : 1.0;
+        }
+
+        foreach ($trainerSections as $section) {
+            $totalLines += 0.5; // subtype header
+            foreach ($section['rows'] as $row) {
+                $totalLines += null !== $row['englishName'] ? 1.5 : 1.0;
+            }
+        }
+
+        foreach ($energyRows as $row) {
+            $totalLines += null !== $row['englishName'] ? 1.5 : 1.0;
+        }
+
+        // Add section headers (Pokemon, Trainer, Energy = 3 headers)
+        $sectionHeaderLines = 3.0;
+        $totalLines += $sectionHeaderLines;
+
+        // Available height: A4 (297mm) - margins (20mm) - header (40mm) = ~237mm
+        $availableHeightMm = 237.0;
+        $lineHeightFactor = 1.35;
+        $ptToMm = 0.353;
+
+        if ($totalLines > 0) {
+            $maxFontSizePt = $availableHeightMm / ($totalLines * $lineHeightFactor * $ptToMm);
+
+            return min(9.0, max(6.0, round($maxFontSizePt, 1)));
+        }
+
+        return 8.0;
+    }
+
+    /**
+     * @param list<DeckCard> $cards
+     */
+    private function sumQuantities(array $cards): int
+    {
+        $total = 0;
+        foreach ($cards as $card) {
+            $total += $card->getQuantity();
+        }
+
+        return $total;
+    }
+
+    private function buildTrigram(User $user): string
+    {
+        $first = mb_strtoupper(mb_substr($user->getFirstName(), 0, 1));
+        $lastName = $user->getLastName();
+        $lastFirst = mb_strtoupper(mb_substr($lastName, 0, 1));
+        $lastLast = mb_strlen($lastName) > 1 ? mb_strtoupper(mb_substr($lastName, -1, 1)) : '';
+
+        return $first.$lastFirst.$lastLast;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildLabels(string $locale): array
+    {
+        return [
+            'playerName' => $this->translator->trans('app.decklist.player_name', locale: $locale),
+            'playerId' => $this->translator->trans('app.decklist.player_id', locale: $locale),
+            'yearOfBirth' => $this->translator->trans('app.decklist.year_of_birth', locale: $locale),
+            'format' => $this->translator->trans('app.decklist.format', locale: $locale),
+            'totalCards' => $this->translator->trans('app.decklist.total_cards', locale: $locale),
+            'pokemon' => $this->translator->trans('app.decklist.section.pokemon', locale: $locale),
+            'trainer' => $this->translator->trans('app.decklist.section.trainer', locale: $locale),
+            'energy' => $this->translator->trans('app.decklist.section.energy', locale: $locale),
+        ];
+    }
+
+    private function translateSubtype(string $subtype, string $locale): string
+    {
+        $key = 'app.decklist.subtype.'.$subtype;
+
+        $translated = $this->translator->trans($key, locale: $locale);
+
+        // If the translation key is not found, fall back to titlecase subtype
+        return $translated !== $key ? $translated : ucfirst($subtype);
+    }
+
+    private function generateQrCode(string $content): string
+    {
+        $builder = new Builder();
+        $result = $builder->build(
+            data: $content,
+            errorCorrectionLevel: ErrorCorrectionLevel::Medium,
+            size: self::QR_CODE_SIZE_PX,
+            margin: 0,
+        );
+
+        return $result->getDataUri();
+    }
+
+    private function renderPdf(string $html): string
+    {
+        $options = new Options();
+        $options->setIsRemoteEnabled(false);
+        $options->setDefaultFont('Helvetica');
+
+        $dompdf = new Dompdf($options);
+        $dompdf->loadHtml($html);
+        $dompdf->setPaper('A4', 'portrait');
+        $dompdf->render();
+
+        return (string) $dompdf->output();
+    }
+}

--- a/src/Service/Label/PdfDecklistGenerator.php
+++ b/src/Service/Label/PdfDecklistGenerator.php
@@ -21,9 +21,6 @@ use App\Entity\User;
 use App\Repository\TcgdexCardRepository;
 use Dompdf\Dompdf;
 use Dompdf\Options;
-use Endroid\QrCode\Builder\Builder;
-use Endroid\QrCode\ErrorCorrectionLevel;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
@@ -37,8 +34,6 @@ use Twig\Environment;
  */
 class PdfDecklistGenerator
 {
-    private const int QR_CODE_SIZE_PX = 200;
-
     /** @var array<string, string> cached set symbol data URIs within one request */
     private array $symbolCache = [];
 
@@ -47,7 +42,6 @@ class PdfDecklistGenerator
 
     public function __construct(
         private readonly Environment $twig,
-        private readonly UrlGeneratorInterface $urlGenerator,
         private readonly HttpClientInterface $httpClient,
         private readonly TranslatorInterface $translator,
         private readonly TcgdexCardRepository $tcgdexCardRepository,
@@ -83,21 +77,14 @@ class PdfDecklistGenerator
         $currentVersion = $deck->getCurrentVersion();
         $locale = $user?->getPreferredLocale() ?? 'en';
 
-        $deckUrl = $this->urlGenerator->generate(
-            'app_deck_show',
-            ['short_tag' => $deck->getShortTag()],
-            UrlGeneratorInterface::ABSOLUTE_URL,
-        );
-
         $groupedCards = null !== $currentVersion
             ? $this->groupCardsForDecklist($currentVersion)
             : ['pokemon' => [], 'trainerGroups' => [], 'energy' => []];
 
         $setSymbolDataUris = $this->fetchSetSymbolDataUris($this->collectSetSymbolUrls($groupedCards['pokemon']));
         $gravatarDataUri = null !== $user ? $this->fetchGravatarDataUri($user->getEmail()) : null;
-        $qrCodeDataUri = $this->generateQrCode($deckUrl);
 
-        $templateData = $this->buildTemplateData($deck, $user, $groupedCards, $setSymbolDataUris, $gravatarDataUri, $qrCodeDataUri, $locale);
+        $templateData = $this->buildTemplateData($deck, $user, $groupedCards, $setSymbolDataUris, $gravatarDataUri, $locale);
 
         $html = $this->twig->render('label/pdf_decklist.html.twig', $templateData);
 
@@ -256,21 +243,19 @@ class PdfDecklistGenerator
         array $groupedCards,
         array $setSymbolDataUris,
         ?string $gravatarDataUri,
-        string $qrCodeDataUri,
         string $locale,
     ): array {
         $pokemonCards = $groupedCards['pokemon'];
         $trainerGroups = $groupedCards['trainerGroups'];
         $energyCards = $groupedCards['energy'];
 
-        // Count totals
+        // Count section totals
         $pokemonCount = $this->sumQuantities($pokemonCards);
         $trainerCount = 0;
         foreach ($trainerGroups as $cards) {
             $trainerCount += $this->sumQuantities($cards);
         }
         $energyCount = $this->sumQuantities($energyCards);
-        $totalCardCount = $pokemonCount + $trainerCount + $energyCount;
 
         // Build card view data with English name resolution
         $pokemonRows = $this->buildCardRows($pokemonCards, $locale, true, $setSymbolDataUris);
@@ -297,10 +282,7 @@ class PdfDecklistGenerator
             'yearOfBirth' => $user?->getYearOfBirth(),
             'trigram' => $trigram,
             'gravatarDataUri' => $gravatarDataUri,
-            'qrCodeDataUri' => $qrCodeDataUri,
             'format' => ucfirst($deck->getFormat()->value),
-            'deckName' => $deck->getName(),
-            'totalCardCount' => $totalCardCount,
             'pokemonCount' => $pokemonCount,
             'pokemonRows' => $pokemonRows,
             'trainerCount' => $trainerCount,
@@ -443,8 +425,6 @@ class PdfDecklistGenerator
             'playerName' => $this->translator->trans('app.decklist.player_name', locale: $locale),
             'playerId' => $this->translator->trans('app.decklist.player_id', locale: $locale),
             'yearOfBirth' => $this->translator->trans('app.decklist.year_of_birth', locale: $locale),
-            'format' => $this->translator->trans('app.decklist.format', locale: $locale),
-            'totalCards' => $this->translator->trans('app.decklist.total_cards', locale: $locale),
             'pokemon' => $this->translator->trans('app.decklist.section.pokemon', locale: $locale),
             'trainer' => $this->translator->trans('app.decklist.section.trainer', locale: $locale),
             'energy' => $this->translator->trans('app.decklist.section.energy', locale: $locale),
@@ -500,19 +480,6 @@ class PdfDecklistGenerator
         $localizedName = $names[$locale] ?? null;
 
         return \is_string($localizedName) ? $localizedName : null;
-    }
-
-    private function generateQrCode(string $content): string
-    {
-        $builder = new Builder();
-        $result = $builder->build(
-            data: $content,
-            errorCorrectionLevel: ErrorCorrectionLevel::Medium,
-            size: self::QR_CODE_SIZE_PX,
-            margin: 0,
-        );
-
-        return $result->getDataUri();
     }
 
     private function renderPdf(string $html): string

--- a/src/Service/Label/PdfDecklistGenerator.php
+++ b/src/Service/Label/PdfDecklistGenerator.php
@@ -75,7 +75,7 @@ class PdfDecklistGenerator
     private function generate(Deck $deck, ?User $user): string
     {
         $currentVersion = $deck->getCurrentVersion();
-        $locale = $user?->getPreferredLocale() ?? 'en';
+        $locale = $this->resolveDeckLocale($deck);
 
         $groupedCards = null !== $currentVersion
             ? $this->groupCardsForDecklist($currentVersion)
@@ -439,6 +439,19 @@ class PdfDecklistGenerator
 
         // If the translation key is not found, fall back to titlecase subtype
         return $translated !== $key ? $translated : ucfirst($subtype);
+    }
+
+    /**
+     * Resolve the locale for card names based on the deck's language list.
+     *
+     * If the deck has exactly one language set, use it (e.g. "fr").
+     * If multiple languages or none, default to English.
+     */
+    private function resolveDeckLocale(Deck $deck): string
+    {
+        $languages = $deck->getLanguages();
+
+        return 1 === \count($languages) ? $languages[0] : 'en';
     }
 
     /**

--- a/src/Service/Label/PdfDecklistGenerator.php
+++ b/src/Service/Label/PdfDecklistGenerator.php
@@ -16,6 +16,7 @@ namespace App\Service\Label;
 use App\Entity\Deck;
 use App\Entity\DeckCard;
 use App\Entity\DeckVersion;
+use App\Entity\TcgdexCard;
 use App\Entity\User;
 use Dompdf\Dompdf;
 use Dompdf\Options;
@@ -317,10 +318,22 @@ class PdfDecklistGenerator
         $rows = [];
 
         foreach ($cards as $card) {
+            $tcgdexCard = $card->getCardPrinting()?->getTcgdexCard();
+
+            // Resolve the display name in the user's locale
+            $displayName = $card->getCardName();
             $englishName = null;
-            if ('en' !== $locale && 'en' !== $card->getCardLocale()) {
-                $nameEn = $card->getCardPrinting()?->getTcgdexCard()?->getNameEn();
-                if (null !== $nameEn && $nameEn !== $card->getCardName()) {
+
+            if ('en' !== $locale && null !== $tcgdexCard) {
+                // Try to get the localized name (e.g. nameFr for French users)
+                $localizedName = $this->getLocalizedCardName($tcgdexCard, $locale);
+                if (null !== $localizedName) {
+                    $displayName = $localizedName;
+                }
+
+                // Show English name as subline if it differs from the displayed name
+                $nameEn = $tcgdexCard->getNameEn();
+                if (null !== $nameEn && $nameEn !== $displayName) {
                     $englishName = $nameEn;
                 }
             }
@@ -336,7 +349,7 @@ class PdfDecklistGenerator
             }
 
             $rows[] = [
-                'name' => $card->getCardName(),
+                'name' => $displayName,
                 'englishName' => $englishName,
                 'quantity' => $card->getQuantity(),
                 'setCode' => $ptcgCode,
@@ -383,8 +396,8 @@ class PdfDecklistGenerator
         $sectionHeaderLines = 3.0;
         $totalLines += $sectionHeaderLines;
 
-        // Available height: A4 (297mm) - margins (20mm) - header (40mm) = ~237mm
-        $availableHeightMm = 237.0;
+        // Available height: A4 (297mm) - margins (22mm) - header (40mm) = ~235mm
+        $availableHeightMm = 235.0;
         $lineHeightFactor = 1.35;
         $ptToMm = 0.353;
 
@@ -445,6 +458,26 @@ class PdfDecklistGenerator
 
         // If the translation key is not found, fall back to titlecase subtype
         return $translated !== $key ? $translated : ucfirst($subtype);
+    }
+
+    /**
+     * Get the card name in the user's locale from TCGdex data.
+     *
+     * Returns null if no localized name is available for the requested locale,
+     * letting the caller fall back to the original DeckCard.cardName.
+     */
+    private function getLocalizedCardName(TcgdexCard $tcgdexCard, string $locale): ?string
+    {
+        $localizedName = $tcgdexCard->getLocalizedName($locale);
+
+        // getLocalizedName falls back to English — only return if we got the requested locale
+        $nameEn = $tcgdexCard->getNameEn();
+        if (null !== $localizedName && $localizedName !== $nameEn) {
+            return $localizedName;
+        }
+
+        // If the localized name equals English, the translation doesn't exist for this locale
+        return null;
     }
 
     private function generateQrCode(string $content): string

--- a/templates/deck/show.html.twig
+++ b/templates/deck/show.html.twig
@@ -117,6 +117,8 @@
                                     <li><a class="dropdown-item" href="{{ path('app_deck_label_pdf', {short_tag: deck.shortTag}) }}" target="_blank">{{ 'app.deck.label_pdf'|trans }}</a></li>
                                     {% if deck.currentVersion %}
                                         <li><a class="dropdown-item" href="{{ path('app_deck_label_foldable_pdf', {short_tag: deck.shortTag}) }}" target="_blank">{{ 'app.deck.label_foldable_pdf'|trans }}</a></li>
+                                        <li><a class="dropdown-item" href="{{ path('app_deck_decklist_pdf', {short_tag: deck.shortTag}) }}" target="_blank">{{ 'app.deck.decklist_pdf'|trans }}</a></li>
+                                        <li><a class="dropdown-item" href="{{ path('app_deck_decklist_pdf', {short_tag: deck.shortTag, anonymous: 1}) }}" target="_blank">{{ 'app.deck.decklist_pdf_anonymous'|trans }}</a></li>
                                     {% endif %}
                                     {% if deck.status.value != 'lent' %}
                                         <li><hr class="dropdown-divider"></li>

--- a/templates/label/pdf_decklist.html.twig
+++ b/templates/label/pdf_decklist.html.twig
@@ -34,72 +34,52 @@
         /* ── Header ──────────────────────────── */
 
         .header {
-            margin-bottom: 4mm;
-            border-bottom: 0.5mm solid #333;
-            padding-bottom: 3mm;
+            margin-bottom: 3mm;
+            border-bottom: 0.3mm solid #999;
+            padding-bottom: 2mm;
         }
 
-        .header-top {
+        .header-table {
             width: 100%;
         }
 
-        .header-left {
-            width: 20mm;
-            vertical-align: top;
-        }
-
-        .header-center {
-            vertical-align: top;
-            padding-left: 3mm;
-        }
-
-        .header-right {
-            width: 22mm;
-            vertical-align: top;
-            text-align: center;
-        }
-
-        .qr-code {
-            width: 18mm;
-            height: 18mm;
-        }
-
         .gravatar {
-            width: 16mm;
-            height: 16mm;
-            border-radius: 2mm;
+            width: 10mm;
+            height: 10mm;
+            border-radius: 1mm;
+            vertical-align: middle;
+            margin-right: 2mm;
         }
 
         .trigram {
-            font-size: 18pt;
+            font-size: 16pt;
             font-weight: bold;
             letter-spacing: 1pt;
             color: #333;
-            border: 0.4mm solid #999;
-            padding: 2mm 3mm;
+            border: 0.3mm solid #999;
+            padding: 1mm 2mm;
             display: inline-block;
-            min-width: 16mm;
+            min-width: 14mm;
             text-align: center;
+            vertical-align: middle;
         }
 
         .trigram-blank {
-            font-size: 18pt;
-            border: 0.4mm solid #999;
-            padding: 2mm 3mm;
+            border: 0.3mm solid #999;
             display: inline-block;
-            width: 16mm;
-            height: 7mm;
+            width: 14mm;
+            height: 6mm;
+            vertical-align: middle;
         }
 
         .field-label {
-            font-size: 7pt;
-            color: #666;
+            font-size: 6.5pt;
+            color: #888;
             text-transform: uppercase;
-            letter-spacing: 0.3pt;
         }
 
         .field-value {
-            font-size: 9pt;
+            font-size: 8pt;
             font-weight: bold;
             color: #111;
         }
@@ -107,39 +87,37 @@
         .field-blank {
             border-bottom: 0.3mm solid #999;
             display: inline-block;
-            width: 40mm;
-            height: 4mm;
+            width: 25mm;
+            height: 3mm;
         }
 
-        .deck-name {
-            font-size: 8pt;
-            color: #555;
-            font-style: italic;
+        .field-blank-short {
+            border-bottom: 0.3mm solid #999;
+            display: inline-block;
+            width: 12mm;
+            height: 3mm;
         }
 
-        .meta-row {
-            margin-top: 1mm;
-        }
-
-        .meta-badge {
+        .format-badge {
             font-size: 7pt;
-            padding: 0.5mm 2mm;
+            padding: 0.3mm 1.5mm;
             background: #e9e9e9;
             border-radius: 1mm;
             display: inline-block;
+            vertical-align: middle;
         }
 
         /* ── Card Sections ───────────────────── */
 
         .section-header {
-            font-size: {{ fontSize + 1 }}pt;
+            font-size: {{ fontSize }}pt;
             font-weight: bold;
             text-transform: uppercase;
-            background: #333;
-            color: #fff;
-            padding: 1mm 2mm;
-            margin-top: 2mm;
-            margin-bottom: 0.5mm;
+            background: #d0d0d0;
+            color: #222;
+            padding: 0.5mm 2mm;
+            margin-top: 1.5mm;
+            margin-bottom: 0.3mm;
         }
 
         .subtype-header {
@@ -168,19 +146,19 @@
             width: 8mm;
             text-align: center;
             font-weight: bold;
-            vertical-align: top;
+            vertical-align: middle;
             padding: 0.3mm 1mm;
         }
 
         .col-name {
-            vertical-align: top;
+            vertical-align: middle;
             padding: 0.3mm 1mm;
         }
 
         .col-set {
             width: 28mm;
             text-align: right;
-            vertical-align: top;
+            vertical-align: middle;
             padding: 0.3mm 1mm;
             color: #555;
             font-size: {{ fontSize - 0.5 }}pt;
@@ -189,7 +167,7 @@
         .col-check {
             width: 22mm;
             text-align: right;
-            vertical-align: top;
+            vertical-align: middle;
             padding: 0.3mm 1mm;
         }
 
@@ -218,49 +196,40 @@
 </head>
 <body>
 
-    {# ── Header ──────────────────────────────────── #}
+    {# ── Header — single line: gravatar + player info + format + trigram ── #}
     <div class="header">
-        <table class="header-top" cellspacing="0" cellpadding="0">
+        <table class="header-table" cellspacing="0" cellpadding="0">
             <tr>
-                <td class="header-left">
+                <td style="width: 12mm; vertical-align: middle;">
                     {% if gravatarDataUri %}
                         <img class="gravatar" src="{{ gravatarDataUri }}" alt="">
                     {% endif %}
-                    <br>
-                    <img class="qr-code" src="{{ qrCodeDataUri }}" alt="QR">
                 </td>
-                <td class="header-center">
-                    <div>
-                        <span class="field-label">{{ labels.playerName }}</span><br>
-                        {% if mode == 'personal' and playerName %}
-                            <span class="field-value">{{ playerName }}</span>
-                        {% else %}
-                            <span class="field-blank"></span>
-                        {% endif %}
-                    </div>
-                    <div style="margin-top: 1.5mm;">
-                        <span class="field-label">{{ labels.playerId }}</span><br>
-                        {% if mode == 'personal' and playerId %}
-                            <span class="field-value">{{ playerId }}</span>
-                        {% else %}
-                            <span class="field-blank"></span>
-                        {% endif %}
-                    </div>
-                    <div style="margin-top: 1.5mm;">
-                        <span class="field-label">{{ labels.yearOfBirth }}</span><br>
-                        {% if mode == 'personal' and yearOfBirth %}
-                            <span class="field-value">{{ yearOfBirth }}</span>
-                        {% else %}
-                            <span class="field-blank" style="width: 20mm;"></span>
-                        {% endif %}
-                    </div>
-                    <div class="meta-row">
-                        <span class="meta-badge">{{ labels.format }}: {{ format }}</span>
-                        <span class="meta-badge">{{ labels.totalCards }}: {{ totalCardCount }}</span>
-                        <span class="deck-name">{{ deckName }}</span>
-                    </div>
+                <td style="vertical-align: middle; padding-left: 2mm;">
+                    <span class="field-label">{{ labels.playerName }}</span>
+                    {% if mode == 'personal' and playerName %}
+                        <span class="field-value">{{ playerName }}</span>
+                    {% else %}
+                        <span class="field-blank"></span>
+                    {% endif %}
+
+                    <span class="field-label" style="margin-left: 3mm;">{{ labels.playerId }}</span>
+                    {% if mode == 'personal' and playerId %}
+                        <span class="field-value">{{ playerId }}</span>
+                    {% else %}
+                        <span class="field-blank" style="width: 18mm;"></span>
+                    {% endif %}
+
+                    <span class="field-label" style="margin-left: 3mm;">{{ labels.yearOfBirth }}</span>
+                    {% if mode == 'personal' and yearOfBirth %}
+                        <span class="field-value">{{ yearOfBirth }}</span>
+                    {% else %}
+                        <span class="field-blank-short"></span>
+                    {% endif %}
+
+                    <span class="format-badge" style="margin-left: 3mm;">{{ format }}</span>
                 </td>
-                <td class="header-right">
+                <td style="width: 20mm; text-align: right; vertical-align: middle;">
                     {% if mode == 'personal' and trigram %}
                         <span class="trigram">{{ trigram }}</span>
                     {% else %}

--- a/templates/label/pdf_decklist.html.twig
+++ b/templates/label/pdf_decklist.html.twig
@@ -15,7 +15,7 @@
     <style>
         @page {
             size: A4 portrait;
-            margin: 8mm 8mm 6mm 8mm;
+            margin: 12mm 12mm 10mm 12mm;
         }
 
         * {
@@ -160,7 +160,7 @@
         }
 
         .card-row-alt {
-            background: #f8f8f8;
+            background: #eaeaea;
         }
 
         .col-qty {
@@ -186,12 +186,18 @@
         }
 
         .col-check {
-            width: 20mm;
+            width: 22mm;
             text-align: right;
             vertical-align: top;
             padding: 0.3mm 1mm;
-            letter-spacing: 0.5pt;
-            color: #888;
+        }
+
+        .checkbox {
+            display: inline-block;
+            width: 3mm;
+            height: 3mm;
+            border: 0.3mm solid #555;
+            margin-left: 0.8mm;
         }
 
         .english-subline {
@@ -283,7 +289,7 @@
                         {% endif %}
                         {{ row.setCode }}-{{ row.cardNumber }}
                     </td>
-                    <td class="col-check">{% for i in 1..row.quantity %}○{% endfor %}</td>
+                    <td class="col-check">{% for i in 1..row.quantity %}<span class="checkbox"></span>{% endfor %}</td>
                 </tr>
             {% endfor %}
         </table>
@@ -307,7 +313,7 @@
                             {% endif %}
                         </td>
                         <td class="col-set"></td>
-                        <td class="col-check">{% for i in 1..row.quantity %}○{% endfor %}</td>
+                        <td class="col-check">{% for i in 1..row.quantity %}<span class="checkbox"></span>{% endfor %}</td>
                     </tr>
                 {% endfor %}
             </table>
@@ -328,7 +334,7 @@
                         {% endif %}
                     </td>
                     <td class="col-set"></td>
-                    <td class="col-check">{% for i in 1..row.quantity %}○{% endfor %}</td>
+                    <td class="col-check">{% for i in 1..row.quantity %}<span class="checkbox"></span>{% endfor %}</td>
                 </tr>
             {% endfor %}
         </table>

--- a/templates/label/pdf_decklist.html.twig
+++ b/templates/label/pdf_decklist.html.twig
@@ -196,48 +196,56 @@
 </head>
 <body>
 
-    {# ── Header — single line: gravatar + player info + format + trigram ── #}
+    {# ── Header ── #}
     <div class="header">
-        <table class="header-table" cellspacing="0" cellpadding="0">
-            <tr>
-                <td style="width: 12mm; vertical-align: middle;">
-                    {% if gravatarDataUri %}
-                        <img class="gravatar" src="{{ gravatarDataUri }}" alt="">
-                    {% endif %}
-                </td>
-                <td style="vertical-align: middle; padding-left: 2mm;">
-                    <span class="field-label">{{ labels.playerName }}</span>
-                    {% if mode == 'personal' and playerName %}
+        {% if mode == 'personal' %}
+            {# Personal: compact single line #}
+            <table class="header-table" cellspacing="0" cellpadding="0">
+                <tr>
+                    <td style="width: 12mm; vertical-align: middle;">
+                        {% if gravatarDataUri %}
+                            <img class="gravatar" src="{{ gravatarDataUri }}" alt="">
+                        {% endif %}
+                    </td>
+                    <td style="vertical-align: middle; padding-left: 2mm;">
+                        <span class="field-label">{{ labels.playerName }}</span>
                         <span class="field-value">{{ playerName }}</span>
-                    {% else %}
-                        <span class="field-blank"></span>
-                    {% endif %}
 
-                    <span class="field-label" style="margin-left: 3mm;">{{ labels.playerId }}</span>
-                    {% if mode == 'personal' and playerId %}
-                        <span class="field-value">{{ playerId }}</span>
-                    {% else %}
-                        <span class="field-blank" style="width: 18mm;"></span>
-                    {% endif %}
+                        <span class="field-label" style="margin-left: 3mm;">{{ labels.playerId }}</span>
+                        <span class="field-value">{{ playerId ?? '' }}</span>
 
-                    <span class="field-label" style="margin-left: 3mm;">{{ labels.yearOfBirth }}</span>
-                    {% if mode == 'personal' and yearOfBirth %}
-                        <span class="field-value">{{ yearOfBirth }}</span>
-                    {% else %}
-                        <span class="field-blank-short"></span>
-                    {% endif %}
+                        <span class="field-label" style="margin-left: 3mm;">{{ labels.yearOfBirth }}</span>
+                        <span class="field-value">{{ yearOfBirth ?? '' }}</span>
 
-                    <span class="format-badge" style="margin-left: 3mm;">{{ format }}</span>
-                </td>
-                <td style="width: 20mm; text-align: right; vertical-align: middle;">
-                    {% if mode == 'personal' and trigram %}
+                        <span class="format-badge" style="margin-left: 3mm;">{{ format }}</span>
+                    </td>
+                    <td style="width: 20mm; text-align: right; vertical-align: middle;">
                         <span class="trigram">{{ trigram }}</span>
-                    {% else %}
+                    </td>
+                </tr>
+            </table>
+        {% else %}
+            {# Anonymous: full-width blanks for handwriting #}
+            <table class="header-table" cellspacing="0" cellpadding="0">
+                <tr>
+                    <td style="vertical-align: middle;">
+                        <span class="field-label">{{ labels.playerName }}</span>
+                        <span class="field-blank" style="width: 80mm;"></span>
+
+                        <span class="field-label" style="margin-left: 4mm;">{{ labels.playerId }}</span>
+                        <span class="field-blank" style="width: 25mm;"></span>
+
+                        <span class="field-label" style="margin-left: 4mm;">{{ labels.yearOfBirth }}</span>
+                        <span class="field-blank-short"></span>
+
+                        <span class="format-badge" style="margin-left: 3mm;">{{ format }}</span>
+                    </td>
+                    <td style="width: 20mm; text-align: right; vertical-align: middle;">
                         <span class="trigram-blank"></span>
-                    {% endif %}
-                </td>
-            </tr>
-        </table>
+                    </td>
+                </tr>
+            </table>
+        {% endif %}
     </div>
 
     {# ── Pokemon Section ─────────────────────────── #}

--- a/templates/label/pdf_decklist.html.twig
+++ b/templates/label/pdf_decklist.html.twig
@@ -28,6 +28,7 @@
             font-size: {{ fontSize }}pt;
             line-height: 1.35;
             color: #222;
+            background: #fff;
         }
 
         /* ── Header ──────────────────────────── */
@@ -194,10 +195,11 @@
 
         .checkbox {
             display: inline-block;
-            width: 3mm;
-            height: 3mm;
-            border: 0.3mm solid #555;
-            margin-left: 0.8mm;
+            width: 2.5mm;
+            height: 2.5mm;
+            border: 0.3mm solid #444;
+            margin-left: 0.6mm;
+            vertical-align: middle;
         }
 
         .english-subline {

--- a/templates/label/pdf_decklist.html.twig
+++ b/templates/label/pdf_decklist.html.twig
@@ -98,14 +98,6 @@
             height: 3mm;
         }
 
-        .format-badge {
-            font-size: 7pt;
-            padding: 0.3mm 1.5mm;
-            background: #e9e9e9;
-            border-radius: 1mm;
-            display: inline-block;
-            vertical-align: middle;
-        }
 
         /* ── Card Sections ───────────────────── */
 
@@ -216,8 +208,6 @@
 
                         <span class="field-label" style="margin-left: 3mm;">{{ labels.yearOfBirth }}</span>
                         <span class="field-value">{{ yearOfBirth ?? '' }}</span>
-
-                        <span class="format-badge" style="margin-left: 3mm;">{{ format }}</span>
                     </td>
                     <td style="width: 20mm; text-align: right; vertical-align: middle;">
                         <span class="trigram">{{ trigram }}</span>
@@ -237,8 +227,6 @@
 
                         <span class="field-label" style="margin-left: 4mm;">{{ labels.yearOfBirth }}</span>
                         <span class="field-blank-short"></span>
-
-                        <span class="format-badge" style="margin-left: 3mm;">{{ format }}</span>
                     </td>
                     <td style="width: 20mm; text-align: right; vertical-align: middle;">
                         <span class="trigram-blank"></span>

--- a/templates/label/pdf_decklist.html.twig
+++ b/templates/label/pdf_decklist.html.twig
@@ -202,11 +202,10 @@
             vertical-align: middle;
         }
 
-        .english-subline {
-            font-size: {{ fontSize - 1.5 }}pt;
+        .english-inline {
+            font-size: {{ fontSize - 1 }}pt;
             color: #888;
             font-style: italic;
-            padding-left: 3mm;
         }
 
         .set-symbol {
@@ -280,10 +279,7 @@
                 <tr class="card-row {{ loop.index is odd ? '' : 'card-row-alt' }}">
                     <td class="col-qty">{{ row.quantity }}</td>
                     <td class="col-name">
-                        {{ row.name }}
-                        {% if row.englishName %}
-                            <br><span class="english-subline">({{ row.englishName }})</span>
-                        {% endif %}
+                        {{ row.name }}{% if row.englishName %} <span class="english-inline">({{ row.englishName }})</span>{% endif %}
                     </td>
                     <td class="col-set">
                         {% if row.symbolDataUri %}
@@ -330,10 +326,7 @@
                 <tr class="card-row {{ loop.index is odd ? '' : 'card-row-alt' }}">
                     <td class="col-qty">{{ row.quantity }}</td>
                     <td class="col-name">
-                        {{ row.name }}
-                        {% if row.englishName %}
-                            <br><span class="english-subline">({{ row.englishName }})</span>
-                        {% endif %}
+                        {{ row.name }}{% if row.englishName %} <span class="english-inline">({{ row.englishName }})</span>{% endif %}
                     </td>
                     <td class="col-set"></td>
                     <td class="col-check">{% for i in 1..row.quantity %}<span class="checkbox"></span>{% endfor %}</td>

--- a/templates/label/pdf_decklist.html.twig
+++ b/templates/label/pdf_decklist.html.twig
@@ -305,10 +305,7 @@
                     <tr class="card-row {{ loop.index is odd ? '' : 'card-row-alt' }}">
                         <td class="col-qty">{{ row.quantity }}</td>
                         <td class="col-name">
-                            {{ row.name }}
-                            {% if row.englishName %}
-                                <br><span class="english-subline">({{ row.englishName }})</span>
-                            {% endif %}
+                            {{ row.name }}{% if row.englishName %} <span class="english-inline">({{ row.englishName }})</span>{% endif %}
                         </td>
                         <td class="col-set"></td>
                         <td class="col-check">{% for i in 1..row.quantity %}<span class="checkbox"></span>{% endfor %}</td>

--- a/templates/label/pdf_decklist.html.twig
+++ b/templates/label/pdf_decklist.html.twig
@@ -1,0 +1,338 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #
+ # @see docs/features.md F5.13 — Printable A4 decklist PDF
+ #}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        @page {
+            size: A4 portrait;
+            margin: 8mm 8mm 6mm 8mm;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: Helvetica, Arial, sans-serif;
+            font-size: {{ fontSize }}pt;
+            line-height: 1.35;
+            color: #222;
+        }
+
+        /* ── Header ──────────────────────────── */
+
+        .header {
+            margin-bottom: 4mm;
+            border-bottom: 0.5mm solid #333;
+            padding-bottom: 3mm;
+        }
+
+        .header-top {
+            width: 100%;
+        }
+
+        .header-left {
+            width: 20mm;
+            vertical-align: top;
+        }
+
+        .header-center {
+            vertical-align: top;
+            padding-left: 3mm;
+        }
+
+        .header-right {
+            width: 22mm;
+            vertical-align: top;
+            text-align: center;
+        }
+
+        .qr-code {
+            width: 18mm;
+            height: 18mm;
+        }
+
+        .gravatar {
+            width: 16mm;
+            height: 16mm;
+            border-radius: 2mm;
+        }
+
+        .trigram {
+            font-size: 18pt;
+            font-weight: bold;
+            letter-spacing: 1pt;
+            color: #333;
+            border: 0.4mm solid #999;
+            padding: 2mm 3mm;
+            display: inline-block;
+            min-width: 16mm;
+            text-align: center;
+        }
+
+        .trigram-blank {
+            font-size: 18pt;
+            border: 0.4mm solid #999;
+            padding: 2mm 3mm;
+            display: inline-block;
+            width: 16mm;
+            height: 7mm;
+        }
+
+        .field-label {
+            font-size: 7pt;
+            color: #666;
+            text-transform: uppercase;
+            letter-spacing: 0.3pt;
+        }
+
+        .field-value {
+            font-size: 9pt;
+            font-weight: bold;
+            color: #111;
+        }
+
+        .field-blank {
+            border-bottom: 0.3mm solid #999;
+            display: inline-block;
+            width: 40mm;
+            height: 4mm;
+        }
+
+        .deck-name {
+            font-size: 8pt;
+            color: #555;
+            font-style: italic;
+        }
+
+        .meta-row {
+            margin-top: 1mm;
+        }
+
+        .meta-badge {
+            font-size: 7pt;
+            padding: 0.5mm 2mm;
+            background: #e9e9e9;
+            border-radius: 1mm;
+            display: inline-block;
+        }
+
+        /* ── Card Sections ───────────────────── */
+
+        .section-header {
+            font-size: {{ fontSize + 1 }}pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            background: #333;
+            color: #fff;
+            padding: 1mm 2mm;
+            margin-top: 2mm;
+            margin-bottom: 0.5mm;
+        }
+
+        .subtype-header {
+            font-size: {{ fontSize - 0.5 }}pt;
+            font-weight: bold;
+            color: #555;
+            padding: 0.5mm 2mm;
+            border-bottom: 0.2mm solid #ccc;
+            font-style: italic;
+        }
+
+        .card-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .card-row {
+            border-bottom: 0.1mm solid #eee;
+        }
+
+        .card-row-alt {
+            background: #f8f8f8;
+        }
+
+        .col-qty {
+            width: 8mm;
+            text-align: center;
+            font-weight: bold;
+            vertical-align: top;
+            padding: 0.3mm 1mm;
+        }
+
+        .col-name {
+            vertical-align: top;
+            padding: 0.3mm 1mm;
+        }
+
+        .col-set {
+            width: 28mm;
+            text-align: right;
+            vertical-align: top;
+            padding: 0.3mm 1mm;
+            color: #555;
+            font-size: {{ fontSize - 0.5 }}pt;
+        }
+
+        .col-check {
+            width: 20mm;
+            text-align: right;
+            vertical-align: top;
+            padding: 0.3mm 1mm;
+            letter-spacing: 0.5pt;
+            color: #888;
+        }
+
+        .english-subline {
+            font-size: {{ fontSize - 1.5 }}pt;
+            color: #888;
+            font-style: italic;
+            padding-left: 3mm;
+        }
+
+        .set-symbol {
+            width: 3.5mm;
+            height: 3.5mm;
+            vertical-align: middle;
+            margin-right: 0.5mm;
+        }
+    </style>
+</head>
+<body>
+
+    {# ── Header ──────────────────────────────────── #}
+    <div class="header">
+        <table class="header-top" cellspacing="0" cellpadding="0">
+            <tr>
+                <td class="header-left">
+                    {% if gravatarDataUri %}
+                        <img class="gravatar" src="{{ gravatarDataUri }}" alt="">
+                    {% endif %}
+                    <br>
+                    <img class="qr-code" src="{{ qrCodeDataUri }}" alt="QR">
+                </td>
+                <td class="header-center">
+                    <div>
+                        <span class="field-label">{{ labels.playerName }}</span><br>
+                        {% if mode == 'personal' and playerName %}
+                            <span class="field-value">{{ playerName }}</span>
+                        {% else %}
+                            <span class="field-blank"></span>
+                        {% endif %}
+                    </div>
+                    <div style="margin-top: 1.5mm;">
+                        <span class="field-label">{{ labels.playerId }}</span><br>
+                        {% if mode == 'personal' and playerId %}
+                            <span class="field-value">{{ playerId }}</span>
+                        {% else %}
+                            <span class="field-blank"></span>
+                        {% endif %}
+                    </div>
+                    <div style="margin-top: 1.5mm;">
+                        <span class="field-label">{{ labels.yearOfBirth }}</span><br>
+                        {% if mode == 'personal' and yearOfBirth %}
+                            <span class="field-value">{{ yearOfBirth }}</span>
+                        {% else %}
+                            <span class="field-blank" style="width: 20mm;"></span>
+                        {% endif %}
+                    </div>
+                    <div class="meta-row">
+                        <span class="meta-badge">{{ labels.format }}: {{ format }}</span>
+                        <span class="meta-badge">{{ labels.totalCards }}: {{ totalCardCount }}</span>
+                        <span class="deck-name">{{ deckName }}</span>
+                    </div>
+                </td>
+                <td class="header-right">
+                    {% if mode == 'personal' and trigram %}
+                        <span class="trigram">{{ trigram }}</span>
+                    {% else %}
+                        <span class="trigram-blank"></span>
+                    {% endif %}
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    {# ── Pokemon Section ─────────────────────────── #}
+    {% if pokemonRows is not empty %}
+        <div class="section-header">{{ labels.pokemon }} ({{ pokemonCount }})</div>
+        <table class="card-table" cellspacing="0" cellpadding="0">
+            {% for row in pokemonRows %}
+                <tr class="card-row {{ loop.index is odd ? '' : 'card-row-alt' }}">
+                    <td class="col-qty">{{ row.quantity }}</td>
+                    <td class="col-name">
+                        {{ row.name }}
+                        {% if row.englishName %}
+                            <br><span class="english-subline">({{ row.englishName }})</span>
+                        {% endif %}
+                    </td>
+                    <td class="col-set">
+                        {% if row.symbolDataUri %}
+                            <img class="set-symbol" src="{{ row.symbolDataUri }}" alt="">
+                        {% endif %}
+                        {{ row.setCode }}-{{ row.cardNumber }}
+                    </td>
+                    <td class="col-check">{% for i in 1..row.quantity %}○{% endfor %}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% endif %}
+
+    {# ── Trainer Section ─────────────────────────── #}
+    {% if trainerSections is not empty %}
+        <div class="section-header">{{ labels.trainer }} ({{ trainerCount }})</div>
+        {% for section in trainerSections %}
+            {% if trainerSections|length > 1 %}
+                <div class="subtype-header">{{ section.label }}</div>
+            {% endif %}
+            <table class="card-table" cellspacing="0" cellpadding="0">
+                {% for row in section.rows %}
+                    <tr class="card-row {{ loop.index is odd ? '' : 'card-row-alt' }}">
+                        <td class="col-qty">{{ row.quantity }}</td>
+                        <td class="col-name">
+                            {{ row.name }}
+                            {% if row.englishName %}
+                                <br><span class="english-subline">({{ row.englishName }})</span>
+                            {% endif %}
+                        </td>
+                        <td class="col-set"></td>
+                        <td class="col-check">{% for i in 1..row.quantity %}○{% endfor %}</td>
+                    </tr>
+                {% endfor %}
+            </table>
+        {% endfor %}
+    {% endif %}
+
+    {# ── Energy Section ──────────────────────────── #}
+    {% if energyRows is not empty %}
+        <div class="section-header">{{ labels.energy }} ({{ energyCount }})</div>
+        <table class="card-table" cellspacing="0" cellpadding="0">
+            {% for row in energyRows %}
+                <tr class="card-row {{ loop.index is odd ? '' : 'card-row-alt' }}">
+                    <td class="col-qty">{{ row.quantity }}</td>
+                    <td class="col-name">
+                        {{ row.name }}
+                        {% if row.englishName %}
+                            <br><span class="english-subline">({{ row.englishName }})</span>
+                        {% endif %}
+                    </td>
+                    <td class="col-set"></td>
+                    <td class="col-check">{% for i in 1..row.quantity %}○{% endfor %}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% endif %}
+
+</body>
+</html>

--- a/templates/profile/edit.html.twig
+++ b/templates/profile/edit.html.twig
@@ -28,6 +28,7 @@
                         {{ form_row(form.lastName) }}
                         {{ form_row(form.screenName) }}
                         {{ form_row(form.playerId) }}
+                        {{ form_row(form.yearOfBirth) }}
                         {{ form_row(form.discordUsername) }}
 
                         <hr>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -525,6 +525,16 @@
                 <target>Label+</target>
                 <note>Button to download foldable PDF label with deck list on the back</note>
             </trans-unit>
+            <trans-unit id="app.deck.decklist_pdf">
+                <source>app.deck.decklist_pdf</source>
+                <target>Decklist PDF</target>
+                <note>Button to download A4 decklist PDF with player info filled</note>
+            </trans-unit>
+            <trans-unit id="app.deck.decklist_pdf_anonymous">
+                <source>app.deck.decklist_pdf_anonymous</source>
+                <target>Decklist PDF (blank)</target>
+                <note>Button to download A4 decklist PDF with blank player fields</note>
+            </trans-unit>
             <trans-unit id="app.deck.retire">
                 <source>app.deck.retire</source>
                 <target>Retire</target>
@@ -2556,6 +2566,16 @@
                 <source>app.form.label.player_id</source>
                 <target>Player ID (optional)</target>
                 <note>Form label for player ID field</note>
+            </trans-unit>
+            <trans-unit id="app.form.label.year_of_birth">
+                <source>app.form.label.year_of_birth</source>
+                <target>Year of birth (optional)</target>
+                <note>Form label for year of birth field in profile</note>
+            </trans-unit>
+            <trans-unit id="app.form.help.year_of_birth">
+                <source>app.form.help.year_of_birth</source>
+                <target>Used on tournament decklist PDFs.</target>
+                <note>Help text for year of birth field</note>
             </trans-unit>
             <trans-unit id="app.form.label.preferred_locale">
                 <source>app.form.label.preferred_locale</source>
@@ -5237,6 +5257,73 @@
                 <source>app.search.navbar_no_results</source>
                 <target>No results</target>
                 <note>Navbar autocomplete: empty state</note>
+            </trans-unit>
+
+            <!-- Decklist PDF (F5.13) -->
+            <trans-unit id="app.decklist.player_name">
+                <source>app.decklist.player_name</source>
+                <target>Player Name</target>
+                <note>PDF decklist field label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.player_id">
+                <source>app.decklist.player_id</source>
+                <target>Player ID</target>
+                <note>PDF decklist field label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.year_of_birth">
+                <source>app.decklist.year_of_birth</source>
+                <target>Year of Birth</target>
+                <note>PDF decklist field label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.format">
+                <source>app.decklist.format</source>
+                <target>Format</target>
+                <note>PDF decklist field label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.total_cards">
+                <source>app.decklist.total_cards</source>
+                <target>Total</target>
+                <note>PDF decklist total card count label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.section.pokemon">
+                <source>app.decklist.section.pokemon</source>
+                <target>Pokemon</target>
+                <note>PDF decklist section header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.section.trainer">
+                <source>app.decklist.section.trainer</source>
+                <target>Trainer</target>
+                <note>PDF decklist section header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.section.energy">
+                <source>app.decklist.section.energy</source>
+                <target>Energy</target>
+                <note>PDF decklist section header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.supporter">
+                <source>app.decklist.subtype.supporter</source>
+                <target>Supporter</target>
+                <note>PDF decklist trainer subtype header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.item">
+                <source>app.decklist.subtype.item</source>
+                <target>Item</target>
+                <note>PDF decklist trainer subtype header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.tool">
+                <source>app.decklist.subtype.tool</source>
+                <target>Tool</target>
+                <note>PDF decklist trainer subtype header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.stadium">
+                <source>app.decklist.subtype.stadium</source>
+                <target>Stadium</target>
+                <note>PDF decklist trainer subtype header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.technical machine">
+                <source>app.decklist.subtype.technical machine</source>
+                <target>Technical Machine</target>
+                <note>PDF decklist trainer subtype header</note>
             </trans-unit>
         </body>
     </file>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -525,6 +525,16 @@
                 <target>Étiquette+</target>
                 <note>Button to download foldable PDF label with deck list on the back</note>
             </trans-unit>
+            <trans-unit id="app.deck.decklist_pdf">
+                <source>app.deck.decklist_pdf</source>
+                <target>Decklist PDF</target>
+                <note>Button to download A4 decklist PDF with player info filled</note>
+            </trans-unit>
+            <trans-unit id="app.deck.decklist_pdf_anonymous">
+                <source>app.deck.decklist_pdf_anonymous</source>
+                <target>Decklist PDF (vierge)</target>
+                <note>Button to download A4 decklist PDF with blank player fields</note>
+            </trans-unit>
             <trans-unit id="app.deck.retire">
                 <source>app.deck.retire</source>
                 <target>Retirer</target>
@@ -2541,6 +2551,16 @@
                 <source>app.form.label.player_id</source>
                 <target>ID Pokemon (optionnel)</target>
                 <note>Form label for player ID field</note>
+            </trans-unit>
+            <trans-unit id="app.form.label.year_of_birth">
+                <source>app.form.label.year_of_birth</source>
+                <target>Année de naissance (optionnel)</target>
+                <note>Form label for year of birth field in profile</note>
+            </trans-unit>
+            <trans-unit id="app.form.help.year_of_birth">
+                <source>app.form.help.year_of_birth</source>
+                <target>Utilisé sur les decklists PDF de tournoi.</target>
+                <note>Help text for year of birth field</note>
             </trans-unit>
             <trans-unit id="app.form.label.preferred_locale">
                 <source>app.form.label.preferred_locale</source>
@@ -5200,6 +5220,73 @@
                 <source>app.search.navbar_no_results</source>
                 <target>Aucun résultat</target>
                 <note>Navbar autocomplete: empty state</note>
+            </trans-unit>
+
+            <!-- Decklist PDF (F5.13) -->
+            <trans-unit id="app.decklist.player_name">
+                <source>app.decklist.player_name</source>
+                <target>Nom du joueur</target>
+                <note>PDF decklist field label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.player_id">
+                <source>app.decklist.player_id</source>
+                <target>ID Joueur</target>
+                <note>PDF decklist field label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.year_of_birth">
+                <source>app.decklist.year_of_birth</source>
+                <target>Année de naissance</target>
+                <note>PDF decklist field label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.format">
+                <source>app.decklist.format</source>
+                <target>Format</target>
+                <note>PDF decklist field label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.total_cards">
+                <source>app.decklist.total_cards</source>
+                <target>Total</target>
+                <note>PDF decklist total card count label</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.section.pokemon">
+                <source>app.decklist.section.pokemon</source>
+                <target>Pokémon</target>
+                <note>PDF decklist section header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.section.trainer">
+                <source>app.decklist.section.trainer</source>
+                <target>Dresseur</target>
+                <note>PDF decklist section header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.section.energy">
+                <source>app.decklist.section.energy</source>
+                <target>Énergie</target>
+                <note>PDF decklist section header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.supporter">
+                <source>app.decklist.subtype.supporter</source>
+                <target>Supporter</target>
+                <note>PDF decklist trainer subtype header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.item">
+                <source>app.decklist.subtype.item</source>
+                <target>Objet</target>
+                <note>PDF decklist trainer subtype header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.tool">
+                <source>app.decklist.subtype.tool</source>
+                <target>Outil</target>
+                <note>PDF decklist trainer subtype header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.stadium">
+                <source>app.decklist.subtype.stadium</source>
+                <target>Stade</target>
+                <note>PDF decklist trainer subtype header</note>
+            </trans-unit>
+            <trans-unit id="app.decklist.subtype.technical machine">
+                <source>app.decklist.subtype.technical machine</source>
+                <target>Machine Technique</target>
+                <note>PDF decklist trainer subtype header</note>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
## Summary
- New `PdfDecklistGenerator` service generating a tournament-ready A4 PDF decklist from deck card data via Dompdf
- **Two modes**: personal (player name, ID, year of birth, Gravatar, trigram auto-filled) and anonymous (wide blank fields for handwriting)
- **Pokemon section**: set symbol icons (fetched from TCGdex CDN, base64-encoded) + PTCG code + card number + checkbox squares
- **Trainer section**: sub-grouped by subtype (Supporter, Item, Tool, Stadium) + checkbox squares
- **Energy section**: card names + checkbox squares
- **Localized card names**: uses deck's language list (single language → localized names with English inline; multiple/none → English). Names from `TcgdexCard` database, never translated programmatically
- **TcgdexCard fallback**: resolves via `tcgdexId` string when `cardPrinting.tcgdexCard` FK is null (all 446 printings lack this FK)
- **Adapt-to-fit**: dynamic font sizing (6–9pt) ensures any deck fits one A4 page
- Compact single-line header with Gravatar + player info + trigram (personal) or wide blank fields (anonymous)
- Lighter section headers (`#d0d0d0`) to save printer ink
- CSS-styled checkbox squares (Dompdf can't render Unicode circles in Helvetica)
- `yearOfBirth` optional field added to User entity + profile form + migration + GDPR anonymization
- Route: `GET /deck/{short_tag}/decklist.pdf?anonymous=0|1` (owner-only)
- Dropdown buttons on deck show page (personal + blank)
- Translations en + fr (17 new keys per locale)

## Test plan
- [ ] Navigate to a deck → dropdown → "Decklist PDF" → verify A4 PDF with filled player info
- [ ] Same with "Decklist PDF (blank)" → verify wide blank fields, no gravatar
- [ ] Verify French card names appear when deck language is `["fr"]` with English inline
- [ ] Verify English-only when deck has multiple languages or `["en"]`
- [ ] Verify set symbol icons appear for Pokemon cards (SVI+ sets have icons)
- [ ] Verify checkbox squares are properly sized and vertically centered
- [ ] Verify a large deck (25+ unique cards) fits on one A4 page
- [ ] Edit profile → set year of birth → verify it appears on personal decklist
- [ ] Verify non-owner gets 403 on the decklist PDF route

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)