### PR TITLE
:sparkles: Feature: filter dashboard "my decks" to active Expanded

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -143,7 +143,7 @@ class HomeController extends AbstractController
             'newsCategory' => $newsCategory,
             'newsTotalCount' => $newsTotalCount,
             'user' => $user,
-            'ownedDecks' => $user->getOwnedDecks(),
+            'ownedDecks' => $deckRepository->findActiveExpandedByOwner($user),
             'myEvents' => $eventRepository->findUpcomingByEngagement($user),
             'staffingEvents' => $eventRepository->findRecentByOrganizerOrStaff($user),
             'recentBorrows' => $borrowRepository->findRecentByBorrower($user),

--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -237,6 +237,31 @@ class DeckRepository extends ServiceEntityRepository
     }
 
     /**
+     * @see docs/features.md F7.1 — Dashboard
+     *
+     * @return list<Deck>
+     */
+    public function findActiveExpandedByOwner(User $owner): array
+    {
+        /** @var list<Deck> $decks */
+        $decks = $this->createQueryBuilder('d')
+            ->leftJoin('d.currentVersion', 'cv')
+            ->addSelect('cv')
+            ->where('d.owner = :owner')
+            ->andWhere('d.format = :expandedFormat')
+            ->andWhere('d.status != :retired')
+            ->andWhere('d.deletedAt IS NULL')
+            ->setParameter('owner', $owner)
+            ->setParameter('expandedFormat', DeckFormat::Expanded)
+            ->setParameter('retired', DeckStatus::Retired)
+            ->orderBy('d.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $decks;
+    }
+
+    /**
      * @see docs/features.md F4.12 — Walk-up lending (direct lend)
      *
      * @return list<Deck>


### PR DESCRIPTION
## Summary
- Replace `User::getOwnedDecks()` with a dedicated repository query for the homepage "My Decks" widget so retired and soft-deleted decks no longer appear.
- Restrict the widget to the Expanded format, matching the project's deck-management scope.
- Add `DeckRepository::findActiveExpandedByOwner()` referencing F7.1 (Dashboard), with eager-loaded `currentVersion` and alphabetical ordering.

## Test plan
- [ ] Sign in as a user with a mix of decks (active Expanded, retired, soft-deleted, non-Expanded) and verify the dashboard "My Decks" widget shows only active Expanded decks.
- [ ] Confirm the listing is sorted alphabetically by deck name.
- [ ] `make phpstan` passes.
- [ ] `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)