### PR TITLE
:wrench: Chore: allow gh issue view and gh project item-list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,8 @@
       "Bash(gh pr diff *)",
       "Bash(gh pr list *)",
       "Bash(gh pr checks *)",
+      "Bash(gh issue view *)",
+      "Bash(gh project item-list *)",
       "Bash(gh search *)",
       "Bash(ls *)",
       "Bash(ls)",


### PR DESCRIPTION
## Summary
- Add `Bash(gh issue view *)` and `Bash(gh project item-list *)` to the project permissions allow list in `.claude/settings.json`.
- Mirrors the existing read-only allow pattern for `gh pr view`/`gh pr list`/`gh pr checks` so the assistant can read issue details and list project board items without prompting, while non-read `gh issue` operations still fall through to the broader `Bash(gh issue *)` ask rule.

## Test plan
- [ ] Run `gh issue view <num>` from a Claude Code session and confirm no permission prompt appears.
- [ ] Run `gh project item-list 1 --owner jbourdin --format json --limit 200` and confirm no permission prompt appears.
- [ ] Confirm a non-read command like `gh issue close` still triggers the ask prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)