### PR TITLE
:wrench: chore: harden Claude Code permission rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,24 @@
   "permissions": {
     "allow": [
       "Bash(make *)",
-      "Bash(git *)",
-      "Bash(gh *)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git checkout *)",
+      "Bash(git fetch *)",
+      "Bash(git branch *)",
+      "Bash(git stash *)",
+      "Bash(git mv *)",
+      "Bash(git restore *)",
+      "Bash(git cherry-pick *)",
+      "Bash(git merge-tree *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh search *)",
       "Bash(ls *)",
       "Bash(ls)",
       "Bash(pwd)",
@@ -11,16 +27,24 @@
       "Bash(symfony composer *)",
       "Bash(symfony php *)",
       "Bash(symfony server:*)",
-      "Bash(npm install *)",
       "Bash(npm outdated *)",
       "Bash(npm info *)",
+      "Bash(npm run *)",
       "Bash(npx encore *)",
       "Bash(npx vitest *)",
-      "Bash(npx eslint *)",
-      "Bash(docker compose *)"
+      "Bash(npx eslint *)"
     ],
     "ask": [
-      "Bash(gh pr merge *)"
+      "Bash(git push *)",
+      "Bash(git rebase *)",
+      "Bash(gh pr *)",
+      "Bash(gh issue *)",
+      "Bash(gh run *)",
+      "Bash(gh repo *)",
+      "Bash(gh release *)",
+      "Bash(gh api *)",
+      "Bash(npm install *)",
+      "Bash(docker compose *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Move destructive and shared-state operations from auto-allow to ask (confirmation required)
- Split `gh pr`: read-only commands (`view/diff/list/checks`) stay auto-allowed, write commands (`create/edit/comment/merge/close`) now prompt
- Move `git push`, `git rebase` to ask (remote/history operations)
- Move `npm install`, `docker compose` to ask (dependency modification, destructive commands)
- Move `gh issue/run/repo/release/api` to ask (GitHub write operations)

## Rationale

Auto-allowing commands that modify shared state (remote repos, GitHub issues/PRs, container state) is a security risk — prompt injection via tool results could trigger unintended actions. Only read-only and local-only operations should be auto-allowed.

## Test plan

- [ ] Verify read-only git commands (`status`, `diff`, `log`, `add`, `commit`) still auto-execute
- [ ] Verify `git push` prompts for confirmation
- [ ] Verify `gh pr view` auto-executes but `gh pr create` prompts