### PR TITLE
:sparkles: Feature: Upgrade sprites to Pokemon HOME 3D renders (F2.26)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,12 @@ fixtures: ## Load fixture data, enrich, and rebuild search index
 	symfony console app:banned-cards:sync
 	$(MAKE) tcgdex.import
 	symfony console app:enrich:retry
+	$(MAKE) sprites.sync
 	$(MAKE) search.reindex
+
+.PHONY: sprites.sync
+sprites.sync: ## Sync Pokemon sprite slug-to-dex mapping from PokeAPI
+	symfony console app:sprites:sync-mapping
 
 .PHONY: tcgdex.import
 tcgdex.import: ## Import TCGdex card database from local git clone

--- a/Makefile
+++ b/Makefile
@@ -102,24 +102,12 @@ tcgdex.import: ## Import TCGdex card database from local git clone
 
 ## —— Assets ——————————————————————————————————————————————————————————
 
-POKESPRITE_DIR := assets/vendor/sprites/pokemon
-POKESPRITE_REPO := https://github.com/martimlobao/pokesprite/archive/refs/heads/master.tar.gz
-
-$(POKESPRITE_DIR):
-	@echo "Downloading PokéSprite assets..."
-	@mkdir -p $(POKESPRITE_DIR)
-	@curl -sL $(POKESPRITE_REPO) | tar xz --strip-components=3 -C $(POKESPRITE_DIR) "pokesprite-master/pokemon/regular"
-	@echo "Downloaded $$(ls $(POKESPRITE_DIR) | wc -l | tr -d ' ') sprites."
-
-.PHONY: sprites
-sprites: $(POKESPRITE_DIR) ## Download PokéSprite assets (cached)
-
 .PHONY: assets
-assets: sprites ## Build frontend assets (production)
+assets: ## Build frontend assets (production)
 	npx encore production
 
 .PHONY: assets.watch
-assets.watch: sprites ## Build frontend assets and watch for changes
+assets.watch: ## Build frontend assets and watch for changes
 	npx encore dev --watch
 
 ## —— Quality —————————————————————————————————————————————————————————

--- a/assets/components/ArchetypeFilterSelect.tsx
+++ b/assets/components/ArchetypeFilterSelect.tsx
@@ -91,9 +91,9 @@ export default function ArchetypeFilterSelect({
                         {archetype.pokemonSlugs.map((pokemonSlug) => (
                             <img
                                 key={pokemonSlug}
-                                src={`/build/sprites/pokemon/${pokemonSlug}.png`}
+                                src={`/sprites/pokemon/${pokemonSlug}.png`}
                                 alt={pokemonSlug.replace(/-/g, ' ')}
-                                style={{ height: 24, imageRendering: 'pixelated' }}
+                                style={{ height: 24 }}
                                 loading="lazy"
                             />
                         ))}

--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -93,9 +93,9 @@ function SpriteList({ slugs, height = 20 }: { slugs: string[]; height?: number }
             {slugs.slice(0, 3).map((slug) => (
                 <img
                     key={slug}
-                    src={`/build/sprites/pokemon/${slug}.png`}
+                    src={`/sprites/pokemon/${slug}.png`}
                     alt={slug}
-                    style={{ height, width: 'auto', marginRight: 2, verticalAlign: 'middle', imageRendering: 'pixelated' }}
+                    style={{ height, width: 'auto', marginRight: 2, verticalAlign: 'middle' }}
                 />
             ))}
         </>

--- a/assets/components/PokemonSpriteSelect.tsx
+++ b/assets/components/PokemonSpriteSelect.tsx
@@ -7,9 +7,8 @@
  * file that was distributed with this source code.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Combobox, Group, Pill, PillsInput, ScrollArea, useCombobox } from '@mantine/core';
-import spriteManifest from '../generated/pokemon-sprites.json';
 
 /**
  * @see docs/features.md F2.22 — Custom Pokemon sprites on decks
@@ -34,21 +33,28 @@ function slugToName(slug: string): string {
 function SpritePreview({ slug }: { slug: string }) {
     return (
         <img
-            src={`/build/sprites/pokemon/${slug}.png`}
+            src={`/sprites/pokemon/${slug}.png`}
             alt={slugToName(slug)}
-            style={{ width: 20, height: 20, imageRendering: 'pixelated' }}
+            style={{ width: 20, height: 20 }}
         />
     );
 }
 
 export default function PokemonSpriteSelect({ initialValues = [], hiddenInputName, placeholder }: PokemonSpriteSelectProps) {
-    const allSlugs: string[] = spriteManifest;
+    const [allSlugs, setAllSlugs] = useState<string[]>([]);
     const [value, setValue] = useState<string[]>(initialValues);
     const [search, setSearch] = useState('');
     const combobox = useCombobox({
         onDropdownClose: () => combobox.resetSelectedOption(),
         onDropdownOpen: () => combobox.updateSelectedOptionIndex('active'),
     });
+
+    useEffect(() => {
+        fetch('/api/sprites/slugs')
+            .then((response) => response.json())
+            .then((slugs: string[]) => setAllSlugs(slugs))
+            .catch(() => setAllSlugs([]));
+    }, []);
 
     const syncHidden = (newValue: string[]) => {
         const hiddenInput = document.querySelector<HTMLInputElement>(

--- a/assets/components/VariantComparePicker.tsx
+++ b/assets/components/VariantComparePicker.tsx
@@ -82,9 +82,9 @@ function SpritePreview({ variant }: { variant: VariantOption | undefined }) {
             {variant.sprites.slice(0, 3).map((slug) => (
                 <img
                     key={slug}
-                    src={`/build/sprites/pokemon/${slug}.png`}
+                    src={`/sprites/pokemon/${slug}.png`}
                     alt=""
-                    style={{ height: 22, imageRendering: 'pixelated' }}
+                    style={{ height: 22 }}
                 />
             ))}
         </span>

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -687,16 +687,15 @@ footer {
     }
 }
 
-// Fixed height keeps sprites visually consistent regardless of native
-// dimensions (23×22 Joltik to 73×62 large Pokémon). Width scales
-// proportionally to preserve aspect ratio.
+// Fixed height keeps sprites visually consistent. Width scales
+// proportionally to preserve aspect ratio. HOME 3D renders (512×512)
+// scale down smoothly — no pixelated rendering needed.
 .archetype-sprite {
     display: inline-block;
     vertical-align: middle;
     height: 40px;
     width: auto;
     margin-right: 2px;
-    image-rendering: pixelated;
 }
 
 // --- Footer ---

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -683,19 +683,19 @@ footer {
 
     // In table rows, reserve space for up to 3 sprites so names align
     .table & {
-        min-width: 120px; // 3 sprites × (~38px avg width + 2px margin)
+        min-width: 160px; // 3 sprites × (~50px avg width + 4px margin)
     }
 }
 
 // Fixed height keeps sprites visually consistent. Width scales
 // proportionally to preserve aspect ratio. HOME 3D renders (512×512)
-// scale down smoothly — no pixelated rendering needed.
+// scale down smoothly at any display size.
 .archetype-sprite {
     display: inline-block;
     vertical-align: middle;
-    height: 40px;
+    height: 52px;
     width: auto;
-    margin-right: 2px;
+    margin-right: 4px;
 }
 
 // --- Footer ---

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -93,9 +93,10 @@ services:
         arguments:
             $editorUploadStorage: '@editor_upload.storage'
 
-    App\Service\Label\PdfLabelGenerator:
+    App\Service\Sprite\SpriteResolver:
         arguments:
             $projectDir: '%kernel.project_dir%'
+            $spriteCdnBaseUrl: '%env(default::SPRITE_CDN_BASE_URL)%'
 
     App\Command\ImportTcgdexDatabaseCommand:
         arguments:

--- a/migrations/Version20260427100000.php
+++ b/migrations/Version20260427100000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Create pokemon_sprite_mapping table for slug → PokeAPI dex ID resolution.
+ *
+ * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
+ */
+final class Version20260427100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create pokemon_sprite_mapping table for sprite CDN proxy';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE pokemon_sprite_mapping (id INT AUTO_INCREMENT NOT NULL, slug VARCHAR(80) NOT NULL, pokedex_id INT NOT NULL, UNIQUE INDEX uniq_sprite_slug (slug), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE pokemon_sprite_mapping');
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.2.3",
                 "@types/sortablejs": "^1.15.9",
-                "copy-webpack-plugin": "^14.0.0",
                 "core-js": "^3.38.0",
                 "eslint": "^9.0.0",
                 "eslint-plugin-react": "^7.0.0",
@@ -6246,30 +6245,6 @@
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/copy-webpack-plugin": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
-            "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "glob-parent": "^6.0.1",
-                "normalize-path": "^3.0.0",
-                "schema-utils": "^4.2.0",
-                "serialize-javascript": "^7.0.3",
-                "tinyglobby": "^0.2.12"
-            },
-            "engines": {
-                "node": ">= 20.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.1.0"
-            }
         },
         "node_modules/core-js": {
             "version": "3.48.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/sortablejs": "^1.15.9",
-        "copy-webpack-plugin": "^14.0.0",
         "core-js": "^3.38.0",
         "eslint": "^9.0.0",
         "eslint-plugin-react": "^7.0.0",

--- a/src/Command/SpritesSyncMappingCommand.php
+++ b/src/Command/SpritesSyncMappingCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Service\Sprite\SpriteMappingSyncService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Sync the Pokemon sprite slug→dex mapping from PokeAPI's CSV data.
+ *
+ * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
+ */
+#[AsCommand(
+    name: 'app:sprites:sync-mapping',
+    description: 'Sync the Pokemon sprite slug-to-dex mapping from PokeAPI CSV data.',
+)]
+class SpritesSyncMappingCommand extends Command
+{
+    public function __construct(
+        private readonly SpriteMappingSyncService $syncService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->section('Fetching PokeAPI pokemon.csv');
+
+        try {
+            $result = $this->syncService->sync();
+        } catch (\RuntimeException $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->success(\sprintf(
+            'Sprite mapping synced: %d inserted, %d updated, %d total entries.',
+            $result['inserted'],
+            $result['updated'],
+            $result['total'],
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/AdminTechnicalController.php
+++ b/src/Controller/AdminTechnicalController.php
@@ -24,6 +24,7 @@ use App\Service\BannedCardsSyncService;
 use App\Service\CardReenrichService;
 use App\Service\EnrichmentFlushService;
 use App\Service\Mosaic\MosaicRedispatchService;
+use App\Service\Sprite\SpriteMappingSyncService;
 use App\Service\Tcgdex\TcgdexApiThrottle;
 use App\Service\Tcgdex\TcgdexSyncStatusService;
 use App\Twig\Runtime\MenuRuntime;
@@ -199,6 +200,31 @@ class AdminTechnicalController extends AbstractAppController
         $this->messageBus->dispatch(new BuildSetMappingsMessage());
 
         $this->addFlash('success', 'app.admin.technical.set_mappings.dispatched');
+
+        return $this->redirectToRoute('app_admin_technical_dashboard');
+    }
+
+    /**
+     * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
+     */
+    #[Route('/sprite-mapping-rebuild', name: 'app_admin_technical_sprite_mapping_rebuild', methods: ['POST'])]
+    public function spriteMappingRebuild(Request $request, SpriteMappingSyncService $syncService): Response
+    {
+        if (!$this->isCsrfTokenValid('technical-sprite-mapping-rebuild', $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        try {
+            $result = $syncService->sync();
+            $this->addFlash('success', $this->container->get('translator')->trans(
+                'app.admin.technical.sprite_mapping.synced',
+                ['%inserted%' => $result['inserted'], '%updated%' => $result['updated'], '%total%' => $result['total']],
+            ));
+        } catch (\RuntimeException $exception) {
+            $this->addFlash('danger', $exception->getMessage());
+        }
 
         return $this->redirectToRoute('app_admin_technical_dashboard');
     }

--- a/src/Controller/SpriteProxyController.php
+++ b/src/Controller/SpriteProxyController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Repository\PokemonSpriteMappingRepository;
+use App\Service\Sprite\SpriteResolver;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Proxy controller for Pokemon HOME sprites.
+ *
+ * Serves sprites from a filesystem cache, fetching from PokeAPI on cache miss.
+ * Designed to sit behind a Bunny CDN pull zone for edge caching.
+ *
+ * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
+ */
+class SpriteProxyController extends AbstractController
+{
+    #[Route('/sprites/pokemon/{slug}.png', name: 'app_sprite_pokemon', methods: ['GET'], requirements: ['slug' => '[a-z0-9-]+'])]
+    public function pokemon(string $slug, SpriteResolver $spriteResolver): Response
+    {
+        $path = $spriteResolver->resolve($slug);
+
+        if (null === $path) {
+            throw new NotFoundHttpException(\sprintf('Sprite not found: %s', $slug));
+        }
+
+        $content = file_get_contents($path);
+
+        if (false === $content) {
+            throw new NotFoundHttpException(\sprintf('Failed to read sprite: %s', $slug));
+        }
+
+        return new Response($content, 200, [
+            'Content-Type' => 'image/png',
+            'Cache-Control' => 'public, max-age=2592000', // 30 days
+        ]);
+    }
+
+    /**
+     * Return all available sprite slugs for the PokemonSpriteSelect autocomplete.
+     */
+    #[Route('/api/sprites/slugs', name: 'app_sprite_slugs', methods: ['GET'])]
+    public function slugs(PokemonSpriteMappingRepository $repository): JsonResponse
+    {
+        return new JsonResponse($repository->findAllSlugs());
+    }
+}

--- a/src/Entity/PokemonSpriteMapping.php
+++ b/src/Entity/PokemonSpriteMapping.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Entity;
+
+use App\Repository\PokemonSpriteMappingRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Maps a Pokemon slug (e.g. "iron-thorns") to its PokeAPI national dex ID
+ * (e.g. 995), used by the sprite proxy controller to fetch HOME 3D renders.
+ *
+ * Populated from PokeAPI's pokemon.csv via the app:sprites:sync-mapping command.
+ *
+ * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
+ */
+#[ORM\Entity(repositoryClass: PokemonSpriteMappingRepository::class)]
+#[ORM\Table(name: 'pokemon_sprite_mapping')]
+#[ORM\UniqueConstraint(name: 'uniq_sprite_slug', columns: ['slug'])]
+class PokemonSpriteMapping
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 80)]
+    private string $slug = '';
+
+    #[ORM\Column]
+    private int $pokedexId = 0;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): static
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+
+    public function getPokedexId(): int
+    {
+        return $this->pokedexId;
+    }
+
+    public function setPokedexId(int $pokedexId): static
+    {
+        $this->pokedexId = $pokedexId;
+
+        return $this;
+    }
+}

--- a/src/Repository/PokemonSpriteMappingRepository.php
+++ b/src/Repository/PokemonSpriteMappingRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Repository;
+
+use App\Entity\PokemonSpriteMapping;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PokemonSpriteMapping>
+ *
+ * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
+ */
+class PokemonSpriteMappingRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PokemonSpriteMapping::class);
+    }
+
+    public function findPokedexIdBySlug(string $slug): ?int
+    {
+        /** @var ?int $result */
+        $result = $this->createQueryBuilder('m')
+            ->select('m.pokedexId')
+            ->where('m.slug = :slug')
+            ->setParameter('slug', $slug)
+            ->getQuery()
+            ->getOneOrNullResult(\Doctrine\ORM\Query::HYDRATE_SINGLE_SCALAR);
+
+        return $result;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function findAllSlugs(): array
+    {
+        /** @var list<string> $slugs */
+        $slugs = $this->createQueryBuilder('m')
+            ->select('m.slug')
+            ->orderBy('m.slug', 'ASC')
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return $slugs;
+    }
+}

--- a/src/Service/Label/PdfLabelGenerator.php
+++ b/src/Service/Label/PdfLabelGenerator.php
@@ -16,6 +16,7 @@ namespace App\Service\Label;
 use App\Entity\Deck;
 use App\Entity\DeckCard;
 use App\Entity\DeckVersion;
+use App\Service\Sprite\SpriteResolver;
 use Dompdf\Dompdf;
 use Dompdf\Options;
 use Endroid\QrCode\Builder\Builder;
@@ -40,7 +41,7 @@ class PdfLabelGenerator
     public function __construct(
         private readonly Environment $twig,
         private readonly UrlGeneratorInterface $urlGenerator,
-        private readonly string $projectDir,
+        private readonly SpriteResolver $spriteResolver,
     ) {
     }
 
@@ -204,6 +205,7 @@ class PdfLabelGenerator
      * so sprites must be embedded as data URIs.
      *
      * @see docs/features.md F2.22 — Custom Pokemon sprites on decks
+     * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
      *
      * @return list<array{dataUri: string, name: string}>
      */
@@ -213,20 +215,14 @@ class PdfLabelGenerator
         $sprites = [];
 
         foreach ($slugs as $slug) {
-            $path = $this->projectDir.'/public/build/sprites/pokemon/'.$slug.'.png';
+            $dataUri = $this->spriteResolver->resolveAsDataUri($slug);
 
-            if (!file_exists($path)) {
-                continue;
-            }
-
-            $data = file_get_contents($path);
-
-            if (false === $data) {
+            if (null === $dataUri) {
                 continue;
             }
 
             $sprites[] = [
-                'dataUri' => 'data:image/png;base64,'.base64_encode($data),
+                'dataUri' => $dataUri,
                 'name' => ucwords(str_replace('-', ' ', $slug)),
             ];
         }

--- a/src/Service/Sprite/SpriteMappingSyncService.php
+++ b/src/Service/Sprite/SpriteMappingSyncService.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Sprite;
+
+use App\Entity\PokemonSpriteMapping;
+use App\Repository\PokemonSpriteMappingRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Synchronizes the PokemonSpriteMapping table from PokeAPI's pokemon.csv.
+ *
+ * Fetches the CSV from GitHub, parses identifier→id pairs, and upserts rows.
+ * Also adds alias entries for known slug naming mismatches between PokeAPI
+ * and PokéSprite conventions.
+ *
+ * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
+ */
+class SpriteMappingSyncService
+{
+    private const string POKEAPI_CSV_URL = 'https://raw.githubusercontent.com/PokeAPI/pokeapi/master/data/v2/csv/pokemon.csv';
+
+    /**
+     * Known slug aliases: PokéSprite slug → PokeAPI dex ID.
+     *
+     * PokeAPI uses game-internal identifiers (e.g. "calyrex-shadow") while
+     * PokéSprite and this project use fan-friendly names (e.g. "calyrex-shadow-rider").
+     */
+    private const array SLUG_ALIASES = [
+        'calyrex-shadow-rider' => 10194,
+        'calyrex-ice-rider' => 10193,
+    ];
+
+    public function __construct(
+        private readonly PokemonSpriteMappingRepository $repository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly HttpClientInterface $httpClient,
+    ) {
+    }
+
+    /**
+     * @return array{inserted: int, updated: int, total: int}
+     */
+    public function sync(): array
+    {
+        $csvContent = $this->fetchCsv();
+        $entries = $this->parseCsv($csvContent);
+
+        // Add known aliases
+        foreach (self::SLUG_ALIASES as $slug => $pokedexId) {
+            $entries[$slug] = $pokedexId;
+        }
+
+        $existingMappings = $this->loadExistingMappings();
+
+        $inserted = 0;
+        $updated = 0;
+
+        foreach ($entries as $slug => $pokedexId) {
+            if (isset($existingMappings[$slug])) {
+                if ($existingMappings[$slug]->getPokedexId() !== $pokedexId) {
+                    $existingMappings[$slug]->setPokedexId($pokedexId);
+                    ++$updated;
+                }
+            } else {
+                $mapping = new PokemonSpriteMapping();
+                $mapping->setSlug($slug);
+                $mapping->setPokedexId($pokedexId);
+                $this->entityManager->persist($mapping);
+                ++$inserted;
+            }
+        }
+
+        $this->entityManager->flush();
+
+        return [
+            'inserted' => $inserted,
+            'updated' => $updated,
+            'total' => \count($entries),
+        ];
+    }
+
+    private function fetchCsv(): string
+    {
+        $response = $this->httpClient->request('GET', self::POKEAPI_CSV_URL, ['timeout' => 10]);
+
+        if (200 !== $response->getStatusCode()) {
+            throw new \RuntimeException(\sprintf('Failed to fetch PokeAPI CSV: HTTP %d', $response->getStatusCode()));
+        }
+
+        return $response->getContent();
+    }
+
+    /**
+     * Parse the CSV: columns are id, identifier, species_id, height, weight, base_experience, order, is_default.
+     *
+     * @return array<string, int> slug → pokedex ID
+     */
+    private function parseCsv(string $csvContent): array
+    {
+        $entries = [];
+        $lines = explode("\n", $csvContent);
+
+        foreach ($lines as $index => $line) {
+            if (0 === $index || '' === trim($line)) {
+                continue; // skip header and empty lines
+            }
+
+            $columns = str_getcsv($line);
+            if (\count($columns) < 2) {
+                continue;
+            }
+
+            $pokedexId = (int) ($columns[0] ?? '0');
+            $slug = (string) ($columns[1] ?? '');
+
+            if ($pokedexId > 0 && '' !== $slug) {
+                $entries[$slug] = $pokedexId;
+            }
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @return array<string, PokemonSpriteMapping>
+     */
+    private function loadExistingMappings(): array
+    {
+        $mappings = [];
+
+        foreach ($this->repository->findAll() as $mapping) {
+            $mappings[$mapping->getSlug()] = $mapping;
+        }
+
+        return $mappings;
+    }
+}

--- a/src/Service/Sprite/SpriteResolver.php
+++ b/src/Service/Sprite/SpriteResolver.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Sprite;
+
+use App\Repository\PokemonSpriteMappingRepository;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Resolves Pokemon sprites: slug → filesystem path, with CDN fetch on cache miss.
+ *
+ * Sprites are cached in var/cache/sprites/ for fast access by PDF generators
+ * and the sprite proxy controller. On a cache miss (e.g. new container), the
+ * sprite is fetched from our own CDN URL (Bunny edge cache), which in turn
+ * may fetch from PokeAPI's GitHub raw URL on its first request.
+ *
+ * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
+ */
+class SpriteResolver
+{
+    private const string POKEAPI_HOME_URL = 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/%d.png';
+
+    private string $cacheDirectory;
+
+    /** @var array<string, ?int> in-memory slug→dex cache */
+    private array $dexCache = [];
+
+    public function __construct(
+        private readonly PokemonSpriteMappingRepository $mappingRepository,
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $projectDir,
+        private readonly ?string $spriteCdnBaseUrl = null,
+    ) {
+        $this->cacheDirectory = $this->projectDir.'/var/cache/sprites';
+    }
+
+    /**
+     * Get the local filesystem path for a sprite, fetching it if needed.
+     *
+     * Returns null if the slug is not mapped or the fetch fails.
+     */
+    public function resolve(string $slug): ?string
+    {
+        $path = $this->getCachePath($slug);
+
+        if (file_exists($path)) {
+            return $path;
+        }
+
+        return $this->fetchAndCache($slug);
+    }
+
+    /**
+     * Get the sprite image content as a base64 data URI for PDF embedding.
+     */
+    public function resolveAsDataUri(string $slug): ?string
+    {
+        $path = $this->resolve($slug);
+
+        if (null === $path) {
+            return null;
+        }
+
+        $content = file_get_contents($path);
+
+        if (false === $content) {
+            return null;
+        }
+
+        return 'data:image/png;base64,'.base64_encode($content);
+    }
+
+    /**
+     * Check if a sprite exists in the filesystem cache without fetching.
+     */
+    public function isCached(string $slug): bool
+    {
+        return file_exists($this->getCachePath($slug));
+    }
+
+    private function getCachePath(string $slug): string
+    {
+        return $this->cacheDirectory.'/'.$slug.'.png';
+    }
+
+    private function fetchAndCache(string $slug): ?string
+    {
+        $content = $this->fetchSpriteContent($slug);
+
+        if (null === $content) {
+            return null;
+        }
+
+        if (!is_dir($this->cacheDirectory)) {
+            mkdir($this->cacheDirectory, 0o777, true);
+        }
+
+        $path = $this->getCachePath($slug);
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    private function fetchSpriteContent(string $slug): ?string
+    {
+        // Try our own CDN first (fast, cached at edge)
+        if (null !== $this->spriteCdnBaseUrl) {
+            $content = $this->fetchUrl($this->spriteCdnBaseUrl.'/sprites/pokemon/'.$slug.'.png');
+            if (null !== $content) {
+                return $content;
+            }
+        }
+
+        // Fall back to PokeAPI directly
+        $pokedexId = $this->resolvePokedexId($slug);
+        if (null === $pokedexId) {
+            return null;
+        }
+
+        return $this->fetchUrl(\sprintf(self::POKEAPI_HOME_URL, $pokedexId));
+    }
+
+    private function resolvePokedexId(string $slug): ?int
+    {
+        if (\array_key_exists($slug, $this->dexCache)) {
+            return $this->dexCache[$slug];
+        }
+
+        $this->dexCache[$slug] = $this->mappingRepository->findPokedexIdBySlug($slug);
+
+        return $this->dexCache[$slug];
+    }
+
+    private function fetchUrl(string $url): ?string
+    {
+        try {
+            $response = $this->httpClient->request('GET', $url, ['timeout' => 5]);
+
+            if (200 !== $response->getStatusCode()) {
+                return null;
+            }
+
+            return $response->getContent();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Twig/Runtime/ArchetypeSpriteRuntime.php
+++ b/src/Twig/Runtime/ArchetypeSpriteRuntime.php
@@ -22,6 +22,7 @@ use Twig\Extension\RuntimeExtensionInterface;
  *
  * @see docs/features.md F2.12 — Archetype sprite pictograms
  * @see docs/features.md F2.22 — Custom Pokemon sprites on decks
+ * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
  */
 class ArchetypeSpriteRuntime implements RuntimeExtensionInterface
 {
@@ -57,7 +58,7 @@ class ArchetypeSpriteRuntime implements RuntimeExtensionInterface
             $escapedSlug = htmlspecialchars($slug, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
             $name = htmlspecialchars(ucwords(str_replace('-', ' ', $slug)), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
             $images .= \sprintf(
-                '<img src="/build/sprites/pokemon/%s.png" alt="%s" title="%s" class="archetype-sprite" loading="lazy">',
+                '<img src="/sprites/pokemon/%s.png" alt="%s" title="%s" class="archetype-sprite" loading="lazy">',
                 $escapedSlug,
                 $name,
                 $name,

--- a/templates/admin/technical/dashboard.html.twig
+++ b/templates/admin/technical/dashboard.html.twig
@@ -153,6 +153,20 @@
         </div>
     </div>
 
+    {# Sprite mapping card #}
+    <div class="card shadow-sm mb-3">
+        <div class="card-header"><strong>{{ 'app.admin.technical.sprite_mapping.title'|trans }}</strong></div>
+        <div class="card-body">
+            <p class="card-text text-muted mb-2">{{ 'app.admin.technical.sprite_mapping.description'|trans }}</p>
+            <form method="post" action="{{ path('app_admin_technical_sprite_mapping_rebuild') }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('technical-sprite-mapping-rebuild') }}">
+                <button type="submit" class="btn btn-gold">
+                    {{ 'app.admin.technical.sprite_mapping.rebuild_button'|trans }}
+                </button>
+            </form>
+        </div>
+    </div>
+
     {# TCGdex database sync card #}
     <div class="card shadow-sm mb-3">
         <div class="card-header card-header-themed">

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -16,19 +16,19 @@
             <div class="display-1 fw-bold text-primary mb-2">{{ status_code }}</div>
             <h1 class="h4 fw-semibold text-primary mb-3">{{ status_text }}</h1>
             {% if status_code == 403 %}
-                <img src="/build/sprites/pokemon/snorlax.png" alt="Snorlax" style="height: 80px; image-rendering: pixelated;" class="mb-3">
+                <img src="/sprites/pokemon/snorlax.png" alt="Snorlax" style="height: 80px;" class="mb-3">
                 <p class="text-muted mb-4">{{ 'app.error.403'|trans }}</p>
             {% elseif status_code == 404 %}
-                <img src="/build/sprites/pokemon/ditto.png" alt="Ditto" style="height: 80px; image-rendering: pixelated;" class="mb-3">
+                <img src="/sprites/pokemon/ditto.png" alt="Ditto" style="height: 80px;" class="mb-3">
                 <p class="text-muted mb-4">{{ 'app.error.404'|trans }}</p>
             {% elseif status_code == 429 %}
-                <img src="/build/sprites/pokemon/maushold-family-of-four.png" alt="Maushold" style="height: 80px; image-rendering: pixelated;" class="mb-3">
+                <img src="/sprites/pokemon/maushold-family-of-four.png" alt="Maushold" style="height: 80px;" class="mb-3">
                 <p class="text-muted mb-4">{{ 'app.error.429'|trans }}</p>
             {% elseif status_code == 500 %}
-                <img src="/build/sprites/pokemon/porygon.png" alt="Porygon" style="height: 80px; image-rendering: pixelated;" class="mb-3">
+                <img src="/sprites/pokemon/porygon.png" alt="Porygon" style="height: 80px;" class="mb-3">
                 <p class="text-muted mb-4">{{ 'app.error.500'|trans }}</p>
             {% else %}
-                <img src="/build/sprites/pokemon/psyduck.png" alt="Psyduck" style="height: 80px; image-rendering: pixelated;" class="mb-3">
+                <img src="/sprites/pokemon/psyduck.png" alt="Psyduck" style="height: 80px;" class="mb-3">
                 <p class="text-muted mb-4">{{ 'app.error.generic'|trans }}</p>
             {% endif %}
             <a href="/" class="btn btn-gold">{{ 'app.error.back_home'|trans }}</a>

--- a/templates/exception/dev.html.twig
+++ b/templates/exception/dev.html.twig
@@ -13,19 +13,19 @@
 {% block body %}
     <div class="text-center mb-4">
         {% if status_code == 403 %}
-            <img src="/build/sprites/pokemon/snorlax.png" alt="Snorlax" style="height: 80px; image-rendering: pixelated;" class="mb-2">
+            <img src="/sprites/pokemon/snorlax.png" alt="Snorlax" style="height: 80px;" class="mb-2">
             <p class="text-muted">{{ 'app.error.403'|trans }}</p>
         {% elseif status_code == 404 %}
-            <img src="/build/sprites/pokemon/ditto.png" alt="Ditto" style="height: 80px; image-rendering: pixelated;" class="mb-2">
+            <img src="/sprites/pokemon/ditto.png" alt="Ditto" style="height: 80px;" class="mb-2">
             <p class="text-muted">{{ 'app.error.404'|trans }}</p>
         {% elseif status_code == 429 %}
-            <img src="/build/sprites/pokemon/maushold-family-of-four.png" alt="Maushold" style="height: 80px; image-rendering: pixelated;" class="mb-2">
+            <img src="/sprites/pokemon/maushold-family-of-four.png" alt="Maushold" style="height: 80px;" class="mb-2">
             <p class="text-muted">{{ 'app.error.429'|trans }}</p>
         {% elseif status_code == 500 %}
-            <img src="/build/sprites/pokemon/porygon.png" alt="Porygon" style="height: 80px; image-rendering: pixelated;" class="mb-2">
+            <img src="/sprites/pokemon/porygon.png" alt="Porygon" style="height: 80px;" class="mb-2">
             <p class="text-muted">{{ 'app.error.500'|trans }}</p>
         {% else %}
-            <img src="/build/sprites/pokemon/psyduck.png" alt="Psyduck" style="height: 80px; image-rendering: pixelated;" class="mb-2">
+            <img src="/sprites/pokemon/psyduck.png" alt="Psyduck" style="height: 80px;" class="mb-2">
             <p class="text-muted">{{ 'app.error.generic'|trans }}</p>
         {% endif %}
     </div>

--- a/tests/Twig/Runtime/ArchetypeSpriteRuntimeTest.php
+++ b/tests/Twig/Runtime/ArchetypeSpriteRuntimeTest.php
@@ -47,7 +47,7 @@ class ArchetypeSpriteRuntimeTest extends TestCase
         $html = $this->runtime->renderSprites($archetype);
 
         self::assertStringContainsString('<span class="archetype-sprites">', $html);
-        self::assertStringContainsString('src="/build/sprites/pokemon/iron-thorns.png"', $html);
+        self::assertStringContainsString('src="/sprites/pokemon/iron-thorns.png"', $html);
         self::assertStringContainsString('alt="Iron Thorns"', $html);
         self::assertStringContainsString('title="Iron Thorns"', $html);
         self::assertStringContainsString('class="archetype-sprite"', $html);

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -4623,6 +4623,28 @@
                 <source>app.admin.technical.set_mappings.rebuild_button</source>
                 <target>Rebuild set mappings</target>
             </trans-unit>
+
+            <!-- Sprite mapping (F2.26) -->
+            <trans-unit id="app.admin.technical.sprite_mapping.title">
+                <source>app.admin.technical.sprite_mapping.title</source>
+                <target>Pokemon Sprite Mapping</target>
+                <note>Admin technical card title</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.sprite_mapping.description">
+                <source>app.admin.technical.sprite_mapping.description</source>
+                <target>Slug-to-Pokedex ID mapping for HOME 3D sprites. Fetched from PokeAPI CSV data.</target>
+                <note>Admin technical card description</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.sprite_mapping.rebuild_button">
+                <source>app.admin.technical.sprite_mapping.rebuild_button</source>
+                <target>Rebuild sprite mapping</target>
+                <note>Admin technical button label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.sprite_mapping.synced">
+                <source>app.admin.technical.sprite_mapping.synced</source>
+                <target>Sprite mapping synced: %inserted% inserted, %updated% updated, %total% total.</target>
+                <note>Flash message after sprite mapping sync</note>
+            </trans-unit>
             <trans-unit id="app.admin.technical.set_mappings.confirm_rebuild">
                 <source>app.admin.technical.set_mappings.confirm_rebuild</source>
                 <target>This will wipe and rebuild all set mappings in the background. Continue?</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -4598,6 +4598,28 @@
                 <source>app.admin.technical.set_mappings.rebuild_button</source>
                 <target>Reconstruire les correspondances</target>
             </trans-unit>
+
+            <!-- Sprite mapping (F2.26) -->
+            <trans-unit id="app.admin.technical.sprite_mapping.title">
+                <source>app.admin.technical.sprite_mapping.title</source>
+                <target>Correspondance des sprites Pokémon</target>
+                <note>Admin technical card title</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.sprite_mapping.description">
+                <source>app.admin.technical.sprite_mapping.description</source>
+                <target>Correspondance slug → Pokédex pour les sprites HOME 3D. Données issues du CSV PokeAPI.</target>
+                <note>Admin technical card description</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.sprite_mapping.rebuild_button">
+                <source>app.admin.technical.sprite_mapping.rebuild_button</source>
+                <target>Reconstruire les sprites</target>
+                <note>Admin technical button label</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.sprite_mapping.synced">
+                <source>app.admin.technical.sprite_mapping.synced</source>
+                <target>Sprites synchronisés : %inserted% ajoutés, %updated% mis à jour, %total% au total.</target>
+                <note>Flash message after sprite mapping sync</note>
+            </trans-unit>
             <trans-unit id="app.admin.technical.set_mappings.confirm_rebuild">
                 <source>app.admin.technical.set_mappings.confirm_rebuild</source>
                 <target>Cela va supprimer et reconstruire toutes les correspondances en arrière-plan. Continuer ?</target>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,31 +8,7 @@
  */
 
 const Encore = require('@symfony/webpack-encore');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
-const fs = require('fs');
-
-/*
- * Generate a static manifest of available Pokemon sprite slugs at build time.
- * The React PokemonSpriteSelect component imports this list for autocomplete.
- *
- * @see docs/features.md F2.22 — Custom Pokemon sprites on decks
- */
-const spritesDir = path.resolve(__dirname, 'assets/vendor/sprites/pokemon');
-const generatedDir = path.resolve(__dirname, 'assets/generated');
-const manifestPath = path.resolve(generatedDir, 'pokemon-sprites.json');
-if (!fs.existsSync(generatedDir)) {
-    fs.mkdirSync(generatedDir, { recursive: true });
-}
-if (fs.existsSync(spritesDir)) {
-    const slugs = fs.readdirSync(spritesDir)
-        .filter((file) => file.endsWith('.png'))
-        .map((file) => file.replace(/\.png$/, ''))
-        .sort();
-    fs.writeFileSync(manifestPath, JSON.stringify(slugs));
-} else {
-    fs.writeFileSync(manifestPath, '[]');
-}
 
 if (!Encore.isRuntimeEnvironmentConfigured()) {
     Encore.configureRuntimeEnvironment(process.env.NODE_ENV || 'dev');
@@ -85,13 +61,6 @@ Encore
         };
     })
 
-    .addPlugin(new CopyWebpackPlugin({
-        patterns: [{
-            from: path.resolve(__dirname, 'assets/vendor/sprites/pokemon'),
-            to: 'sprites/pokemon',
-            noErrorOnMissing: true,
-        }],
-    }))
 ;
 
 module.exports = Encore.getWebpackConfig();


### PR DESCRIPTION
## Summary
- Replace PokéSprite pixel art (42×42px) with Pokemon HOME 3D renders (512×512px) via a **CDN pull-through proxy** architecture
- New `PokemonSpriteMapping` entity + migration for slug → PokeAPI dex ID resolution
- `app:sprites:sync-mapping` CLI command fetches PokeAPI CSV (1350+ entries), handles slug aliases (e.g. `calyrex-shadow-rider` → 10194)
- `SpriteProxyController` at `/sprites/pokemon/{slug}.png` serves sprites from filesystem cache (`var/cache/sprites/`), fetching from PokeAPI on cache miss — designed for Bunny CDN pull zone
- `SpriteResolver` service provides container-safe sprite resolution: fetches from own CDN URL on cold start, falls back to PokeAPI on first-ever global request
- `/api/sprites/slugs` endpoint replaces the build-time sprite manifest for the `PokemonSpriteSelect` React autocomplete
- `PdfLabelGenerator` updated to use `SpriteResolver` instead of reading from `public/build/`
- "Rebuild sprite mapping" button in admin technical dashboard
- `make sprites.sync` target, integrated into `make fixtures`
- **Removed**: PokéSprite tarball download, `copy-webpack-plugin`, `assets/vendor/sprites/`, build-time manifest generation, `image-rendering: pixelated`
- All sprite URLs updated: Twig runtime, 4 React components, 2 error templates, CSS
- Translations en + fr

## Cache layers (no CDN hammering)
1. **Browser**: `Cache-Control: public, max-age=2592000` (30 days)
2. **Bunny CDN edge** (production): pull-through cache on `/sprites/pokemon/`
3. **Filesystem**: `var/cache/sprites/{slug}.png` — persists across requests, PokeAPI hit once per slug ever

## Test plan
- [ ] Run `make migrations` then `make sprites.sync` (or `make fixtures`)
- [ ] Verify sprites render as 3D artwork on archetype pages, deck cards, dashboard
- [ ] Verify `/sprites/pokemon/iron-thorns.png` returns a 512×512 PNG
- [ ] Verify sprite autocomplete still works in archetype admin form
- [ ] Verify PDF labels show higher-res sprites
- [ ] Verify admin technical dashboard "Rebuild sprite mapping" button works
- [ ] Verify `make assets` builds without PokéSprite dependency
- [ ] Verify error pages show sprites

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)