### PR TITLE
:bug: Fix: strip leading zeros from card numbers on export and display

### DIFF
--- a/assets/components/ArchetypeVariantSelector.tsx
+++ b/assets/components/ArchetypeVariantSelector.tsx
@@ -12,6 +12,7 @@ import { ActionIcon, Button, CopyButton, Group, Loader, Select, SegmentedControl
 import { useMediaQuery } from '@mantine/hooks';
 import { IconArrowsExchange, IconCheck, IconCopy, IconShare } from '@tabler/icons-react';
 import { initCardHover } from '../shared/card-hover';
+import { displayCardNumber } from '../utils/cardNumber';
 import CardImageModal, { type FlatCard } from './CardImageModal';
 import CardMosaicGrid from './CardMosaicGrid';
 
@@ -141,7 +142,7 @@ function CardSection({ title, cards, labels, onCardClick, canCopyTag }: {
                                 )}
                             </td>
                             <td><span className="badge bg-secondary">{card.setCode}</span></td>
-                            <td>{card.cardNumber}</td>
+                            <td>{displayCardNumber(card.cardNumber)}</td>
                             {canCopyTag && (
                                 <td>
                                     <CopyButton value={`[[card:${card.setCode}-${card.cardNumber}]]`} timeout={2000}>

--- a/assets/utils/cardNumber.ts
+++ b/assets/utils/cardNumber.ts
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Strip leading zeros from a card number for user-facing display
+ * (PTCG Live's text format expects "DRI 51", not "DRI 051").
+ *
+ * @see docs/features.md F6.7 — Export deck list as PTCGL text
+ */
+export const displayCardNumber = (cardNumber: string): string => {
+    if (cardNumber === '') {
+        return '';
+    }
+
+    const stripped = cardNumber.replace(/^0+/, '');
+
+    return stripped === '' ? '0' : stripped;
+};

--- a/src/Service/DeckList/CardNumberFormatter.php
+++ b/src/Service/DeckList/CardNumberFormatter.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\DeckList;
+
+/**
+ * Formats card set numbers for user-facing output.
+ *
+ * Card numbers may be stored zero-padded (e.g. "051", "086"), but PTCG Live's
+ * text format and the on-screen displays expect plain numbers ("51", "86").
+ *
+ * @see docs/features.md F6.7 — Export deck list as PTCGL text
+ */
+final class CardNumberFormatter
+{
+    public static function display(string $cardNumber): string
+    {
+        if ('' === $cardNumber) {
+            return '';
+        }
+
+        $stripped = ltrim($cardNumber, '0');
+
+        return '' === $stripped ? '0' : $stripped;
+    }
+}

--- a/src/Service/DeckList/MinifiedListGenerator.php
+++ b/src/Service/DeckList/MinifiedListGenerator.php
@@ -242,6 +242,6 @@ class MinifiedListGenerator
 
     private function formatLine(int $quantity, string $name, string $setCode, string $cardNumber): string
     {
-        return \sprintf('%d %s %s %s', $quantity, $name, $setCode, $cardNumber);
+        return \sprintf('%d %s %s %s', $quantity, $name, $setCode, CardNumberFormatter::display($cardNumber));
     }
 }

--- a/src/Service/DeckList/OriginalListFormatter.php
+++ b/src/Service/DeckList/OriginalListFormatter.php
@@ -85,7 +85,7 @@ class OriginalListFormatter
                 $currentType = $type;
             }
 
-            $lines[] = \sprintf('%d %s %s %s', $entry['quantity'], $entry['name'], $entry['setCode'], $entry['cardNumber']);
+            $lines[] = \sprintf('%d %s %s %s', $entry['quantity'], $entry['name'], $entry['setCode'], CardNumberFormatter::display($entry['cardNumber']));
         }
 
         $lines[] = '';

--- a/src/Service/DeckVersionDiffer.php
+++ b/src/Service/DeckVersionDiffer.php
@@ -15,6 +15,7 @@ namespace App\Service;
 
 use App\Entity\DeckCard;
 use App\Entity\DeckVersion;
+use App\Service\DeckList\CardNumberFormatter;
 
 /**
  * @see docs/features.md F2.9 — Deck version history
@@ -106,7 +107,7 @@ final class DeckVersionDiffer
         return [
             'cardName' => $card->getCardName(),
             'setCode' => $card->getSetCode(),
-            'cardNumber' => $card->getCardNumber(),
+            'cardNumber' => CardNumberFormatter::display($card->getCardNumber()),
             'quantity' => $card->getQuantity(),
             'cardType' => $card->getCardType(),
             'trainerSubtype' => $trainerSubtype,

--- a/src/Twig/Extension/CardNumberExtension.php
+++ b/src/Twig/Extension/CardNumberExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Twig\Extension;
+
+use App\Service\DeckList\CardNumberFormatter;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * @see docs/features.md F6.7 — Export deck list as PTCGL text
+ */
+final class CardNumberExtension extends AbstractExtension
+{
+    /**
+     * @return list<TwigFilter>
+     */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('card_number', [CardNumberFormatter::class, 'display']),
+        ];
+    }
+}

--- a/templates/archetype/variant_compare.html.twig
+++ b/templates/archetype/variant_compare.html.twig
@@ -109,7 +109,7 @@
                                         {% endif %}
                                     </td>
                                     <td><span class="badge bg-secondary">{{ entry.setCode }}</span></td>
-                                    <td>{{ entry.cardNumber }}</td>
+                                    <td>{{ entry.cardNumber|card_number }}</td>
                                 </tr>
                             {% endfor %}
                         </tbody>

--- a/templates/deck/show.html.twig
+++ b/templates/deck/show.html.twig
@@ -55,7 +55,7 @@
                                 {% endif %}
                             </td>
                             <td><code>{{ card.setCode }}</code></td>
-                            <td>{{ card.cardNumber }}</td>
+                            <td>{{ card.cardNumber|card_number }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -314,7 +314,7 @@
                 {{ 'app.deck.name_match_warning_body'|trans }}
                 <ul class="mb-0 mt-1">
                     {% for card in nameMatchedCards %}
-                        <li>{{ card.cardName }} ({{ card.setCode }} {{ card.cardNumber }})</li>
+                        <li>{{ card.cardName }} ({{ card.setCode }} {{ card.cardNumber|card_number }})</li>
                     {% endfor %}
                 </ul>
             </div>
@@ -330,7 +330,7 @@
                         cardName: card.cardName,
                         quantity: card.quantity,
                         setCode: card.setCode,
-                        cardNumber: card.cardNumber,
+                        cardNumber: card.cardNumber|card_number,
                         cardType: card.cardType,
                         trainerSubtype: card.trainerSubtype,
                         imageUrl: card.imageUrl,

--- a/templates/label/pdf_decklist.html.twig
+++ b/templates/label/pdf_decklist.html.twig
@@ -250,7 +250,7 @@
                         {% if row.symbolDataUri %}
                             <img class="set-symbol" src="{{ row.symbolDataUri }}" alt="">
                         {% endif %}
-                        {{ row.setCode }}-{{ row.cardNumber }}
+                        {{ row.setCode }}-{{ row.cardNumber|card_number }}
                     </td>
                     <td class="col-check">{% for i in 1..row.quantity %}<span class="checkbox"></span>{% endfor %}</td>
                 </tr>

--- a/templates/label/pdf_label_foldable.html.twig
+++ b/templates/label/pdf_label_foldable.html.twig
@@ -204,7 +204,7 @@
                 <div class="decklist-section decklist-shade-{{ loop.index0 % 2 }}">
                     {% for card in cards %}
                         <div class="decklist-card">
-                            <span class="decklist-qty">{{ card.quantity }}</span> {{ card.cardName }} <span class="decklist-set">{{ card.setCode }} {{ card.cardNumber }}</span>
+                            <span class="decklist-qty">{{ card.quantity }}</span> {{ card.cardName }} <span class="decklist-set">{{ card.setCode }} {{ card.cardNumber|card_number }}</span>
                         </div>
                     {% endfor %}
                 </div>

--- a/tests/Service/DeckList/CardNumberFormatterTest.php
+++ b/tests/Service/DeckList/CardNumberFormatterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\DeckList;
+
+use App\Service\DeckList\CardNumberFormatter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F6.7 — Export deck list as PTCGL text
+ */
+class CardNumberFormatterTest extends TestCase
+{
+    #[DataProvider('cardNumberProvider')]
+    public function testDisplay(string $input, string $expected): void
+    {
+        self::assertSame($expected, CardNumberFormatter::display($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function cardNumberProvider(): iterable
+    {
+        yield 'plain number is unchanged' => ['51', '51'];
+        yield 'three-digit unpadded is unchanged' => ['127', '127'];
+        yield 'leading zero is stripped' => ['051', '51'];
+        yield 'multiple leading zeros are stripped' => ['086', '86'];
+        yield 'all zeros collapses to single zero' => ['000', '0'];
+        yield 'single zero is preserved' => ['0', '0'];
+        yield 'empty string is preserved' => ['', ''];
+        yield 'alphanumeric suffix is preserved' => ['001A', '1A'];
+        yield 'leading-letter number is unchanged' => ['SV001', 'SV001'];
+    }
+}

--- a/tests/Service/DeckList/MinifiedListGeneratorTest.php
+++ b/tests/Service/DeckList/MinifiedListGeneratorTest.php
@@ -203,6 +203,18 @@ final class MinifiedListGeneratorTest extends TestCase
         self::assertStringContainsString('2 N NVI 92', $output);
     }
 
+    public function testStripsLeadingZerosFromCardNumber(): void
+    {
+        $card = $this->createDeckCard("Team Rocket's Articuno", 'DRI', '051', 'pokemon', 2);
+
+        $version = $this->createVersionWithCards([$card]);
+
+        $generator = new MinifiedListGenerator($this->printingRepository, $this->identityResolver, $this->logger);
+        $output = $generator->generate($version);
+
+        self::assertStringContainsString("2 Team Rocket's Articuno DRI 51", $output);
+    }
+
     private function createDeckCard(string $name, string $setCode, string $cardNumber, string $cardType, int $quantity): DeckCard
     {
         $card = new DeckCard();

--- a/tests/Service/DeckList/OriginalListFormatterTest.php
+++ b/tests/Service/DeckList/OriginalListFormatterTest.php
@@ -116,6 +116,19 @@ class OriginalListFormatterTest extends TestCase
         self::assertSame("\nTotal Cards: 0", $result);
     }
 
+    public function testStripsLeadingZerosFromCardNumber(): void
+    {
+        $version = $this->createVersion([
+            ['name' => "Team Rocket's Articuno", 'quantity' => 2, 'set' => 'DRI', 'number' => '051', 'type' => 'pokemon', 'subtype' => null],
+            ['name' => 'Ignition Energy', 'quantity' => 4, 'set' => 'WHT', 'number' => '086', 'type' => 'energy', 'subtype' => null],
+        ]);
+
+        $result = $this->formatter->format($version);
+
+        self::assertStringContainsString("2 Team Rocket's Articuno DRI 51", $result);
+        self::assertStringContainsString('4 Ignition Energy WHT 86', $result);
+    }
+
     /**
      * @param list<array{name: string, quantity: int, set: string, number: string, type: string, subtype: ?string}> $cards
      */


### PR DESCRIPTION
## Summary

- Card numbers were rendered zero-padded (e.g. `DRI 051`, `WHT 086`) in PTCG Live exports and on-screen tables, while TCG Live's text format expects plain numbers (`DRI 51`, `WHT 86`). Pasting the export into TCG Live produced an invalid deck list.
- Add `CardNumberFormatter::display()` PHP helper, a matching `card_number` Twig filter (`CardNumberExtension`), and a `displayCardNumber` JS util.
- Apply at every user-facing surface: PTCG Live original + minified text exports, deck show table + name-match warning, archetype variant selector, deck/archetype version-compare diffs, foldable deck label PDF, printed decklist PDF.
- Storage and lookup paths are untouched — padded values remain in the DB and `[[card:SET-NNN]]` shortcodes keep resolving via `ArchetypeDescriptionRenderer`. The React copy-button in `ArchetypeVariantSelector` keeps emitting the raw padded form for the same reason.

## Test plan

- [ ] `make cs-fix && make phpstan && make test.unit && make test.front` all green
- [ ] Open a deck whose stored numbers are padded (e.g. Articuno `DRI 051`, Ignition Energy `WHT 086`); on the deck page table, the number column shows `51` / `86`
- [ ] Click "Copy" on the deck list → pasted text uses unpadded numbers
- [ ] Same expectation for the minified variant
- [ ] Open archetype detail and a variant comparison — number column unpadded; `[[card:SET-NNN]]` copy still emits the padded raw form (so legacy descriptions resolve)
- [ ] Open `/deck/{tag}/versions` compare view — diff table shows unpadded numbers
- [ ] Generate the deck PDFs (decklist + foldable label) — printed numbers are unpadded

🤖 Generated with [Claude Code](https://claude.com/claude-code)