### PR TITLE
:sparkles: Feature: event tags, public iCal feed, and personal agenda

### DIFF
--- a/assets/components/EventTagSelect.tsx
+++ b/assets/components/EventTagSelect.tsx
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React, { useState } from 'react';
+import { TagsInput } from '@mantine/core';
+
+/**
+ * @see docs/features.md F3.12 — Event tags
+ */
+
+interface EventTagSelectProps {
+    existingTags: string[];
+    initialValues?: string[];
+    hiddenInputName: string;
+    placeholder?: string;
+}
+
+const normalizeTag = (tag: string): string => tag.replace(/\s+/g, ' ').trim();
+
+const EventTagSelect: React.FC<EventTagSelectProps> = ({ existingTags, initialValues = [], hiddenInputName, placeholder }) => {
+    const [value, setValue] = useState<string[]>(initialValues);
+
+    const syncHidden = (newValue: string[]): void => {
+        const hiddenInput = document.querySelector<HTMLInputElement>(
+            `input[name="${hiddenInputName}"]`,
+        );
+
+        if (hiddenInput) {
+            hiddenInput.value = JSON.stringify(newValue);
+        }
+    };
+
+    if (initialValues.length > 0) {
+        const hiddenInput = document.querySelector<HTMLInputElement>(
+            `input[name="${hiddenInputName}"]`,
+        );
+        if (hiddenInput && hiddenInput.value === '') {
+            hiddenInput.value = JSON.stringify(initialValues);
+        }
+    }
+
+    const handleChange = (newValue: string[]): void => {
+        const normalized = newValue.map(normalizeTag).filter((tag) => tag.length >= 2);
+        const seen = new Set<string>();
+        const unique: string[] = [];
+
+        for (const tag of normalized) {
+            const key = tag.toLowerCase();
+
+            if (!seen.has(key)) {
+                seen.add(key);
+                unique.push(tag);
+            }
+        }
+
+        setValue(unique);
+        syncHidden(unique);
+    };
+
+    return (
+        <TagsInput
+            data={existingTags}
+            value={value}
+            onChange={handleChange}
+            placeholder={placeholder ?? ''}
+            clearable
+            splitChars={[',']}
+        />
+    );
+};
+
+export default EventTagSelect;

--- a/assets/event-calendar-copy.ts
+++ b/assets/event-calendar-copy.ts
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @see docs/features.md F3.16 — Public iCal feed
+ */
+
+document.addEventListener('click', (event) => {
+    const target = event.target as HTMLElement | null;
+
+    if (!target) {
+        return;
+    }
+
+    const button = target.closest<HTMLButtonElement>('[data-event-calendar-copy]');
+
+    if (!button) {
+        return;
+    }
+
+    event.preventDefault();
+
+    const url = button.dataset.copyUrl ?? '';
+    const labelSpan = button.querySelector('span');
+    const defaultLabel = button.dataset.labelDefault ?? '';
+    const copiedLabel = button.dataset.labelCopied ?? '';
+
+    if (url === '') {
+        return;
+    }
+
+    navigator.clipboard.writeText(url).then(() => {
+        if (labelSpan && copiedLabel !== '') {
+            labelSpan.textContent = copiedLabel;
+
+            setTimeout(() => {
+                labelSpan.textContent = defaultLabel;
+            }, 2000);
+        }
+    }).catch(() => {
+        // Clipboard API can fail in non-secure contexts; we silently degrade.
+    });
+});

--- a/assets/event-form.tsx
+++ b/assets/event-form.tsx
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { MantineProvider } from '@mantine/core';
+import EventTagSelect from './components/EventTagSelect';
+
+import '@mantine/core/styles.css';
+
+/**
+ * @see docs/features.md F3.12 — Event tags
+ */
+
+const tagRoot = document.getElementById('event-tag-select-root');
+
+if (tagRoot) {
+    let existingTags: string[] = [];
+    let initialValues: string[] = [];
+
+    try {
+        const rawTags = tagRoot.dataset.existingTags;
+        if (rawTags) {
+            existingTags = JSON.parse(rawTags);
+        }
+    } catch {
+        // Invalid JSON — use empty array
+    }
+
+    try {
+        const rawValues = tagRoot.dataset.values;
+        if (rawValues) {
+            initialValues = JSON.parse(rawValues);
+        }
+    } catch {
+        // Invalid JSON — use empty array
+    }
+
+    const hiddenInputName = tagRoot.dataset.hiddenInputName ?? 'event_form[tagsInput]';
+    const placeholder = tagRoot.dataset.placeholder ?? '';
+
+    createRoot(tagRoot).render(
+        <MantineProvider>
+            <EventTagSelect
+                existingTags={existingTags}
+                initialValues={initialValues}
+                hiddenInputName={hiddenInputName}
+                placeholder={placeholder}
+            />
+        </MantineProvider>,
+    );
+}

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "doctrine/doctrine-migrations-bundle": "^4.0",
         "doctrine/orm": "^3.6.3",
         "dompdf/dompdf": "^3.1.5",
+        "eluceo/ical": "^2.16",
         "endroid/qr-code": "^6.1.3",
         "friendlycaptcha/sdk": "^0.2.0",
         "league/commonmark": "^2.8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1743fbd9ca3268785f41a395b43482d3",
+    "content-hash": "6b609a0522faa4d1579d30a66de8d54c",
     "packages": [
         {
             "name": "async-aws/core",
@@ -1882,6 +1882,66 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "eluceo/ical",
+            "version": "2.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/markuspoerschke/iCal.git",
+                "reference": "4bdc085e14d0a213d7b387a80793320e4f45d430"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/markuspoerschke/iCal/zipball/4bdc085e14d0a213d7b387a80793320e4f45d430",
+                "reference": "4bdc085e14d0a213d7b387a80793320e4f45d430",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "~8.4.0 || ~8.5.0",
+                "symfony/deprecation-contracts": "^3.6"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.48",
+                "friendsofphp/php-cs-fixer": "^3.92",
+                "infection/infection": "^0.32",
+                "phpunit/phpunit": "^10.5",
+                "vimeo/psalm": "^6.14"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Eluceo\\iCal\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Poerschke",
+                    "email": "markus@poerschke.nrw",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The eluceo/iCal package offers an abstraction layer for creating iCalendars. You can easily create iCal files by using PHP objects instead of typing your *.ics file by hand. The output will follow RFC 5545 as best as possible.",
+            "homepage": "https://github.com/markuspoerschke/iCal",
+            "keywords": [
+                "calendar",
+                "iCalendar",
+                "ical",
+                "ics",
+                "php calendar"
+            ],
+            "support": {
+                "docs": "https://ical.poerschke.nrw",
+                "forum": "https://github.com/markuspoerschke/iCal/discussions",
+                "issues": "https://github.com/markuspoerschke/iCal/issues",
+                "source": "https://github.com/markuspoerschke/iCal"
+            },
+            "time": "2026-01-07T21:34:08+00:00"
         },
         {
             "name": "endroid/qr-code",

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -54,6 +54,9 @@ security:
         - { path: ^/api/archetype/search$, roles: PUBLIC_ACCESS }
         - { path: ^/api/deck-owner/search$, roles: PUBLIC_ACCESS }
         - { path: ^/event$, roles: PUBLIC_ACCESS }
+        - { path: ^/event\.ics$, roles: PUBLIC_ACCESS }
+        - { path: '^/event/tag/[a-z0-9][a-z0-9-]*$', roles: PUBLIC_ACCESS }
+        - { path: '^/event/tag/[a-z0-9][a-z0-9-]*\.ics$', roles: PUBLIC_ACCESS }
         - { path: ^/events/discover$, roles: PUBLIC_ACCESS }
         - { path: '^/event/\d+/results$', roles: PUBLIC_ACCESS }
         - { path: ^/health, roles: PUBLIC_ACCESS }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -57,6 +57,7 @@ security:
         - { path: ^/event\.ics$, roles: PUBLIC_ACCESS }
         - { path: '^/event/tag/[a-z0-9][a-z0-9-]*$', roles: PUBLIC_ACCESS }
         - { path: '^/event/tag/[a-z0-9][a-z0-9-]*\.ics$', roles: PUBLIC_ACCESS }
+        - { path: '^/calendar/event/[A-Za-z0-9_-]+\.ics$', roles: PUBLIC_ACCESS }
         - { path: ^/events/discover$, roles: PUBLIC_ACCESS }
         - { path: '^/event/\d+/results$', roles: PUBLIC_ACCESS }
         - { path: ^/health, roles: PUBLIC_ACCESS }

--- a/migrations/Version20260501100000.php
+++ b/migrations/Version20260501100000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Create event_tag and event_event_tag join table for tagging events.
+ *
+ * @see docs/features.md F3.12 — Event tags
+ */
+final class Version20260501100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create event_tag table and event_event_tag join for event tagging';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE event_tag (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(50) NOT NULL, slug VARCHAR(50) NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', UNIQUE INDEX uniq_event_tag_name (name), UNIQUE INDEX uniq_event_tag_slug (slug), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE event_event_tag (event_id INT NOT NULL, event_tag_id INT NOT NULL, INDEX IDX_event_event_tag_event (event_id), INDEX IDX_event_event_tag_tag (event_tag_id), PRIMARY KEY(event_id, event_tag_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE event_event_tag ADD CONSTRAINT FK_event_event_tag_event FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE event_event_tag ADD CONSTRAINT FK_event_event_tag_tag FOREIGN KEY (event_tag_id) REFERENCES event_tag (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event_event_tag DROP FOREIGN KEY FK_event_event_tag_event');
+        $this->addSql('ALTER TABLE event_event_tag DROP FOREIGN KEY FK_event_event_tag_tag');
+        $this->addSql('DROP TABLE event_event_tag');
+        $this->addSql('DROP TABLE event_tag');
+    }
+}

--- a/migrations/Version20260501150000.php
+++ b/migrations/Version20260501150000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add calendar_token column to user for the per-user iCal agenda feed.
+ *
+ * @see docs/features.md F3.14 — iCal agenda feed
+ */
+final class Version20260501150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add user.calendar_token for the personal iCal agenda feed';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD calendar_token VARCHAR(64) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX uniq_user_calendar_token ON user (calendar_token)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_user_calendar_token ON user');
+        $this->addSql('ALTER TABLE user DROP calendar_token');
+    }
+}

--- a/src/Controller/EventAgendaController.php
+++ b/src/Controller/EventAgendaController.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Repository\EventRepository;
+use App\Service\Event\EventIcalBuilder;
+use App\Service\Event\PersonalCalendarTokenService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Per-user agenda view + private iCal feed.
+ *
+ * @see docs/features.md F3.14 — iCal agenda feed
+ */
+class EventAgendaController extends AbstractController
+{
+    private const int FEED_LIMIT = 200;
+    private const int CACHE_MAX_AGE = 1800;
+
+    /**
+     * Logged-in agenda: every upcoming event the current user is engaged with
+     * (interested, invited, registered playing, registered spectating).
+     */
+    #[Route('/event/agenda', name: 'app_event_agenda', methods: ['GET'], priority: 20)]
+    #[IsGranted('ROLE_USER')]
+    public function show(
+        EventRepository $eventRepository,
+        PersonalCalendarTokenService $tokenService,
+    ): Response {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $token = $tokenService->ensureToken($user);
+
+        $events = $eventRepository->findUpcomingForUserAgenda($user);
+
+        return $this->render('event/agenda.html.twig', [
+            'events' => $events,
+            'icalUrl' => $this->generateUrl(
+                'app_event_agenda_ical',
+                ['token' => $token],
+                UrlGeneratorInterface::ABSOLUTE_PATH,
+            ),
+            'icalAbsoluteUrl' => $this->generateUrl(
+                'app_event_agenda_ical',
+                ['token' => $token],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            ),
+        ]);
+    }
+
+    /**
+     * Issue a fresh token, invalidating the previous URL.
+     */
+    #[Route('/event/agenda/regenerate-token', name: 'app_event_agenda_regenerate', methods: ['POST'], priority: 20)]
+    #[IsGranted('ROLE_USER')]
+    public function regenerate(Request $request, PersonalCalendarTokenService $tokenService): RedirectResponse
+    {
+        if (!$this->isCsrfTokenValid('event-agenda-regenerate', $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.flash.invalid_token');
+
+            return $this->redirectToRoute('app_event_agenda');
+        }
+
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $tokenService->regenerateToken($user);
+        $this->addFlash('success', 'app.event.agenda.token_regenerated');
+
+        return $this->redirectToRoute('app_event_agenda');
+    }
+
+    /**
+     * Anonymous-friendly per-user iCal feed. The token in the URL is the
+     * sole authentication factor, so we never reveal whether a token exists
+     * (404 covers both unknown tokens and unknown users).
+     */
+    #[Route('/calendar/event/{token}.ics', name: 'app_event_agenda_ical', methods: ['GET'], requirements: ['token' => '[A-Za-z0-9_-]{8,64}'], priority: 30)]
+    public function feed(
+        string $token,
+        EventRepository $eventRepository,
+        PersonalCalendarTokenService $tokenService,
+        EventIcalBuilder $builder,
+        TranslatorInterface $translator,
+    ): Response {
+        $user = $tokenService->findUserByToken($token);
+
+        if (null === $user) {
+            throw $this->createNotFoundException();
+        }
+
+        $events = $eventRepository->findUpcomingForUserAgenda($user);
+
+        $calendar = $builder->build(
+            \array_slice($events, 0, self::FEED_LIMIT),
+            $translator->trans('app.event.ical.agenda_feed_title', ['%name%' => $user->getScreenName()]),
+        );
+
+        $response = new Response($calendar, Response::HTTP_OK, [
+            'Content-Type' => 'text/calendar; charset=utf-8',
+            'Content-Disposition' => \sprintf('inline; filename="agenda-%s.ics"', $user->getScreenName()),
+            'Cache-Control' => \sprintf('private, max-age=%d', self::CACHE_MAX_AGE),
+        ]);
+
+        $response->setPrivate();
+        $response->setMaxAge(self::CACHE_MAX_AGE);
+
+        return $response;
+    }
+}

--- a/src/Controller/EventAgendaController.php
+++ b/src/Controller/EventAgendaController.php
@@ -116,14 +116,13 @@ class EventAgendaController extends AbstractController
             $translator->trans('app.event.ical.agenda_feed_title', ['%name%' => $user->getScreenName()]),
         );
 
-        $response = new Response($calendar, Response::HTTP_OK, [
-            'Content-Type' => 'text/calendar; charset=utf-8',
-            'Content-Disposition' => \sprintf('inline; filename="agenda-%s.ics"', $user->getScreenName()),
-            'Cache-Control' => \sprintf('private, max-age=%d', self::CACHE_MAX_AGE),
-        ]);
+        $response = new Response($calendar);
 
+        $response->headers->set('Content-Type', 'text/calendar; charset=utf-8');
+        $response->headers->set('Content-Disposition', \sprintf('inline; filename="agenda-%s.ics"', $user->getScreenName()));
         $response->setPrivate();
         $response->setMaxAge(self::CACHE_MAX_AGE);
+        $response->headers->set('Cache-Control', 'private, max-age='.self::CACHE_MAX_AGE);
 
         return $response;
     }

--- a/src/Controller/EventCalendarController.php
+++ b/src/Controller/EventCalendarController.php
@@ -79,14 +79,14 @@ class EventCalendarController extends AbstractController
 
     private function buildIcalResponse(string $calendar, string $filename): Response
     {
-        $response = new Response($calendar, Response::HTTP_OK, [
-            'Content-Type' => 'text/calendar; charset=utf-8',
-            'Content-Disposition' => \sprintf('inline; filename="%s"', $filename),
-            'Cache-Control' => \sprintf('public, max-age=%d', self::CACHE_MAX_AGE),
-        ]);
+        $response = new Response($calendar);
 
+        $response->headers->set('Content-Type', 'text/calendar; charset=utf-8');
+        $response->headers->set('Content-Disposition', \sprintf('inline; filename="%s"', $filename));
         $response->setPublic();
         $response->setMaxAge(self::CACHE_MAX_AGE);
+        $response->setSharedMaxAge(self::CACHE_MAX_AGE);
+        $response->headers->set('Cache-Control', 'public, max-age='.self::CACHE_MAX_AGE);
 
         return $response;
     }

--- a/src/Controller/EventCalendarController.php
+++ b/src/Controller/EventCalendarController.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use App\Repository\EventRepository;
+use App\Repository\EventTagRepository;
+use App\Service\Event\EventIcalBuilder;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Public iCal calendar feeds for upcoming events.
+ *
+ * @see docs/features.md F3.16 — Public iCal feed
+ */
+class EventCalendarController extends AbstractController
+{
+    private const int CACHE_MAX_AGE = 3600;
+    private const int FEED_LIMIT = 200;
+
+    /**
+     * Calendar feed of all upcoming public events.
+     */
+    #[Route('/event.ics', name: 'app_event_list_ical', methods: ['GET'], priority: 20)]
+    public function list(
+        EventRepository $eventRepository,
+        EventIcalBuilder $builder,
+        TranslatorInterface $translator,
+    ): Response {
+        $events = $eventRepository->findPublicUpcoming(self::FEED_LIMIT);
+
+        $calendar = $builder->build(
+            $events,
+            $translator->trans('app.event.ical.feed_title'),
+        );
+
+        return $this->buildIcalResponse($calendar, 'expanded-decks-events.ics');
+    }
+
+    /**
+     * Calendar feed of upcoming public events tagged with the given slug.
+     */
+    #[Route('/event/tag/{slug}.ics', name: 'app_event_tag_ical', methods: ['GET'], requirements: ['slug' => '[a-z0-9][a-z0-9-]*'], priority: 20)]
+    public function tag(
+        string $slug,
+        EventRepository $eventRepository,
+        EventTagRepository $tagRepository,
+        EventIcalBuilder $builder,
+        TranslatorInterface $translator,
+    ): Response {
+        $tag = $tagRepository->findOneBySlug($slug);
+
+        if (null === $tag) {
+            throw $this->createNotFoundException();
+        }
+
+        $events = $eventRepository->findPublicUpcomingByTag($tag, self::FEED_LIMIT);
+
+        $calendar = $builder->build(
+            $events,
+            $translator->trans('app.event.ical.feed_title_tag', ['%name%' => $tag->getName()]),
+        );
+
+        return $this->buildIcalResponse($calendar, \sprintf('expanded-decks-events-%s.ics', $tag->getSlug()));
+    }
+
+    private function buildIcalResponse(string $calendar, string $filename): Response
+    {
+        $response = new Response($calendar, Response::HTTP_OK, [
+            'Content-Type' => 'text/calendar; charset=utf-8',
+            'Content-Disposition' => \sprintf('inline; filename="%s"', $filename),
+            'Cache-Control' => \sprintf('public, max-age=%d', self::CACHE_MAX_AGE),
+        ]);
+
+        $response->setPublic();
+        $response->setMaxAge(self::CACHE_MAX_AGE);
+
+        return $response;
+    }
+}

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -20,6 +20,7 @@ use App\Entity\EventDeckEntry;
 use App\Entity\EventDeckRegistration;
 use App\Entity\EventEngagement;
 use App\Entity\EventStaff;
+use App\Entity\EventTag;
 use App\Entity\User;
 use App\Enum\BorrowStatus;
 use App\Enum\DeckStatus;
@@ -35,6 +36,7 @@ use App\Repository\DeckRepository;
 use App\Repository\EventDeckEntryRepository;
 use App\Repository\EventDeckRegistrationRepository;
 use App\Repository\EventStaffRepository;
+use App\Repository\EventTagRepository;
 use App\Repository\UserRepository;
 use App\Service\BorrowService;
 use App\Service\EventNotificationService;
@@ -71,7 +73,7 @@ class EventController extends AbstractAppController
      */
     #[Route('/new', name: 'app_event_new', methods: ['GET', 'POST'])]
     #[IsGranted('ROLE_ORGANIZER')]
-    public function new(Request $request, EntityManagerInterface $em): Response
+    public function new(Request $request, EntityManagerInterface $em, EventTagRepository $tagRepository): Response
     {
         /** @var User $user */
         $user = $this->getUser();
@@ -87,6 +89,7 @@ class EventController extends AbstractAppController
         if ($form->isSubmitted() && $form->isValid()) {
             $event->setOrganizer($user);
             $event->setFormat('Expanded');
+            $this->applyTagsFromForm($event, $form, $tagRepository);
             $em->persist($event);
             $em->flush();
 
@@ -97,6 +100,8 @@ class EventController extends AbstractAppController
 
         return $this->render('event/new.html.twig', [
             'form' => $form,
+            'existingTagNames' => $this->collectExistingTagNames($tagRepository),
+            'initialTagNames' => $this->collectEventTagNames($event),
         ]);
     }
 
@@ -391,7 +396,7 @@ class EventController extends AbstractAppController
      */
     #[Route('/{id}/edit', name: 'app_event_edit', methods: ['GET', 'POST'], requirements: ['id' => '\d+'])]
     #[IsGranted('ROLE_ORGANIZER')]
-    public function edit(Event $event, Request $request, EntityManagerInterface $em, EventNotificationService $notificationService): Response
+    public function edit(Event $event, Request $request, EntityManagerInterface $em, EventNotificationService $notificationService, EventTagRepository $tagRepository): Response
     {
         $this->denyAccessUnlessOrganizer($event);
 
@@ -408,6 +413,7 @@ class EventController extends AbstractAppController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event->setFormat('Expanded');
+            $this->applyTagsFromForm($event, $form, $tagRepository);
             $em->flush();
 
             $notificationService->notifyEventUpdated($event);
@@ -420,6 +426,8 @@ class EventController extends AbstractAppController
         return $this->render('event/edit.html.twig', [
             'event' => $event,
             'form' => $form,
+            'existingTagNames' => $this->collectExistingTagNames($tagRepository),
+            'initialTagNames' => $this->collectEventTagNames($event),
         ]);
     }
 
@@ -1264,5 +1272,61 @@ class EventController extends AbstractAppController
         if ($event->getOrganizer()->getId() !== $user->getId()) {
             throw $this->createAccessDeniedException('You are not the organizer of this event.');
         }
+    }
+
+    /**
+     * @see docs/features.md F3.12 — Event tags
+     *
+     * @param \Symfony\Component\Form\FormInterface<Event> $form
+     */
+    private function applyTagsFromForm(Event $event, \Symfony\Component\Form\FormInterface $form, EventTagRepository $tagRepository): void
+    {
+        /** @var string|null $tagsJson */
+        $tagsJson = $form->get('tagsInput')->getData();
+
+        if (null === $tagsJson || '' === $tagsJson) {
+            $event->setTags([]);
+
+            return;
+        }
+
+        $decoded = json_decode($tagsJson, true);
+
+        if (!\is_array($decoded)) {
+            $event->setTags([]);
+
+            return;
+        }
+
+        /** @var list<string> $names */
+        $names = array_values(array_filter($decoded, 'is_string'));
+
+        $event->setTags($tagRepository->resolveByNames($names));
+    }
+
+    /**
+     * @see docs/features.md F3.12 — Event tags
+     *
+     * @return list<string>
+     */
+    private function collectExistingTagNames(EventTagRepository $tagRepository): array
+    {
+        return array_map(static fn (EventTag $tag): string => $tag->getName(), $tagRepository->findAllOrderedByName());
+    }
+
+    /**
+     * @see docs/features.md F3.12 — Event tags
+     *
+     * @return list<string>
+     */
+    private function collectEventTagNames(Event $event): array
+    {
+        $names = [];
+
+        foreach ($event->getTags() as $tag) {
+            $names[] = $tag->getName();
+        }
+
+        return $names;
     }
 }

--- a/src/Controller/EventListController.php
+++ b/src/Controller/EventListController.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\EventTag;
 use App\Entity\User;
 use App\Repository\EventRepository;
+use App\Repository\EventTagRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,6 +26,7 @@ use Symfony\Component\Routing\Attribute\Route;
  * Public event listing, accessible without authentication.
  *
  * @see docs/features.md F3.2 — Event listing
+ * @see docs/features.md F3.12 — Event tags
  * @see docs/features.md F3.15 — Event discovery
  */
 class EventListController extends AbstractController
@@ -32,12 +35,16 @@ class EventListController extends AbstractController
 
     /**
      * @see docs/features.md F3.11 — Event visibility
+     * @see docs/features.md F3.12 — Event tags
      * @see docs/features.md F3.15 — Event discovery
      * @see docs/features.md F7.1 — Dashboard (scope=staffing)
      */
     #[Route('/event', name: 'app_event_list', methods: ['GET'], priority: 10)]
-    public function list(Request $request, EventRepository $eventRepository): Response
-    {
+    public function list(
+        Request $request,
+        EventRepository $eventRepository,
+        EventTagRepository $tagRepository,
+    ): Response {
         /** @var User|null $user */
         $user = $this->getUser();
         $scope = $request->query->getString('scope', 'all');
@@ -51,15 +58,62 @@ class EventListController extends AbstractController
             $scope = 'public';
         }
 
-        $events = match ($scope) {
-            'public' => $eventRepository->findPublicUpcoming(),
-            'staffing' => $eventRepository->findUpcomingByOrganizerOrStaff($user ?? throw new \LogicException()),
-            default => $eventRepository->findVisibleUpcoming($user),
-        };
+        $tagSlug = trim($request->query->getString('tag'));
+        $activeTag = '' !== $tagSlug ? $tagRepository->findOneBySlug($tagSlug) : null;
+
+        if (null !== $activeTag) {
+            $events = match ($scope) {
+                'public' => $eventRepository->findPublicUpcomingByTag($activeTag),
+                default => $eventRepository->findVisibleUpcomingByTag($user, $activeTag),
+            };
+        } else {
+            $events = match ($scope) {
+                'public' => $eventRepository->findPublicUpcoming(),
+                'staffing' => $eventRepository->findUpcomingByOrganizerOrStaff($user ?? throw new \LogicException()),
+                default => $eventRepository->findVisibleUpcoming($user),
+            };
+        }
 
         return $this->render('event/list.html.twig', [
             'events' => $events,
             'scope' => $scope,
+            'allTags' => $tagRepository->findAllOrderedByName(),
+            'activeTag' => $activeTag,
+            'icalUrl' => $this->generateIcalUrl($activeTag),
+        ]);
+    }
+
+    /**
+     * Public list of upcoming events tagged with a given slug.
+     *
+     * @see docs/features.md F3.12 — Event tags
+     * @see docs/features.md F3.16 — Public iCal feed
+     */
+    #[Route('/event/tag/{slug}', name: 'app_event_tag', methods: ['GET'], requirements: ['slug' => '[a-z0-9][a-z0-9-]*'], priority: 10)]
+    public function tag(
+        string $slug,
+        EventRepository $eventRepository,
+        EventTagRepository $tagRepository,
+    ): Response {
+        $tag = $tagRepository->findOneBySlug($slug);
+
+        if (null === $tag) {
+            throw $this->createNotFoundException();
+        }
+
+        /** @var User|null $user */
+        $user = $this->getUser();
+
+        $events = null !== $user
+            ? $eventRepository->findVisibleUpcomingByTag($user, $tag)
+            : $eventRepository->findPublicUpcomingByTag($tag);
+
+        return $this->render('event/list.html.twig', [
+            'events' => $events,
+            'scope' => 'public',
+            'allTags' => $tagRepository->findAllOrderedByName(),
+            'activeTag' => $tag,
+            'icalUrl' => $this->generateIcalUrl($tag),
         ]);
     }
 
@@ -70,5 +124,14 @@ class EventListController extends AbstractController
     public function discover(): Response
     {
         return $this->redirectToRoute('app_event_list', ['scope' => 'public'], Response::HTTP_MOVED_PERMANENTLY);
+    }
+
+    private function generateIcalUrl(?EventTag $tag): string
+    {
+        if (null !== $tag) {
+            return $this->generateUrl('app_event_tag_ical', ['slug' => $tag->getSlug()]);
+        }
+
+        return $this->generateUrl('app_event_list_ical');
     }
 }

--- a/src/Controller/EventListController.php
+++ b/src/Controller/EventListController.php
@@ -31,7 +31,7 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 class EventListController extends AbstractController
 {
-    private const VALID_SCOPES = ['all', 'public', 'staffing'];
+    private const VALID_SCOPES = ['all', 'public'];
 
     /**
      * @see docs/features.md F3.11 — Event visibility
@@ -69,7 +69,6 @@ class EventListController extends AbstractController
         } else {
             $events = match ($scope) {
                 'public' => $eventRepository->findPublicUpcoming(),
-                'staffing' => $eventRepository->findUpcomingByOrganizerOrStaff($user ?? throw new \LogicException()),
                 default => $eventRepository->findVisibleUpcoming($user),
             };
         }

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -152,6 +152,16 @@ class Event
     #[ORM\OneToMany(targetEntity: EventDeckRegistration::class, mappedBy: 'event')]
     private Collection $deckRegistrations;
 
+    /**
+     * @see docs/features.md F3.12 — Event tags
+     *
+     * @var Collection<int, EventTag>
+     */
+    #[ORM\ManyToMany(targetEntity: EventTag::class, inversedBy: 'events', cascade: ['persist'])]
+    #[ORM\JoinTable(name: 'event_event_tag')]
+    #[ORM\OrderBy(['name' => 'ASC'])]
+    private Collection $tags;
+
     public function __construct()
     {
         $this->date = new \DateTimeImmutable();
@@ -161,6 +171,7 @@ class Event
         $this->borrows = new ArrayCollection();
         $this->deckEntries = new ArrayCollection();
         $this->deckRegistrations = new ArrayCollection();
+        $this->tags = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -550,6 +561,49 @@ class Event
     public function getDeckRegistrations(): Collection
     {
         return $this->deckRegistrations;
+    }
+
+    /**
+     * @see docs/features.md F3.12 — Event tags
+     *
+     * @return Collection<int, EventTag>
+     */
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function addTag(EventTag $tag): static
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags->add($tag);
+        }
+
+        return $this;
+    }
+
+    public function removeTag(EventTag $tag): static
+    {
+        $this->tags->removeElement($tag);
+
+        return $this;
+    }
+
+    /**
+     * Replace the current tag set with the given collection. Used after the
+     * form resolver returns the desired list of EventTag entities.
+     *
+     * @param iterable<EventTag> $tags
+     */
+    public function setTags(iterable $tags): static
+    {
+        $this->tags->clear();
+
+        foreach ($tags as $tag) {
+            $this->addTag($tag);
+        }
+
+        return $this;
     }
 
     #[ORM\PrePersist]

--- a/src/Entity/EventTag.php
+++ b/src/Entity/EventTag.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Entity;
+
+use App\Repository\EventTagRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @see docs/features.md F3.12 — Event tags
+ */
+#[ORM\Entity(repositoryClass: EventTagRepository::class)]
+#[ORM\HasLifecycleCallbacks]
+class EventTag
+{
+    public const int MAX_NAME_LENGTH = 50;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: self::MAX_NAME_LENGTH, unique: true)]
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 2, max: self::MAX_NAME_LENGTH)]
+    private string $name = '';
+
+    #[ORM\Column(length: self::MAX_NAME_LENGTH, unique: true)]
+    private string $slug = '';
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    /**
+     * @var Collection<int, Event>
+     */
+    #[ORM\ManyToMany(targetEntity: Event::class, mappedBy: 'tags')]
+    private Collection $events;
+
+    public function __construct()
+    {
+        $this->events = new ArrayCollection();
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    #[ORM\PrePersist]
+    public function onPrePersist(): void
+    {
+        if ('' === $this->slug && '' !== $this->name) {
+            $this->slug = self::slugify($this->name);
+        }
+    }
+
+    public static function slugify(string $name): string
+    {
+        $name = trim($name);
+
+        if ('' === $name) {
+            return '';
+        }
+
+        $slug = mb_strtolower($name);
+        $slug = (string) preg_replace('/[^\p{L}\p{N}]+/u', '-', $slug);
+        $slug = trim($slug, '-');
+
+        if (mb_strlen($slug) > self::MAX_NAME_LENGTH) {
+            $slug = mb_substr($slug, 0, self::MAX_NAME_LENGTH);
+            $slug = trim($slug, '-');
+        }
+
+        return $slug;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = trim($name);
+        $this->slug = self::slugify($this->name);
+
+        return $this;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return Collection<int, Event>
+     */
+    public function getEvents(): Collection
+    {
+        return $this->events;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -135,6 +135,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(options: ['default' => false])]
     private bool $showCardmarketExport = false;
 
+    /**
+     * @see docs/features.md F3.14 — iCal agenda feed
+     */
+    #[ORM\Column(length: 64, unique: true, nullable: true)]
+    private ?string $calendarToken = null;
+
     /** @var Collection<int, Deck> */
     #[ORM\OneToMany(targetEntity: Deck::class, mappedBy: 'owner')]
     private Collection $ownedDecks;
@@ -468,6 +474,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->deletionToken = null;
         $this->deletionTokenExpiresAt = null;
         $this->notificationPreferences = null;
+        $this->calendarToken = null;
     }
 
     public function isAnonymized(): bool
@@ -607,6 +614,21 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setShowCardmarketExport(bool $showCardmarketExport): static
     {
         $this->showCardmarketExport = $showCardmarketExport;
+
+        return $this;
+    }
+
+    /**
+     * @see docs/features.md F3.14 — iCal agenda feed
+     */
+    public function getCalendarToken(): ?string
+    {
+        return $this->calendarToken;
+    }
+
+    public function setCalendarToken(?string $calendarToken): static
+    {
+        $this->calendarToken = $calendarToken;
 
         return $this;
     }

--- a/src/Form/EventFormType.php
+++ b/src/Form/EventFormType.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -31,6 +32,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @see docs/features.md F3.1 — Create a new event
+ * @see docs/features.md F3.12 — Event tags
  *
  * @extends AbstractType<Event>
  */
@@ -145,6 +147,10 @@ class EventFormType extends AbstractType
             ])
             ->add('isInvitationOnly', CheckboxType::class, [
                 'label' => 'app.form.label.invitation_only',
+                'required' => false,
+            ])
+            ->add('tagsInput', HiddenType::class, [
+                'mapped' => false,
                 'required' => false,
             ]);
     }

--- a/src/Repository/EventRepository.php
+++ b/src/Repository/EventRepository.php
@@ -373,6 +373,36 @@ class EventRepository extends ServiceEntityRepository
     }
 
     /**
+     * Every upcoming event the user is connected to: organizer, staff, or any
+     * engagement state (interested, invited, registered playing, spectating).
+     *
+     * @see docs/features.md F3.14 — iCal agenda feed
+     *
+     * @return list<Event>
+     */
+    public function findUpcomingForUserAgenda(User $user): array
+    {
+        /** @var list<Event> $events */
+        $events = $this->createQueryBuilder('e')
+            ->join('e.organizer', 'o')
+            ->addSelect('o')
+            ->leftJoin('e.engagements', 'eg', 'WITH', 'eg.user = :user')
+            ->leftJoin('e.staff', 's', 'WITH', 's.user = :user')
+            ->where('e.organizer = :user OR eg.id IS NOT NULL OR s.id IS NOT NULL')
+            ->andWhere('e.date >= :today')
+            ->andWhere('e.cancelledAt IS NULL')
+            ->andWhere('e.finishedAt IS NULL')
+            ->andWhere('e.deletedAt IS NULL')
+            ->setParameter('user', $user)
+            ->setParameter('today', new \DateTimeImmutable('today'))
+            ->orderBy('e.date', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $events;
+    }
+
+    /**
      * Upcoming events where the user has any engagement (interested, playing, spectating).
      *
      * @see docs/features.md F7.1 — Dashboard

--- a/src/Repository/EventRepository.php
+++ b/src/Repository/EventRepository.php
@@ -15,10 +15,12 @@ namespace App\Repository;
 
 use App\Entity\Deck;
 use App\Entity\Event;
+use App\Entity\EventTag;
 use App\Entity\User;
 use App\Enum\EngagementState;
 use App\Enum\EventVisibility;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -142,7 +144,70 @@ class EventRepository extends ServiceEntityRepository
     public function findPublicUpcoming(int $limit = 50): array
     {
         /** @var list<Event> $events */
-        $events = $this->createQueryBuilder('e')
+        $events = $this->buildPublicUpcomingQuery(null, $limit)->getQuery()->getResult();
+
+        return $events;
+    }
+
+    /**
+     * Public upcoming events filtered by a single tag.
+     *
+     * @see docs/features.md F3.12 — Event tags
+     * @see docs/features.md F3.16 — Public iCal feed
+     *
+     * @return list<Event>
+     */
+    public function findPublicUpcomingByTag(EventTag $tag, int $limit = 50): array
+    {
+        /** @var list<Event> $events */
+        $events = $this->buildPublicUpcomingQuery($tag, $limit)->getQuery()->getResult();
+
+        return $events;
+    }
+
+    /**
+     * Visible upcoming events filtered by a single tag.
+     *
+     * @see docs/features.md F3.12 — Event tags
+     *
+     * @return list<Event>
+     */
+    public function findVisibleUpcomingByTag(?User $user, EventTag $tag, int $limit = 20): array
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->join('e.organizer', 'o')
+            ->addSelect('o')
+            ->join('e.tags', 't')
+            ->where('e.date >= :today')
+            ->andWhere('e.cancelledAt IS NULL')
+            ->andWhere('e.finishedAt IS NULL')
+            ->andWhere('e.deletedAt IS NULL')
+            ->andWhere('t.id = :tagId')
+            ->setParameter('today', new \DateTimeImmutable('today'))
+            ->setParameter('tagId', $tag->getId())
+            ->orderBy('e.date', 'ASC')
+            ->setMaxResults($limit);
+
+        if (null !== $user) {
+            $qb->leftJoin('e.engagements', 'eg', 'WITH', 'eg.user = :user')
+                ->leftJoin('e.staff', 's', 'WITH', 's.user = :user')
+                ->andWhere('e.visibility = :public OR e.organizer = :user OR eg.id IS NOT NULL OR s.id IS NOT NULL')
+                ->setParameter('user', $user)
+                ->setParameter('public', EventVisibility::Public);
+        } else {
+            $qb->andWhere('e.visibility = :public')
+                ->setParameter('public', EventVisibility::Public);
+        }
+
+        /** @var list<Event> $events */
+        $events = $qb->getQuery()->getResult();
+
+        return $events;
+    }
+
+    private function buildPublicUpcomingQuery(?EventTag $tag, int $limit): QueryBuilder
+    {
+        $qb = $this->createQueryBuilder('e')
             ->join('e.organizer', 'o')
             ->addSelect('o')
             ->where('e.date >= :today')
@@ -153,11 +218,15 @@ class EventRepository extends ServiceEntityRepository
             ->setParameter('today', new \DateTimeImmutable('today'))
             ->setParameter('visibility', EventVisibility::Public)
             ->orderBy('e.date', 'ASC')
-            ->setMaxResults($limit)
-            ->getQuery()
-            ->getResult();
+            ->setMaxResults($limit);
 
-        return $events;
+        if (null !== $tag) {
+            $qb->join('e.tags', 't')
+                ->andWhere('t.id = :tagId')
+                ->setParameter('tagId', $tag->getId());
+        }
+
+        return $qb;
     }
 
     /**

--- a/src/Repository/EventTagRepository.php
+++ b/src/Repository/EventTagRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Repository;
+
+use App\Entity\EventTag;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @see docs/features.md F3.12 — Event tags
+ *
+ * @extends ServiceEntityRepository<EventTag>
+ */
+class EventTagRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, EventTag::class);
+    }
+
+    public function findOneBySlug(string $slug): ?EventTag
+    {
+        return $this->findOneBy(['slug' => $slug]);
+    }
+
+    /**
+     * @return list<EventTag>
+     */
+    public function findAllOrderedByName(): array
+    {
+        /** @var list<EventTag> $tags */
+        $tags = $this->createQueryBuilder('t')
+            ->orderBy('t.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $tags;
+    }
+
+    /**
+     * Resolve a list of free-form tag names to existing tags + newly-instantiated
+     * (un-flushed) EventTag rows for unknown names. The caller persists new ones.
+     *
+     * @param list<string> $names
+     *
+     * @return list<EventTag>
+     */
+    public function resolveByNames(array $names): array
+    {
+        $resolved = [];
+        $seenSlugs = [];
+
+        foreach ($names as $rawName) {
+            $name = trim($rawName);
+
+            if ('' === $name) {
+                continue;
+            }
+
+            $slug = EventTag::slugify($name);
+
+            if ('' === $slug || isset($seenSlugs[$slug])) {
+                continue;
+            }
+
+            $seenSlugs[$slug] = true;
+
+            $existing = $this->findOneBySlug($slug);
+
+            if (null !== $existing) {
+                $resolved[] = $existing;
+
+                continue;
+            }
+
+            $tag = new EventTag();
+            $tag->setName($name);
+            $resolved[] = $tag;
+        }
+
+        return $resolved;
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -67,6 +67,14 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
     }
 
     /**
+     * @see docs/features.md F3.14 — iCal agenda feed
+     */
+    public function findOneByCalendarToken(string $token): ?User
+    {
+        return $this->findOneBy(['calendarToken' => $token]);
+    }
+
+    /**
      * Searches users by screen name, email, or Pokemon ID.
      *
      * @see docs/features.md F3.5 — Assign event staff team

--- a/src/Service/Event/EventIcalBuilder.php
+++ b/src/Service/Event/EventIcalBuilder.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Event;
+
+use App\Entity\Event as AppEvent;
+use Eluceo\iCal\Domain\Entity\Calendar;
+use Eluceo\iCal\Domain\Entity\Event as IcalEvent;
+use Eluceo\iCal\Domain\Enum\EventStatus;
+use Eluceo\iCal\Domain\ValueObject\DateTime as IcalDateTime;
+use Eluceo\iCal\Domain\ValueObject\Location;
+use Eluceo\iCal\Domain\ValueObject\TimeSpan;
+use Eluceo\iCal\Domain\ValueObject\Timestamp;
+use Eluceo\iCal\Domain\ValueObject\UniqueIdentifier;
+use Eluceo\iCal\Domain\ValueObject\Uri;
+use Eluceo\iCal\Presentation\Factory\CalendarFactory;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Render a list of Expanded Decks events as an iCalendar (RFC 5545) feed.
+ *
+ * @see docs/features.md F3.16 — Public iCal feed
+ */
+final class EventIcalBuilder
+{
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * @param iterable<AppEvent> $events
+     */
+    public function build(iterable $events, ?string $feedTitle = null): string
+    {
+        $icalEvents = [];
+
+        foreach ($events as $appEvent) {
+            $icalEvents[] = $this->buildEvent($appEvent);
+        }
+
+        $calendar = new Calendar($icalEvents);
+        $calendar->setProductIdentifier('-//Expanded Decks//Event Calendar//EN');
+
+        $output = (string) (new CalendarFactory())->createCalendar($calendar);
+
+        // eluceo/ical 2.x has no first-class API for the human-readable feed name
+        // (X-WR-CALNAME / NAME), so we inject it after rendering when provided.
+        if (null !== $feedTitle && '' !== $feedTitle) {
+            $output = $this->injectCalendarName($output, $feedTitle);
+        }
+
+        return $output;
+    }
+
+    private function injectCalendarName(string $calendar, string $name): string
+    {
+        $escaped = $this->escapeText($name);
+        $headers = "X-WR-CALNAME:{$escaped}\r\nNAME:{$escaped}\r\n";
+
+        return preg_replace(
+            '/(PRODID:[^\r\n]+\r\n)/',
+            '$1'.$headers,
+            $calendar,
+            1,
+        ) ?? $calendar;
+    }
+
+    private function escapeText(string $value): string
+    {
+        return strtr($value, [
+            '\\' => '\\\\',
+            "\r\n" => '\\n',
+            "\n" => '\\n',
+            ',' => '\\,',
+            ';' => '\\;',
+        ]);
+    }
+
+    private function buildEvent(AppEvent $appEvent): IcalEvent
+    {
+        $startUtc = $this->toUtc($appEvent->getDate());
+        $endUtc = $this->toUtc($appEvent->getEndDate() ?? $appEvent->getDate()->modify('+3 hours'));
+
+        $url = $this->urlGenerator->generate(
+            'app_event_show',
+            ['id' => $appEvent->getId()],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        $icalEvent = (new IcalEvent(new UniqueIdentifier(\sprintf('event-%d@expandeddecks.app', $appEvent->getId() ?? 0))))
+            ->setSummary($appEvent->getName())
+            ->setDescription($this->buildDescription($appEvent, $url))
+            ->setUrl(new Uri($url))
+            ->setOccurrence(new TimeSpan(
+                new IcalDateTime($startUtc, true),
+                new IcalDateTime($endUtc, true),
+            ));
+
+        $location = $appEvent->getLocation();
+
+        if (null !== $location && '' !== $location) {
+            $icalEvent->setLocation(new Location($location));
+        }
+
+        if (null !== $appEvent->getCancelledAt()) {
+            $icalEvent->setStatus(EventStatus::CANCELLED());
+        } elseif (null !== $appEvent->getFinishedAt()) {
+            $icalEvent->setStatus(EventStatus::CONFIRMED());
+        }
+
+        $icalEvent->touch(new Timestamp($appEvent->getCreatedAt()));
+
+        return $icalEvent;
+    }
+
+    private function toUtc(\DateTimeImmutable $dateTime): \DateTimeImmutable
+    {
+        return $dateTime->setTimezone(new \DateTimeZone('UTC'));
+    }
+
+    private function buildDescription(AppEvent $appEvent, string $url): string
+    {
+        $lines = [];
+
+        $organizer = $appEvent->getOrganizer()->getScreenName();
+        $lines[] = $this->translator->trans('app.event.ical.organized_by', ['%name%' => $organizer]);
+
+        if (null !== $appEvent->getTournamentStructure()) {
+            $structureLabel = ucwords(str_replace('_', ' ', $appEvent->getTournamentStructure()->value));
+            $lines[] = $this->translator->trans('app.event.ical.structure', ['%structure%' => $structureLabel]);
+        }
+
+        $description = $appEvent->getDescription();
+
+        if (null !== $description && '' !== trim($description)) {
+            $lines[] = '';
+            $lines[] = trim($description);
+        }
+
+        $lines[] = '';
+        $lines[] = $url;
+
+        return implode("\n", $lines);
+    }
+}

--- a/src/Service/Event/PersonalCalendarTokenService.php
+++ b/src/Service/Event/PersonalCalendarTokenService.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Service\Event;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Issue and rotate the per-user calendar feed token used by F3.14.
+ *
+ * The token is a 32-byte URL-safe random string stored on the User. It is
+ * cryptographically unguessable, so the calendar feed URL behaves like a
+ * capability — knowing the URL is enough to subscribe, no login required.
+ *
+ * @see docs/features.md F3.14 — iCal agenda feed
+ */
+final class PersonalCalendarTokenService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository,
+    ) {
+    }
+
+    /**
+     * Return the user's existing calendar token, generating one on first use.
+     */
+    public function ensureToken(User $user): string
+    {
+        $existing = $user->getCalendarToken();
+
+        if (null !== $existing && '' !== $existing) {
+            return $existing;
+        }
+
+        return $this->regenerateToken($user);
+    }
+
+    /**
+     * Issue a brand-new calendar token, invalidating the previous URL.
+     */
+    public function regenerateToken(User $user): string
+    {
+        $token = $this->generateToken();
+
+        $user->setCalendarToken($token);
+        $this->entityManager->flush();
+
+        return $token;
+    }
+
+    public function findUserByToken(string $token): ?User
+    {
+        if ('' === $token) {
+            return null;
+        }
+
+        return $this->userRepository->findOneByCalendarToken($token);
+    }
+
+    private function generateToken(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -116,6 +116,9 @@
                                         <li><a class="dropdown-item" href="{{ path('app_dashboard') }}">{{ 'app.nav.dashboard'|trans }}</a></li>
                                         <li><a class="dropdown-item" href="{{ path('app_my_decks') }}">{{ 'app.nav.my_decks'|trans }}</a></li>
                                     {% endif %}
+                                    {% if channel.enableEvents %}
+                                        <li><a class="dropdown-item" href="{{ path('app_event_agenda') }}">{{ 'app.nav.my_agenda'|trans }}</a></li>
+                                    {% endif %}
                                     <li><a class="dropdown-item" href="{{ path('app_profile_edit') }}">{{ 'app.nav.profile'|trans }}</a></li>
                                     {% if channel.enableDecks %}
                                         <li><a class="dropdown-item" href="{{ path('app_profile_notifications') }}">{{ 'app.nav.notifications'|trans }}</a></li>

--- a/templates/event/_calendar_button.html.twig
+++ b/templates/event/_calendar_button.html.twig
@@ -1,0 +1,47 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{# @see docs/features.md F3.16 — Public iCal feed #}
+{% set absoluteIcalUrl = absolute_url(icalUrl) %}
+{% set webcalUrl = absoluteIcalUrl|replace({'http://': 'webcal://', 'https://': 'webcal://'}) %}
+<div class="dropdown">
+    <button type="button"
+            class="btn btn-outline-secondary btn-sm dropdown-toggle"
+            data-bs-toggle="dropdown"
+            aria-expanded="false"
+            title="{{ 'app.event.calendar.button_title'|trans }}">
+        <i class="bi bi-calendar-plus" aria-hidden="true"></i>
+        <span class="d-none d-sm-inline">{{ 'app.event.calendar.button'|trans }}</span>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-end p-2" style="min-width: 280px;">
+        <li class="px-1 pb-2 small text-muted">{{ 'app.event.calendar.help'|trans }}</li>
+        <li>
+            <a class="dropdown-item d-flex align-items-center gap-2" href="{{ webcalUrl }}">
+                <i class="bi bi-calendar2-event" aria-hidden="true"></i>
+                {{ 'app.event.calendar.subscribe'|trans }}
+            </a>
+        </li>
+        <li>
+            <a class="dropdown-item d-flex align-items-center gap-2" href="{{ icalUrl }}" download>
+                <i class="bi bi-download" aria-hidden="true"></i>
+                {{ 'app.event.calendar.download'|trans }}
+            </a>
+        </li>
+        <li>
+            <button type="button"
+                    class="dropdown-item d-flex align-items-center gap-2"
+                    data-event-calendar-copy
+                    data-copy-url="{{ absoluteIcalUrl }}"
+                    data-label-default="{{ 'app.event.calendar.copy_url'|trans }}"
+                    data-label-copied="{{ 'app.event.calendar.copied'|trans }}">
+                <i class="bi bi-clipboard" aria-hidden="true"></i>
+                <span>{{ 'app.event.calendar.copy_url'|trans }}</span>
+            </button>
+        </li>
+    </ul>
+</div>

--- a/templates/event/_tag_selector.html.twig
+++ b/templates/event/_tag_selector.html.twig
@@ -1,0 +1,19 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{# @see docs/features.md F3.12 — Event tags #}
+<div class="mb-3">
+    <label class="form-label">{{ 'app.event.tag.label'|trans }}</label>
+    <div id="event-tag-select-root"
+         data-existing-tags="{{ existingTagNames|json_encode|e('html_attr') }}"
+         data-values="{{ initialTagNames|json_encode|e('html_attr') }}"
+         data-hidden-input-name="{{ form.tagsInput.vars.full_name }}"
+         data-placeholder="{{ 'app.event.tag.placeholder'|trans }}"></div>
+    <div class="form-text">{{ 'app.event.tag.help'|trans }}</div>
+    {{ form_widget(form.tagsInput) }}
+</div>

--- a/templates/event/_tags.html.twig
+++ b/templates/event/_tags.html.twig
@@ -1,0 +1,16 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{# @see docs/features.md F3.12 — Event tags #}
+{% if event.tags|length > 0 %}
+    <div class="event-tag-list d-inline-flex flex-wrap gap-1 align-items-center">
+        {% for tag in event.tags %}
+            <a href="{{ path('app_event_tag', {slug: tag.slug}) }}" class="badge text-bg-light border text-decoration-none">{{ tag.name }}</a>
+        {% endfor %}
+    </div>
+{% endif %}

--- a/templates/event/agenda.html.twig
+++ b/templates/event/agenda.html.twig
@@ -1,0 +1,109 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'app.event.agenda.title'|trans }} — {{ channel_param('brand_name', 'Expanded Decks') }}{% endblock %}
+
+{% block body %}
+    <h1 class="mb-2">{{ 'app.event.agenda.title'|trans }}</h1>
+    <p class="text-muted">{{ 'app.event.agenda.intro'|trans }}</p>
+
+    {% set webcalUrl = icalAbsoluteUrl|replace({'http://': 'webcal://', 'https://': 'webcal://'}) %}
+    <div class="card shadow-sm mb-4">
+        <div class="card-header card-header-themed">
+            <h5 class="mb-0">{{ 'app.event.agenda.feed_section_title'|trans }}</h5>
+        </div>
+        <div class="card-body">
+            <p class="text-muted small mb-2">{{ 'app.event.agenda.feed_section_help'|trans }}</p>
+            <div class="input-group input-group-sm mb-2">
+                <input type="text" class="form-control font-monospace" readonly value="{{ icalAbsoluteUrl }}">
+                <button type="button"
+                        class="btn btn-outline-secondary"
+                        data-event-calendar-copy
+                        data-copy-url="{{ icalAbsoluteUrl }}"
+                        data-label-default="{{ 'app.event.calendar.copy_url'|trans }}"
+                        data-label-copied="{{ 'app.event.calendar.copied'|trans }}">
+                    <i class="bi bi-clipboard" aria-hidden="true"></i>
+                    <span>{{ 'app.event.calendar.copy_url'|trans }}</span>
+                </button>
+            </div>
+            <div class="d-flex flex-wrap gap-2 mb-3">
+                <a href="{{ webcalUrl }}" class="btn btn-sm btn-primary">
+                    <i class="bi bi-calendar2-event" aria-hidden="true"></i>
+                    {{ 'app.event.calendar.subscribe'|trans }}
+                </a>
+                <a href="{{ icalUrl }}" class="btn btn-sm btn-outline-secondary" download>
+                    <i class="bi bi-download" aria-hidden="true"></i>
+                    {{ 'app.event.calendar.download'|trans }}
+                </a>
+            </div>
+            <p class="text-muted small mb-2"><strong>{{ 'app.event.agenda.security_warning_title'|trans }}</strong> {{ 'app.event.agenda.security_warning_body'|trans }}</p>
+            <form method="post" action="{{ path('app_event_agenda_regenerate') }}" class="d-inline">
+                <input type="hidden" name="_token" value="{{ csrf_token('event-agenda-regenerate') }}">
+                <button type="submit"
+                        class="btn btn-sm btn-outline-danger"
+                        onclick="return confirm('{{ 'app.event.agenda.regenerate_confirm'|trans|e('js') }}')">
+                    <i class="bi bi-arrow-repeat" aria-hidden="true"></i>
+                    {{ 'app.event.agenda.regenerate_button'|trans }}
+                </button>
+            </form>
+        </div>
+    </div>
+
+    {% if events|length > 0 %}
+        <div class="row">
+            {% for event in events %}
+                {% set engagement = event.engagementFor(app.user) %}
+                {% set isOrganizer = event.organizer.id == app.user.id %}
+                {% set staff = event.staffFor(app.user) %}
+                <div class="col-md-6 col-lg-4 mb-3">
+                    <div class="card shadow-sm h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                <a href="{{ path('app_event_show', {id: event.id}) }}">{{ event.name }}</a>
+                            </h5>
+                            <p class="text-muted mb-1">
+                                {% include 'event/_datetime.html.twig' with {dt: event.date, tz: event.timezone} %}
+                            </p>
+                            {% if event.location %}
+                                <p class="text-muted mb-1">{{ event.location }}</p>
+                            {% endif %}
+                            <p class="mb-2 d-flex flex-wrap gap-1">
+                                {% if isOrganizer %}
+                                    <span class="badge text-bg-warning">{{ 'app.event.agenda.state.organizing'|trans }}</span>
+                                {% elseif staff %}
+                                    <span class="badge text-bg-warning">{{ 'app.event.agenda.state.staffing'|trans }}</span>
+                                {% endif %}
+                                {% if engagement %}
+                                    <span class="badge text-bg-info">{{ ('app.event.agenda.state.' ~ engagement.state.value)|trans }}</span>
+                                {% endif %}
+                            </p>
+                            {% if event.tags|length > 0 %}
+                                <p class="mb-0">
+                                    {% include 'event/_tags.html.twig' with {event: event} only %}
+                                </p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="card shadow-sm">
+            <div class="card-body text-center py-5">
+                <p class="text-muted mb-0">{{ 'app.event.agenda.empty'|trans }}</p>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {{ encore_entry_script_tags('event_calendar_copy') }}
+{% endblock %}

--- a/templates/event/edit.html.twig
+++ b/templates/event/edit.html.twig
@@ -76,6 +76,8 @@
 
                         {{ form_row(form.isDecklistMandatory) }}
 
+                        {% include 'event/_tag_selector.html.twig' with {form: form, existingTagNames: existingTagNames, initialTagNames: initialTagNames} only %}
+
                         <div class="d-flex gap-2">
                             <button type="submit" class="btn btn-gold">{{ 'app.event.save_button'|trans }}</button>
                             <a href="{{ path('app_event_show', {id: event.id}) }}" class="btn btn-outline-secondary">{{ 'app.common.cancel'|trans }}</a>
@@ -87,7 +89,13 @@
     </div>
 {% endblock %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    {{ encore_entry_link_tags('event_form') }}
+{% endblock %}
+
 {% block javascripts %}
     {{ parent() }}
     {{ encore_entry_script_tags('event_sync') }}
+    {{ encore_entry_script_tags('event_form') }}
 {% endblock %}

--- a/templates/event/list.html.twig
+++ b/templates/event/list.html.twig
@@ -8,15 +8,24 @@
  #}
 {% extends 'base.html.twig' %}
 
-{% block title %}{{ 'app.event.list_title'|trans }} — {{ channel_param('brand_name', 'Expanded Decks') }}{% endblock %}
+{% block title %}{% if activeTag %}{{ 'app.event.tag.page_title'|trans({'%name%': activeTag.name}) }}{% else %}{{ 'app.event.list_title'|trans }}{% endif %} — {{ channel_param('brand_name', 'Expanded Decks') }}{% endblock %}
 
 {% block canonical %}
-    <link rel="canonical" href="{{ canonical_url('events', 'app_event_list') }}">
+    {% if activeTag %}
+        <link rel="canonical" href="{{ canonical_url('events', 'app_event_tag', {slug: activeTag.slug}) }}">
+    {% else %}
+        <link rel="canonical" href="{{ canonical_url('events', 'app_event_list') }}">
+    {% endif %}
 {% endblock %}
 
 {% block opengraph %}
-    {% set og_title = 'app.event.list_title'|trans ~ ' — ' ~ channel_param('brand_name', 'Expanded Decks') %}
-    {% set og_url = canonical_url('events', 'app_event_list') %}
+    {% if activeTag %}
+        {% set og_title = 'app.event.tag.page_title'|trans({'%name%': activeTag.name}) ~ ' — ' ~ channel_param('brand_name', 'Expanded Decks') %}
+        {% set og_url = canonical_url('events', 'app_event_tag', {slug: activeTag.slug}) %}
+    {% else %}
+        {% set og_title = 'app.event.list_title'|trans ~ ' — ' ~ channel_param('brand_name', 'Expanded Decks') %}
+        {% set og_url = canonical_url('events', 'app_event_list') %}
+    {% endif %}
     {% include '_partials/opengraph.html.twig' %}
 {% endblock %}
 
@@ -30,17 +39,39 @@
 
 {% block body %}
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h1 class="mb-0">{{ 'app.event.list_title'|trans }}</h1>
-        {% if is_granted('ROLE_ORGANIZER') %}
-            <a href="{{ path('app_event_new') }}" class="btn btn-gold">{{ 'app.event.new_event'|trans }}</a>
-        {% endif %}
+        <div>
+            <h1 class="mb-0">
+                {% if activeTag %}{{ 'app.event.tag.page_title'|trans({'%name%': activeTag.name}) }}{% else %}{{ 'app.event.list_title'|trans }}{% endif %}
+            </h1>
+            {% if activeTag %}
+                <a href="{{ path('app_event_list') }}" class="small text-decoration-none">&larr; {{ 'app.event.tag.back_to_all'|trans }}</a>
+            {% endif %}
+        </div>
+        <div class="d-flex align-items-center gap-2">
+            {% if icalUrl is defined and icalUrl %}
+                {% include 'event/_calendar_button.html.twig' with {icalUrl: icalUrl} only %}
+            {% endif %}
+            {% if is_granted('ROLE_ORGANIZER') %}
+                <a href="{{ path('app_event_new') }}" class="btn btn-gold">{{ 'app.event.new_event'|trans }}</a>
+            {% endif %}
+        </div>
     </div>
 
-    {% if app.user %}
-        <div class="btn-group mb-4" role="group" aria-label="{{ 'app.event.filter_scope'|trans }}">
+    {% if app.user and not activeTag %}
+        <div class="btn-group mb-3" role="group" aria-label="{{ 'app.event.filter_scope'|trans }}">
             <a href="{{ path('app_event_list', {scope: 'all'}) }}" class="btn btn-sm {{ scope|default('all') == 'all' ? 'btn-primary' : 'btn-outline-primary' }}">{{ 'app.common.all'|trans }}</a>
             <a href="{{ path('app_event_list', {scope: 'public'}) }}" class="btn btn-sm {{ scope|default('all') == 'public' ? 'btn-primary' : 'btn-outline-primary' }}">{{ 'app.event.scope_public'|trans }}</a>
             <a href="{{ path('app_event_list', {scope: 'staffing'}) }}" class="btn btn-sm {{ scope|default('all') == 'staffing' ? 'btn-primary' : 'btn-outline-primary' }}">{{ 'app.event.scope_staffing'|trans }}</a>
+        </div>
+    {% endif %}
+
+    {% if allTags is defined and allTags|length > 0 %}
+        <div class="mb-4 d-flex flex-wrap gap-1 align-items-center">
+            <small class="text-muted me-1">{{ 'app.event.tag.filter_label'|trans }}:</small>
+            <a href="{{ path('app_event_list') }}" class="badge text-decoration-none {{ activeTag is null ? 'text-bg-primary' : 'text-bg-light border' }}">{{ 'app.common.all'|trans }}</a>
+            {% for tag in allTags %}
+                <a href="{{ path('app_event_tag', {slug: tag.slug}) }}" class="badge text-decoration-none {{ activeTag and activeTag.id == tag.id ? 'text-bg-primary' : 'text-bg-light border' }}">{{ tag.name }}</a>
+            {% endfor %}
         </div>
     {% endif %}
 
@@ -67,6 +98,11 @@
                                     {% endif %}
                                 </small>
                             </p>
+                            {% if event.tags|length > 0 %}
+                                <p class="mb-2">
+                                    {% include 'event/_tags.html.twig' with {event: event} only %}
+                                </p>
+                            {% endif %}
                             <div class="d-flex justify-content-between align-items-center">
                                 <small class="text-muted">
                                     {{ 'app.event.organized_by'|trans({'%name%': event.organizer.screenName}) }}
@@ -93,4 +129,9 @@
             </div>
         </div>
     {% endif %}
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {{ encore_entry_script_tags('event_calendar_copy') }}
 {% endblock %}

--- a/templates/event/list.html.twig
+++ b/templates/event/list.html.twig
@@ -51,6 +51,9 @@
             {% if icalUrl is defined and icalUrl %}
                 {% include 'event/_calendar_button.html.twig' with {icalUrl: icalUrl} only %}
             {% endif %}
+            {% if app.user %}
+                <a href="{{ path('app_event_agenda') }}" class="btn btn-outline-primary">{{ 'app.nav.my_agenda'|trans }}</a>
+            {% endif %}
             {% if is_granted('ROLE_ORGANIZER') %}
                 <a href="{{ path('app_event_new') }}" class="btn btn-gold">{{ 'app.event.new_event'|trans }}</a>
             {% endif %}
@@ -61,7 +64,6 @@
         <div class="btn-group mb-3" role="group" aria-label="{{ 'app.event.filter_scope'|trans }}">
             <a href="{{ path('app_event_list', {scope: 'all'}) }}" class="btn btn-sm {{ scope|default('all') == 'all' ? 'btn-primary' : 'btn-outline-primary' }}">{{ 'app.common.all'|trans }}</a>
             <a href="{{ path('app_event_list', {scope: 'public'}) }}" class="btn btn-sm {{ scope|default('all') == 'public' ? 'btn-primary' : 'btn-outline-primary' }}">{{ 'app.event.scope_public'|trans }}</a>
-            <a href="{{ path('app_event_list', {scope: 'staffing'}) }}" class="btn btn-sm {{ scope|default('all') == 'staffing' ? 'btn-primary' : 'btn-outline-primary' }}">{{ 'app.event.scope_staffing'|trans }}</a>
         </div>
     {% endif %}
 

--- a/templates/event/new.html.twig
+++ b/templates/event/new.html.twig
@@ -76,6 +76,8 @@
 
                         {{ form_row(form.isDecklistMandatory) }}
 
+                        {% include 'event/_tag_selector.html.twig' with {form: form, existingTagNames: existingTagNames, initialTagNames: initialTagNames} only %}
+
                         <button type="submit" class="btn btn-gold w-100">{{ 'app.event.create_button'|trans }}</button>
                     {{ form_end(form) }}
                 </div>
@@ -84,7 +86,13 @@
     </div>
 {% endblock %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    {{ encore_entry_link_tags('event_form') }}
+{% endblock %}
+
 {% block javascripts %}
     {{ parent() }}
     {{ encore_entry_script_tags('event_sync') }}
+    {{ encore_entry_script_tags('event_form') }}
 {% endblock %}

--- a/templates/event/show.html.twig
+++ b/templates/event/show.html.twig
@@ -107,6 +107,14 @@
                 </div>
             </div>
 
+            {% if event.tags|length > 0 %}
+                <hr>
+                <div class="d-flex align-items-center gap-2">
+                    <span class="text-muted small">{{ 'app.event.tag.label'|trans }}:</span>
+                    {% include 'event/_tags.html.twig' with {event: event} only %}
+                </div>
+            {% endif %}
+
             {% if event.description %}
                 <hr>
                 <p class="mb-0">{{ event.description|nl2br }}</p>

--- a/templates/home/dashboard.html.twig
+++ b/templates/home/dashboard.html.twig
@@ -105,7 +105,7 @@
                 </a>
             </div>
             <div class="col-12 col-sm-6 col-md-3 mb-3 mb-sm-0">
-                <a href="{{ path('app_event_list', {scope: 'staffing'}) }}" class="card text-center shadow-sm h-100 text-decoration-none">
+                <a href="{{ path('app_event_agenda') }}" class="card text-center shadow-sm h-100 text-decoration-none">
                     <div class="card-body py-3">
                         <div class="fs-2 fw-bold text-info">{{ myStats.upcomingEvents }}</div>
                         <small class="text-muted">{{ 'app.dashboard.stats.upcoming_events'|trans }}</small>
@@ -162,7 +162,7 @@
                 <div class="card-header card-header-themed d-flex justify-content-between align-items-center">
                     <h5 class="mb-0">{{ 'app.dashboard.my_events'|trans }}</h5>
                     <div class="d-flex gap-2">
-                        <a href="{{ path('app_event_list') }}" class="btn btn-sm btn-outline-light">{{ 'app.common.see_all'|trans }}</a>
+                        <a href="{{ path('app_event_agenda') }}" class="btn btn-sm btn-outline-light">{{ 'app.common.see_all'|trans }}</a>
                         {% if is_granted('ROLE_ORGANIZER') %}
                             <a href="{{ path('app_event_new') }}" class="btn btn-sm btn-gold">{{ 'app.common.new'|trans }}</a>
                         {% endif %}

--- a/tests/Controller/EventCalendarControllerTest.php
+++ b/tests/Controller/EventCalendarControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Controller\EventCalendarController;
+use App\Entity\EventTag;
+use App\Repository\EventRepository;
+use App\Repository\EventTagRepository;
+use App\Service\Event\EventIcalBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Direct (non-kernel) tests for the public iCal feeds — Symfony's
+ * SessionListener rewrites cache headers in WebTestCase, so we exercise
+ * the controller without the kernel to verify the headers we set.
+ *
+ * @see docs/features.md F3.16 — Public iCal feed
+ */
+final class EventCalendarControllerTest extends TestCase
+{
+    public function testListSetsPublicCacheHeadersAndContentType(): void
+    {
+        $controller = new EventCalendarController();
+
+        $eventRepo = $this->createStub(EventRepository::class);
+        $eventRepo->method('findPublicUpcoming')->willReturn([]);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $builder = new EventIcalBuilder(
+            $this->createStub(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class),
+            $translator,
+        );
+
+        $response = $controller->list($eventRepo, $builder, $translator);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('text/calendar; charset=utf-8', $response->headers->get('Content-Type'));
+        self::assertSame('inline; filename="expanded-decks-events.ics"', $response->headers->get('Content-Disposition'));
+
+        $cacheControl = (string) $response->headers->get('Cache-Control');
+        self::assertStringContainsString('public', $cacheControl);
+        self::assertStringContainsString('max-age=3600', $cacheControl);
+
+        self::assertStringStartsWith('BEGIN:VCALENDAR', (string) $response->getContent());
+    }
+
+    public function testTagSetsFilenameFromSlug(): void
+    {
+        $controller = new EventCalendarController();
+
+        $tag = (new EventTag())->setName('League');
+
+        $tagRepo = $this->createStub(EventTagRepository::class);
+        $tagRepo->method('findOneBySlug')->willReturn($tag);
+
+        $eventRepo = $this->createStub(EventRepository::class);
+        $eventRepo->method('findPublicUpcomingByTag')->willReturn([]);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $builder = new EventIcalBuilder(
+            $this->createStub(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class),
+            $translator,
+        );
+
+        $response = $controller->tag('league', $eventRepo, $tagRepo, $builder, $translator);
+
+        self::assertSame('inline; filename="expanded-decks-events-league.ics"', $response->headers->get('Content-Disposition'));
+    }
+
+    public function testTagThrowsNotFoundForUnknownSlug(): void
+    {
+        $controller = new EventCalendarController();
+
+        $tagRepo = $this->createStub(EventTagRepository::class);
+        $tagRepo->method('findOneBySlug')->willReturn(null);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $builder = new EventIcalBuilder(
+            $this->createStub(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class),
+            $translator,
+        );
+
+        $controller->tag(
+            'no-such-tag',
+            $this->createStub(EventRepository::class),
+            $tagRepo,
+            $builder,
+            $translator,
+        );
+    }
+}

--- a/tests/Entity/EventTagTest.php
+++ b/tests/Entity/EventTagTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Entity;
+
+use App\Entity\EventTag;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F3.12 — Event tags
+ */
+final class EventTagTest extends TestCase
+{
+    public function testSetNameTrimsAndDerivesSlug(): void
+    {
+        $tag = new EventTag();
+        $tag->setName('  League Cup  ');
+
+        self::assertSame('League Cup', $tag->getName());
+        self::assertSame('league-cup', $tag->getSlug());
+    }
+
+    public function testCreatedAtIsSetOnConstruction(): void
+    {
+        $tag = new EventTag();
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $tag->getCreatedAt());
+    }
+
+    public function testEventsCollectionStartsEmpty(): void
+    {
+        $tag = new EventTag();
+
+        self::assertCount(0, $tag->getEvents());
+    }
+
+    #[DataProvider('slugifyProvider')]
+    public function testSlugify(string $input, string $expected): void
+    {
+        self::assertSame($expected, EventTag::slugify($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function slugifyProvider(): iterable
+    {
+        yield 'simple word' => ['League', 'league'];
+        yield 'multi word with spaces' => ['Regional Championship', 'regional-championship'];
+        yield 'collapses repeated separators' => ['weekend / saturday', 'weekend-saturday'];
+        yield 'trims leading and trailing dashes' => ['  --hello-- ', 'hello'];
+        yield 'preserves accents via unicode-aware regex' => ['Été français', 'été-français'];
+        yield 'all punctuation collapses to empty' => ['!!!???', ''];
+        yield 'empty input is preserved' => ['', ''];
+    }
+}

--- a/tests/Functional/EventAgendaControllerTest.php
+++ b/tests/Functional/EventAgendaControllerTest.php
@@ -103,6 +103,20 @@ class EventAgendaControllerTest extends AbstractFunctionalTest
         self::assertResponseStatusCodeSame(404);
     }
 
+    public function testRegenerateRejectsInvalidCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', '/event/agenda');
+        $original = $this->getUserByEmail('admin@example.com')->getCalendarToken();
+
+        $this->client->request('POST', '/event/agenda/regenerate-token', [
+            '_token' => 'definitely-not-the-csrf-token',
+        ]);
+
+        self::assertResponseRedirects('/event/agenda');
+        self::assertSame($original, $this->getUserByEmail('admin@example.com')->getCalendarToken());
+    }
+
     public function testTokenServiceFindsUserByToken(): void
     {
         /** @var PersonalCalendarTokenService $tokenService */

--- a/tests/Functional/EventAgendaControllerTest.php
+++ b/tests/Functional/EventAgendaControllerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\Event\PersonalCalendarTokenService;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F3.14 — iCal agenda feed
+ */
+class EventAgendaControllerTest extends AbstractFunctionalTest
+{
+    public function testAgendaPageRequiresLogin(): void
+    {
+        $this->client->request('GET', '/event/agenda');
+
+        self::assertResponseRedirects();
+        self::assertStringContainsString('/login', (string) $this->client->getResponse()->headers->get('Location'));
+    }
+
+    public function testAgendaPageRendersAndAssignsTokenOnFirstVisit(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $admin = $this->getUserByEmail('admin@example.com');
+        self::assertNull($admin->getCalendarToken(), 'Token should start unset.');
+
+        $this->client->request('GET', '/event/agenda');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'My agenda');
+
+        $admin = $this->getUserByEmail('admin@example.com');
+        self::assertNotNull($admin->getCalendarToken());
+        self::assertGreaterThanOrEqual(40, \strlen((string) $admin->getCalendarToken()));
+    }
+
+    public function testRegenerateTokenIssuesNewTokenAndInvalidatesPrevious(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/event/agenda');
+        self::assertResponseIsSuccessful();
+
+        $original = $this->getUserByEmail('admin@example.com')->getCalendarToken();
+        self::assertNotNull($original);
+
+        // Submit the regenerate form by extracting its CSRF token from the rendered page.
+        $crawler = $this->client->getCrawler();
+        $form = $crawler->filter('form[action$="/event/agenda/regenerate-token"]')->form();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/event/agenda');
+
+        $regenerated = $this->getUserByEmail('admin@example.com')->getCalendarToken();
+        self::assertNotNull($regenerated);
+        self::assertNotSame($original, $regenerated);
+
+        // Old token's feed URL must now 404.
+        $this->client->request('GET', \sprintf('/calendar/event/%s.ics', $original));
+        self::assertResponseStatusCodeSame(404);
+
+        // New token's feed URL works without authentication.
+        $this->client->request('GET', \sprintf('/calendar/event/%s.ics', $regenerated));
+        self::assertResponseIsSuccessful();
+        self::assertStringStartsWith('BEGIN:VCALENDAR', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testAnonymousIcalFeedReturnsCalendarForKnownToken(): void
+    {
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', '/event/agenda');
+        $token = $this->getUserByEmail('admin@example.com')->getCalendarToken();
+        self::assertNotNull($token);
+
+        // Switch to a fresh anonymous client.
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->client->request('GET', \sprintf('/calendar/event/%s.ics', $token));
+
+        self::assertResponseIsSuccessful();
+        $contentType = (string) $this->client->getResponse()->headers->get('Content-Type');
+        self::assertStringContainsString('text/calendar', $contentType);
+    }
+
+    public function testIcalFeedReturns404ForUnknownToken(): void
+    {
+        $this->client->request('GET', '/calendar/event/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ics');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testTokenServiceFindsUserByToken(): void
+    {
+        /** @var PersonalCalendarTokenService $tokenService */
+        $tokenService = static::getContainer()->get(PersonalCalendarTokenService::class);
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $admin = $this->getUserByEmail('admin@example.com');
+        $token = $tokenService->ensureToken($admin);
+        $em->flush();
+
+        $resolved = $tokenService->findUserByToken($token);
+        self::assertNotNull($resolved);
+        self::assertSame('admin@example.com', $resolved->getEmail());
+    }
+
+    private function getUserByEmail(string $email): User
+    {
+        /** @var UserRepository $repository */
+        $repository = static::getContainer()->get(UserRepository::class);
+
+        $user = $repository->findOneBy(['email' => $email]);
+        self::assertNotNull($user);
+
+        return $user;
+    }
+}

--- a/tests/Functional/EventCalendarControllerTest.php
+++ b/tests/Functional/EventCalendarControllerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\Event;
+use App\Entity\EventTag;
+use App\Repository\EventRepository;
+use App\Repository\EventTagRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F3.16 — Public iCal feed
+ */
+class EventCalendarControllerTest extends AbstractFunctionalTest
+{
+    public function testListIcalReturnsCalendarToAnonymous(): void
+    {
+        $this->client->request('GET', '/event.ics');
+
+        self::assertResponseIsSuccessful();
+        $response = $this->client->getResponse();
+        self::assertStringContainsString('text/calendar', (string) $response->headers->get('Content-Type'));
+        self::assertStringStartsWith('BEGIN:VCALENDAR', (string) $response->getContent());
+        self::assertStringContainsString('PRODID:-//Expanded Decks//Event Calendar//EN', (string) $response->getContent());
+    }
+
+    public function testTagIcalReturns404ForUnknownSlug(): void
+    {
+        $this->client->request('GET', '/event/tag/no-such-tag.ics');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testTagIcalReturnsCalendarForExistingTag(): void
+    {
+        $tag = $this->seedTagAndAttachToFirstPublicEvent('league');
+
+        $this->client->request('GET', \sprintf('/event/tag/%s.ics', $tag->getSlug()));
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $this->client->getResponse()->getContent();
+        self::assertStringStartsWith('BEGIN:VCALENDAR', $body);
+        self::assertStringContainsString('NAME:', $body);
+    }
+
+    public function testTagListPageRendersWithTaggedEvents(): void
+    {
+        $tag = $this->seedTagAndAttachToFirstPublicEvent('weekend');
+
+        $this->client->request('GET', \sprintf('/event/tag/%s', $tag->getSlug()));
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'weekend');
+    }
+
+    public function testTagListPageReturns404ForUnknownSlug(): void
+    {
+        $this->client->request('GET', '/event/tag/no-such-tag');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testEventListAcceptsTagFilterQueryParam(): void
+    {
+        $tag = $this->seedTagAndAttachToFirstPublicEvent('league-cup');
+
+        $this->client->request('GET', \sprintf('/event?tag=%s', $tag->getSlug()));
+
+        self::assertResponseIsSuccessful();
+    }
+
+    private function seedTagAndAttachToFirstPublicEvent(string $name): EventTag
+    {
+        $container = static::getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine.orm.entity_manager');
+        /** @var EventRepository $eventRepo */
+        $eventRepo = $container->get(EventRepository::class);
+        /** @var EventTagRepository $tagRepo */
+        $tagRepo = $container->get(EventTagRepository::class);
+
+        [$tag] = $tagRepo->resolveByNames([$name]);
+        $em->persist($tag);
+
+        $events = $eventRepo->findPublicUpcoming(1);
+        self::assertNotEmpty($events, 'Fixture must contain at least one public upcoming event.');
+        /** @var Event $event */
+        $event = $events[0];
+        $event->addTag($tag);
+
+        $em->flush();
+
+        return $tag;
+    }
+}

--- a/tests/Functional/EventControllerTagsTest.php
+++ b/tests/Functional/EventControllerTagsTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\Event;
+use App\Entity\EventTag;
+use App\Repository\EventRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Covers the event-form ↔ tag pipeline introduced for F3.12.
+ *
+ * @see docs/features.md F3.12 — Event tags
+ */
+class EventControllerTagsTest extends AbstractFunctionalTest
+{
+    public function testCreateEventWithNewAndExistingTagsUpsertsTags(): void
+    {
+        $em = $this->em();
+        $existing = new EventTag();
+        $existing->setName('Regional');
+        $em->persist($existing);
+        $em->flush();
+
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', '/event/new');
+        $this->client->submitForm('Create Event', [
+            'event_form[name]' => 'Tagged Event',
+            'event_form[date]' => '2026-09-15T14:00',
+            'event_form[timezone]' => 'Europe/Paris',
+            'event_form[registrationLink]' => 'https://example.com/tagged',
+            'event_form[tagsInput]' => json_encode(['regional', 'League Cup', '']),
+        ]);
+
+        self::assertResponseRedirects();
+
+        /** @var EventRepository $repo */
+        $repo = static::getContainer()->get(EventRepository::class);
+        /** @var Event|null $event */
+        $event = $repo->findOneBy(['name' => 'Tagged Event']);
+        self::assertNotNull($event);
+
+        $tagSlugs = array_map(static fn (EventTag $tag): string => $tag->getSlug(), $event->getTags()->toArray());
+        sort($tagSlugs);
+        self::assertSame(['league-cup', 'regional'], $tagSlugs);
+    }
+
+    public function testEditEventReplacesTagSet(): void
+    {
+        $em = $this->em();
+
+        $event = new Event();
+        $event->setName('Editable Tag Event');
+        $event->setDate(new \DateTimeImmutable('+10 days'));
+        $event->setTimezone('UTC');
+        $event->setOrganizer($this->getAdmin());
+        $event->setRegistrationLink('https://example.com/editable');
+        $event->setFormat('Expanded');
+
+        $oldTag = new EventTag();
+        $oldTag->setName('Old');
+        $event->addTag($oldTag);
+
+        $em->persist($oldTag);
+        $em->persist($event);
+        $em->flush();
+
+        $eventId = $event->getId();
+        self::assertNotNull($eventId);
+
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', \sprintf('/event/%d/edit', $eventId));
+        $this->client->submitForm('Save', [
+            'event_form[tagsInput]' => json_encode(['Brand New']),
+        ]);
+
+        self::assertResponseRedirects();
+
+        // Reload from DB to confirm the tag set actually changed.
+        $em->clear();
+        /** @var EventRepository $repo */
+        $repo = static::getContainer()->get(EventRepository::class);
+        /** @var Event $reloaded */
+        $reloaded = $repo->find($eventId);
+
+        $names = array_map(static fn (EventTag $tag): string => $tag->getName(), $reloaded->getTags()->toArray());
+        self::assertSame(['Brand New'], $names);
+    }
+
+    public function testCreateEventWithEmptyTagsInputClearsTags(): void
+    {
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', '/event/new');
+        $this->client->submitForm('Create Event', [
+            'event_form[name]' => 'No-Tag Event',
+            'event_form[date]' => '2026-10-15T14:00',
+            'event_form[timezone]' => 'UTC',
+            'event_form[registrationLink]' => 'https://example.com/no-tag',
+            'event_form[tagsInput]' => '',
+        ]);
+
+        self::assertResponseRedirects();
+
+        /** @var EventRepository $repo */
+        $repo = static::getContainer()->get(EventRepository::class);
+        /** @var Event|null $event */
+        $event = $repo->findOneBy(['name' => 'No-Tag Event']);
+        self::assertNotNull($event);
+        self::assertCount(0, $event->getTags());
+    }
+
+    public function testCreateEventWithMalformedTagsJsonClearsTags(): void
+    {
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', '/event/new');
+        $this->client->submitForm('Create Event', [
+            'event_form[name]' => 'Garbled Tags Event',
+            'event_form[date]' => '2026-10-20T14:00',
+            'event_form[timezone]' => 'UTC',
+            'event_form[registrationLink]' => 'https://example.com/garbled',
+            'event_form[tagsInput]' => 'not-json',
+        ]);
+
+        self::assertResponseRedirects();
+
+        /** @var EventRepository $repo */
+        $repo = static::getContainer()->get(EventRepository::class);
+        /** @var Event|null $event */
+        $event = $repo->findOneBy(['name' => 'Garbled Tags Event']);
+        self::assertNotNull($event);
+        self::assertCount(0, $event->getTags());
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        return $em;
+    }
+
+    private function getAdmin(): \App\Entity\User
+    {
+        /** @var \App\Repository\UserRepository $repo */
+        $repo = static::getContainer()->get(\App\Repository\UserRepository::class);
+        $admin = $repo->findOneBy(['email' => 'admin@example.com']);
+        self::assertNotNull($admin);
+
+        return $admin;
+    }
+}

--- a/tests/Functional/EventTagRepositoryTest.php
+++ b/tests/Functional/EventTagRepositoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\EventTag;
+use App\Repository\EventTagRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F3.12 — Event tags
+ */
+class EventTagRepositoryTest extends AbstractFunctionalTest
+{
+    public function testResolveByNamesCreatesNewTagsForUnknownNames(): void
+    {
+        $repository = $this->repository();
+
+        $tags = $repository->resolveByNames(['Regional', 'League Cup']);
+
+        self::assertCount(2, $tags);
+        self::assertSame('Regional', $tags[0]->getName());
+        self::assertSame('regional', $tags[0]->getSlug());
+        self::assertSame('League Cup', $tags[1]->getName());
+        self::assertSame('league-cup', $tags[1]->getSlug());
+        self::assertNull($tags[0]->getId(), 'New tags are returned un-flushed.');
+    }
+
+    public function testResolveByNamesReusesExistingTagsBySlug(): void
+    {
+        $em = $this->em();
+
+        $existing = new EventTag();
+        $existing->setName('Weekend');
+        $em->persist($existing);
+        $em->flush();
+
+        $tags = $this->repository()->resolveByNames(['weekend', 'WEEKEND', 'New One']);
+
+        self::assertCount(2, $tags, 'Duplicates collapsing to the same slug must be deduped.');
+        self::assertSame($existing->getId(), $tags[0]->getId());
+        self::assertSame('new-one', $tags[1]->getSlug());
+    }
+
+    public function testResolveByNamesIgnoresEmptyAndPunctuationOnlyEntries(): void
+    {
+        $tags = $this->repository()->resolveByNames(['', '   ', '???', 'Real']);
+
+        self::assertCount(1, $tags);
+        self::assertSame('Real', $tags[0]->getName());
+    }
+
+    public function testFindAllOrderedByNameReturnsSortedList(): void
+    {
+        $em = $this->em();
+
+        foreach (['Zeta', 'Alpha', 'Mu'] as $name) {
+            $tag = new EventTag();
+            $tag->setName($name);
+            $em->persist($tag);
+        }
+        $em->flush();
+
+        $names = array_map(static fn (EventTag $tag): string => $tag->getName(), $this->repository()->findAllOrderedByName());
+
+        self::assertSame(['Alpha', 'Mu', 'Zeta'], $names);
+    }
+
+    private function repository(): EventTagRepository
+    {
+        /** @var EventTagRepository $repository */
+        $repository = static::getContainer()->get(EventTagRepository::class);
+
+        return $repository;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        return $em;
+    }
+}

--- a/tests/Service/Event/EventIcalBuilderTest.php
+++ b/tests/Service/Event/EventIcalBuilderTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\Event;
+
+use App\Entity\Event;
+use App\Entity\User;
+use App\Service\Event\EventIcalBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @see docs/features.md F3.16 — Public iCal feed
+ */
+final class EventIcalBuilderTest extends TestCase
+{
+    public function testBuildsValidVCalendarWithVEventForEachInputEvent(): void
+    {
+        $builder = $this->makeBuilder();
+
+        $output = $builder->build([$this->makeEvent(1, 'League Cup'), $this->makeEvent(2, 'Regional')]);
+
+        self::assertStringStartsWith('BEGIN:VCALENDAR', $output);
+        self::assertStringContainsString('PRODID:-//Expanded Decks//Event Calendar//EN', $output);
+        self::assertStringContainsString('SUMMARY:League Cup', $output);
+        self::assertStringContainsString('SUMMARY:Regional', $output);
+        self::assertStringContainsString('UID:event-1@expandeddecks.app', $output);
+        self::assertStringContainsString('UID:event-2@expandeddecks.app', $output);
+        self::assertStringContainsString('URL:https://example.test/event/1', $output);
+        self::assertStringContainsString("END:VCALENDAR\r\n", $output);
+    }
+
+    public function testIncludesFeedTitleAsCalendarName(): void
+    {
+        $builder = $this->makeBuilder();
+
+        $output = $builder->build([$this->makeEvent(1, 'Cup')], 'My Feed');
+
+        self::assertStringContainsString('NAME:My Feed', $output);
+    }
+
+    public function testEmptyEventListProducesEmptyCalendar(): void
+    {
+        $builder = $this->makeBuilder();
+
+        $output = $builder->build([]);
+
+        self::assertStringContainsString('BEGIN:VCALENDAR', $output);
+        self::assertStringNotContainsString('BEGIN:VEVENT', $output);
+    }
+
+    public function testCancelledEventGetsCancelledStatus(): void
+    {
+        $builder = $this->makeBuilder();
+        $event = $this->makeEvent(1, 'Cancelled Cup');
+        $event->setCancelledAt(new \DateTimeImmutable('2026-04-01'));
+
+        $output = $builder->build([$event]);
+
+        self::assertStringContainsString('STATUS:CANCELLED', $output);
+    }
+
+    private function makeBuilder(): EventIcalBuilder
+    {
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')
+            ->willReturnCallback(static fn (string $name, array $params): string => \sprintf('https://example.test/event/%d', $params['id'] ?? 0));
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        return new EventIcalBuilder($urlGenerator, $translator);
+    }
+
+    private function makeEvent(int $id, string $name): Event
+    {
+        $organizer = $this->createStub(User::class);
+        $organizer->method('getScreenName')->willReturn('Alice');
+
+        $event = new Event();
+
+        // Force the auto-incremented id via reflection so that the iCal UID is deterministic.
+        $reflection = new \ReflectionProperty(Event::class, 'id');
+        $reflection->setValue($event, $id);
+
+        $event->setName($name);
+        $event->setOrganizer($organizer);
+        $event->setDate(new \DateTimeImmutable('2026-06-01 14:00:00', new \DateTimeZone('Europe/Paris')));
+
+        return $event;
+    }
+}

--- a/tests/Service/Event/PersonalCalendarTokenServiceTest.php
+++ b/tests/Service/Event/PersonalCalendarTokenServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service\Event;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\Event\PersonalCalendarTokenService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F3.14 — iCal agenda feed
+ */
+final class PersonalCalendarTokenServiceTest extends TestCase
+{
+    public function testEnsureTokenAssignsAndPersistsWhenMissing(): void
+    {
+        $user = new User();
+        self::assertNull($user->getCalendarToken());
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $service = new PersonalCalendarTokenService($em, $this->createStub(UserRepository::class));
+
+        $token = $service->ensureToken($user);
+
+        self::assertNotEmpty($token);
+        self::assertSame($token, $user->getCalendarToken());
+        self::assertGreaterThanOrEqual(40, \strlen($token));
+    }
+
+    public function testEnsureTokenIsIdempotentWhenTokenAlreadyExists(): void
+    {
+        $user = new User();
+        $user->setCalendarToken('existing-token-value');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('flush');
+
+        $service = new PersonalCalendarTokenService($em, $this->createStub(UserRepository::class));
+
+        self::assertSame('existing-token-value', $service->ensureToken($user));
+    }
+
+    public function testRegenerateTokenReplacesExistingToken(): void
+    {
+        $user = new User();
+        $user->setCalendarToken('old-token');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $service = new PersonalCalendarTokenService($em, $this->createStub(UserRepository::class));
+
+        $newToken = $service->regenerateToken($user);
+
+        self::assertNotSame('old-token', $newToken);
+        self::assertSame($newToken, $user->getCalendarToken());
+    }
+
+    public function testFindUserByTokenReturnsNullForEmptyToken(): void
+    {
+        $repository = $this->createMock(UserRepository::class);
+        $repository->expects(self::never())->method('findOneByCalendarToken');
+
+        $service = new PersonalCalendarTokenService(
+            $this->createStub(EntityManagerInterface::class),
+            $repository,
+        );
+
+        self::assertNull($service->findUserByToken(''));
+    }
+
+    public function testFindUserByTokenDelegatesToRepository(): void
+    {
+        $expectedUser = new User();
+
+        $repository = $this->createMock(UserRepository::class);
+        $repository->expects(self::once())
+            ->method('findOneByCalendarToken')
+            ->with('abc-123')
+            ->willReturn($expectedUser);
+
+        $service = new PersonalCalendarTokenService(
+            $this->createStub(EntityManagerInterface::class),
+            $repository,
+        );
+
+        self::assertSame($expectedUser, $service->findUserByToken('abc-123'));
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1198,6 +1198,91 @@
                 <target>No upcoming events.</target>
                 <note>Empty state when no upcoming events</note>
             </trans-unit>
+            <trans-unit id="app.event.tag.label">
+                <source>app.event.tag.label</source>
+                <target>Tags</target>
+                <note>Label for the event tag selector and tag list section</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.placeholder">
+                <source>app.event.tag.placeholder</source>
+                <target>Pick existing tags or type to create…</target>
+                <note>Placeholder inside the event tag selector input</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.help">
+                <source>app.event.tag.help</source>
+                <target>Use tags to group your events (e.g. league, weekend, regional). Type a name and press Enter to create a new one.</target>
+                <note>Helper text shown below the event tag selector</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.filter_label">
+                <source>app.event.tag.filter_label</source>
+                <target>Filter by tag</target>
+                <note>Label for the tag filter row on the event list</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.page_title">
+                <source>app.event.tag.page_title</source>
+                <target>Events tagged "%name%"</target>
+                <note>Title of the per-tag event list page</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.back_to_all">
+                <source>app.event.tag.back_to_all</source>
+                <target>All events</target>
+                <note>Back link from a tag-filtered event page to the full list</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.button">
+                <source>app.event.calendar.button</source>
+                <target>Calendar</target>
+                <note>Button opening calendar subscribe/download options on the event list</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.button_title">
+                <source>app.event.calendar.button_title</source>
+                <target>Subscribe to or download the event calendar</target>
+                <note>Tooltip on the calendar button</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.help">
+                <source>app.event.calendar.help</source>
+                <target>Add these events to your calendar app — updates automatically when subscribed.</target>
+                <note>Help text in the calendar dropdown menu</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.subscribe">
+                <source>app.event.calendar.subscribe</source>
+                <target>Subscribe (auto-update)</target>
+                <note>Calendar dropdown action: open with the OS calendar app via webcal://</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.download">
+                <source>app.event.calendar.download</source>
+                <target>Download .ics file</target>
+                <note>Calendar dropdown action: download the iCal file</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.copy_url">
+                <source>app.event.calendar.copy_url</source>
+                <target>Copy feed URL</target>
+                <note>Calendar dropdown action: copy the absolute iCal URL to the clipboard</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.copied">
+                <source>app.event.calendar.copied</source>
+                <target>Copied!</target>
+                <note>Confirmation shown after the calendar URL is copied</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.feed_title">
+                <source>app.event.ical.feed_title</source>
+                <target>Expanded Decks — Upcoming events</target>
+                <note>Calendar feed title shown by calendar apps</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.feed_title_tag">
+                <source>app.event.ical.feed_title_tag</source>
+                <target>Expanded Decks — Events tagged "%name%"</target>
+                <note>Per-tag calendar feed title shown by calendar apps</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.organized_by">
+                <source>app.event.ical.organized_by</source>
+                <target>Organized by %name%</target>
+                <note>First line of the iCal event description</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.structure">
+                <source>app.event.ical.structure</source>
+                <target>Structure: %structure%</target>
+                <note>Tournament structure line in the iCal event description</note>
+            </trans-unit>
             <trans-unit id="app.event.visibility.public">
                 <source>app.event.visibility.public</source>
                 <target>Public</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -13,6 +13,11 @@
                 <target>My Decks</target>
                 <note>User dropdown menu link to own decks</note>
             </trans-unit>
+            <trans-unit id="app.nav.my_agenda">
+                <source>app.nav.my_agenda</source>
+                <target>My Agenda</target>
+                <note>User dropdown menu link to the personal event agenda</note>
+            </trans-unit>
             <trans-unit id="app.nav.archetypes">
                 <source>app.nav.archetypes</source>
                 <target>Archetypes</target>
@@ -1282,6 +1287,91 @@
                 <source>app.event.ical.structure</source>
                 <target>Structure: %structure%</target>
                 <note>Tournament structure line in the iCal event description</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.agenda_feed_title">
+                <source>app.event.ical.agenda_feed_title</source>
+                <target>%name%'s Expanded Decks agenda</target>
+                <note>Per-user iCal agenda feed title</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.title">
+                <source>app.event.agenda.title</source>
+                <target>My agenda</target>
+                <note>Title of the personal event agenda page</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.intro">
+                <source>app.event.agenda.intro</source>
+                <target>Every upcoming event you're connected to: organizing, staffing, registered to play or spectate, invited, or interested.</target>
+                <note>Intro paragraph on the agenda page</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.feed_section_title">
+                <source>app.event.agenda.feed_section_title</source>
+                <target>Personal calendar feed</target>
+                <note>Section title for the per-user calendar URL</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.feed_section_help">
+                <source>app.event.agenda.feed_section_help</source>
+                <target>Subscribe to this URL in your calendar app to keep your Expanded Decks agenda in sync.</target>
+                <note>Help text above the per-user calendar URL field</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.security_warning_title">
+                <source>app.event.agenda.security_warning_title</source>
+                <target>Keep this URL private.</target>
+                <note>Lead-in for the security note about the personal calendar URL</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.security_warning_body">
+                <source>app.event.agenda.security_warning_body</source>
+                <target>Anyone with this link can read your agenda. If you've shared it by mistake, regenerate the URL to invalidate the old one.</target>
+                <note>Security note about the personal calendar URL</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.regenerate_button">
+                <source>app.event.agenda.regenerate_button</source>
+                <target>Regenerate URL</target>
+                <note>Button that issues a new calendar token, invalidating the previous URL</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.regenerate_confirm">
+                <source>app.event.agenda.regenerate_confirm</source>
+                <target>This will invalidate your current calendar URL. Continue?</target>
+                <note>Confirmation prompt before regenerating the calendar token</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.token_regenerated">
+                <source>app.event.agenda.token_regenerated</source>
+                <target>Your calendar URL has been regenerated. Update your calendar app to subscribe to the new URL.</target>
+                <note>Flash shown after regenerating the calendar token</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.empty">
+                <source>app.event.agenda.empty</source>
+                <target>You have no upcoming events on your agenda.</target>
+                <note>Empty state on the personal agenda page</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.interested">
+                <source>app.event.agenda.state.interested</source>
+                <target>Interested</target>
+                <note>Engagement state badge label</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.invited">
+                <source>app.event.agenda.state.invited</source>
+                <target>Invited</target>
+                <note>Engagement state badge label</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.registered_playing">
+                <source>app.event.agenda.state.registered_playing</source>
+                <target>Playing</target>
+                <note>Engagement state badge label</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.registered_spectating">
+                <source>app.event.agenda.state.registered_spectating</source>
+                <target>Spectating</target>
+                <note>Engagement state badge label</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.organizing">
+                <source>app.event.agenda.state.organizing</source>
+                <target>Organizing</target>
+                <note>Agenda role badge for events the user organizes</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.staffing">
+                <source>app.event.agenda.state.staffing</source>
+                <target>Staffing</target>
+                <note>Agenda role badge for events the user staffs</note>
             </trans-unit>
             <trans-unit id="app.event.visibility.public">
                 <source>app.event.visibility.public</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -13,6 +13,11 @@
                 <target>Mes Decks</target>
                 <note>User dropdown menu link to own decks</note>
             </trans-unit>
+            <trans-unit id="app.nav.my_agenda">
+                <source>app.nav.my_agenda</source>
+                <target>Mon Agenda</target>
+                <note>User dropdown menu link to the personal event agenda</note>
+            </trans-unit>
             <trans-unit id="app.nav.archetypes">
                 <source>app.nav.archetypes</source>
                 <target>Archétypes</target>
@@ -1272,6 +1277,91 @@
                 <source>app.event.ical.structure</source>
                 <target>Structure : %structure%</target>
                 <note>Tournament structure line in the iCal event description</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.agenda_feed_title">
+                <source>app.event.ical.agenda_feed_title</source>
+                <target>Agenda Expanded Decks de %name%</target>
+                <note>Per-user iCal agenda feed title</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.title">
+                <source>app.event.agenda.title</source>
+                <target>Mon agenda</target>
+                <note>Title of the personal event agenda page</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.intro">
+                <source>app.event.agenda.intro</source>
+                <target>Tous les événements à venir où tu es lié : organisateur(rice), staff, inscrit(e) comme joueur(se) ou spectateur(rice), invité(e) ou intéressé(e).</target>
+                <note>Intro paragraph on the agenda page</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.feed_section_title">
+                <source>app.event.agenda.feed_section_title</source>
+                <target>Flux personnel</target>
+                <note>Section title for the per-user calendar URL</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.feed_section_help">
+                <source>app.event.agenda.feed_section_help</source>
+                <target>Abonne-toi à cette URL dans ton agenda pour garder ton planning Expanded Decks à jour.</target>
+                <note>Help text above the per-user calendar URL field</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.security_warning_title">
+                <source>app.event.agenda.security_warning_title</source>
+                <target>Garde cette URL privée.</target>
+                <note>Lead-in for the security note about the personal calendar URL</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.security_warning_body">
+                <source>app.event.agenda.security_warning_body</source>
+                <target>N'importe qui ayant ce lien peut lire ton agenda. Si tu l'as partagé par erreur, régénère l'URL pour invalider l'ancienne.</target>
+                <note>Security note about the personal calendar URL</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.regenerate_button">
+                <source>app.event.agenda.regenerate_button</source>
+                <target>Régénérer l'URL</target>
+                <note>Button that issues a new calendar token, invalidating the previous URL</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.regenerate_confirm">
+                <source>app.event.agenda.regenerate_confirm</source>
+                <target>Cela invalidera l'URL de calendrier actuelle. Continuer ?</target>
+                <note>Confirmation prompt before regenerating the calendar token</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.token_regenerated">
+                <source>app.event.agenda.token_regenerated</source>
+                <target>Ton URL de calendrier a été régénérée. Mets à jour ton application d'agenda pour t'abonner à la nouvelle URL.</target>
+                <note>Flash shown after regenerating the calendar token</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.empty">
+                <source>app.event.agenda.empty</source>
+                <target>Aucun événement à venir dans ton agenda.</target>
+                <note>Empty state on the personal agenda page</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.interested">
+                <source>app.event.agenda.state.interested</source>
+                <target>Intéressé(e)</target>
+                <note>Engagement state badge label</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.invited">
+                <source>app.event.agenda.state.invited</source>
+                <target>Invité(e)</target>
+                <note>Engagement state badge label</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.registered_playing">
+                <source>app.event.agenda.state.registered_playing</source>
+                <target>Joueur(se)</target>
+                <note>Engagement state badge label</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.registered_spectating">
+                <source>app.event.agenda.state.registered_spectating</source>
+                <target>Spectateur(rice)</target>
+                <note>Engagement state badge label</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.organizing">
+                <source>app.event.agenda.state.organizing</source>
+                <target>Organisateur(rice)</target>
+                <note>Agenda role badge for events the user organizes</note>
+            </trans-unit>
+            <trans-unit id="app.event.agenda.state.staffing">
+                <source>app.event.agenda.state.staffing</source>
+                <target>Staff</target>
+                <note>Agenda role badge for events the user staffs</note>
             </trans-unit>
             <trans-unit id="app.event.visibility.public">
                 <source>app.event.visibility.public</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -1188,6 +1188,91 @@
                 <target>Aucun événement à venir.</target>
                 <note>Empty state when no upcoming events</note>
             </trans-unit>
+            <trans-unit id="app.event.tag.label">
+                <source>app.event.tag.label</source>
+                <target>Tags</target>
+                <note>Label for the event tag selector and tag list section</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.placeholder">
+                <source>app.event.tag.placeholder</source>
+                <target>Choisis des tags ou tape pour en créer…</target>
+                <note>Placeholder inside the event tag selector input</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.help">
+                <source>app.event.tag.help</source>
+                <target>Utilise des tags pour regrouper tes événements (ex. league, week-end, régional). Tape un nom et appuie sur Entrée pour en créer un nouveau.</target>
+                <note>Helper text shown below the event tag selector</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.filter_label">
+                <source>app.event.tag.filter_label</source>
+                <target>Filtrer par tag</target>
+                <note>Label for the tag filter row on the event list</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.page_title">
+                <source>app.event.tag.page_title</source>
+                <target>Événements taggés « %name% »</target>
+                <note>Title of the per-tag event list page</note>
+            </trans-unit>
+            <trans-unit id="app.event.tag.back_to_all">
+                <source>app.event.tag.back_to_all</source>
+                <target>Tous les événements</target>
+                <note>Back link from a tag-filtered event page to the full list</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.button">
+                <source>app.event.calendar.button</source>
+                <target>Calendrier</target>
+                <note>Button opening calendar subscribe/download options on the event list</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.button_title">
+                <source>app.event.calendar.button_title</source>
+                <target>S'abonner ou télécharger le calendrier des événements</target>
+                <note>Tooltip on the calendar button</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.help">
+                <source>app.event.calendar.help</source>
+                <target>Ajoute ces événements à ton agenda — mise à jour automatique en mode abonnement.</target>
+                <note>Help text in the calendar dropdown menu</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.subscribe">
+                <source>app.event.calendar.subscribe</source>
+                <target>S'abonner (mise à jour auto)</target>
+                <note>Calendar dropdown action: open with the OS calendar app via webcal://</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.download">
+                <source>app.event.calendar.download</source>
+                <target>Télécharger le fichier .ics</target>
+                <note>Calendar dropdown action: download the iCal file</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.copy_url">
+                <source>app.event.calendar.copy_url</source>
+                <target>Copier l'URL du flux</target>
+                <note>Calendar dropdown action: copy the absolute iCal URL to the clipboard</note>
+            </trans-unit>
+            <trans-unit id="app.event.calendar.copied">
+                <source>app.event.calendar.copied</source>
+                <target>Copié !</target>
+                <note>Confirmation shown after the calendar URL is copied</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.feed_title">
+                <source>app.event.ical.feed_title</source>
+                <target>Expanded Decks — Événements à venir</target>
+                <note>Calendar feed title shown by calendar apps</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.feed_title_tag">
+                <source>app.event.ical.feed_title_tag</source>
+                <target>Expanded Decks — Événements taggés « %name% »</target>
+                <note>Per-tag calendar feed title shown by calendar apps</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.organized_by">
+                <source>app.event.ical.organized_by</source>
+                <target>Organisé par %name%</target>
+                <note>First line of the iCal event description</note>
+            </trans-unit>
+            <trans-unit id="app.event.ical.structure">
+                <source>app.event.ical.structure</source>
+                <target>Structure : %structure%</target>
+                <note>Tournament structure line in the iCal event description</note>
+            </trans-unit>
             <trans-unit id="app.event.visibility.public">
                 <source>app.event.visibility.public</source>
                 <target>Public</target>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,6 +44,8 @@ Encore
     .addEntry('toggle_private_decks', './assets/toggle-private-decks.ts')
     .addEntry('friendly_captcha', './assets/friendly-captcha.ts')
     .addEntry('deck_found', './assets/deck-found.tsx')
+    .addEntry('event_form', './assets/event-form.tsx')
+    .addEntry('event_calendar_copy', './assets/event-calendar-copy.ts')
 
     .splitEntryChunks()
     .enableSingleRuntimeChunk()


### PR DESCRIPTION
## Summary

Three event-discovery features that share the iCal infrastructure: **F3.12 Event tags** (#170), **F3.14 iCal agenda feed** (#171), and **F3.16 Public iCal feed** (#172).

### Tags
- New `EventTag` entity (name, slug, createdAt) with ManyToMany on `Event`, cascade-persist so unknown tags typed in the form are upserted on submit.
- Mantine `TagsInput` React island wired to a HiddenType field on `EventFormType`; existing tags fed via data attribute, names resolved server-side by slug via `EventTagRepository::resolveByNames()`.
- Tag chips on the event detail page and on event-list cards, each linking to `GET /event/tag/{slug}` (route `app_event_tag`).
- Tag filter row on `/event` with active-tag highlight.

### Public calendar feed
- `eluceo/ical` ^2.16 + `EventIcalBuilder` produce RFC 5545 VCALENDAR/VEVENTs with stable UID, UTC DTSTART/DTEND, SUMMARY, LOCATION, URL, STATUS, plus injected `X-WR-CALNAME` / `NAME` for the feed name.
- `GET /event.ics` (route `app_event_list_ical`) and `GET /event/tag/{slug}.ics` (`app_event_tag_ical`) serve `text/calendar` with `Cache-Control: public, max-age=3600`.
- Subscribe button on every event list with three actions (Subscribe via `webcal://`, Download `.ics`, Copy feed URL) — URL adapts to the active tag.

### Personal agenda + private iCal feed (F3.14)
- `GET /event/agenda` (`app_event_agenda`, ROLE_USER) lists upcoming events where the user is **organizer**, **on staff**, or holds **any engagement** (interested / invited / registered playing / spectating). One ORed query in `EventRepository::findUpcomingForUserAgenda`.
- Cards show a yellow **Organizing** / **Staffing** badge plus a blue engagement chip when both apply.
- New `User.calendarToken` (varchar 64, unique) generated lazily by `PersonalCalendarTokenService::ensureToken()` (base64url-encoded `random_bytes(32)`). Cleared in `User::anonymize()` for GDPR.
- `GET /calendar/event/{token}.ics` (PUBLIC, anonymous, 404 on unknown token) reuses `EventIcalBuilder`; `Cache-Control: private, max-age=1800`.
- `POST /event/agenda/regenerate-token` (CSRF + confirm) rotates the token so a leaked URL can be invalidated.
- Single feed block on the agenda page: URL field + Copy + Subscribe (webcal://) + Download + security note + Regenerate form, in that order.

### Plumbing
- `security.yaml`: PUBLIC_ACCESS for `/event.ics`, `/event/tag/<slug>(.ics)?`, and `/calendar/event/<token>.ics` so anonymous calendar clients aren't redirected to login.
- Navigation: **My Agenda** in the user dropdown (after My Decks, gated on `channel.enableEvents`); **My Agenda** outline button in the event list header next to the Calendar dropdown (mirrors the My Decks pattern on the deck catalog).
- Dashboard: "My events → see all" and the upcoming-events stats card both point to `/event/agenda`.
- Event list scope filter: drops `staffing` (covered by My Agenda) — only **All / Public** remain.
- Migrations `Version20260501100000` (event_tag + event_event_tag) and `Version20260501150000` (user.calendar_token).
- Translations under `app.event.tag.*`, `app.event.calendar.*`, `app.event.ical.*`, `app.event.agenda.*`, and `app.nav.my_agenda` in en + fr.
- Tests: `EventTagTest` (slugify / lifecycle), `EventIcalBuilderTest` (VCALENDAR shape, UID/URL, status, named feed, empty list), `PersonalCalendarTokenServiceTest` (ensure / regenerate / find).

Closes #170
Closes #171
Closes #172

## Test plan

- [ ] `make migrations` then `make assets` succeed
- [ ] As an organizer, create or edit an event with a couple of tags via the new selector — tags display on the event page and on list cards
- [ ] Click a tag chip → `/event/tag/<slug>` lists matching events; the tag-filter row on `/event` mirrors that
- [ ] Anonymous `curl -k https://expandeddecks.wip/event.ics | head` starts with `BEGIN:VCALENDAR`; same for `/event/tag/<slug>.ics`
- [ ] Logged-in `/event/agenda` lists events where you're organizer / staff / interested / invited / registered playing / spectating, with the appropriate role + engagement badges
- [ ] The agenda block exposes the absolute calendar URL with Copy / Subscribe (webcal://) / Download / Regenerate; regenerating invalidates the previous URL (old token returns 404)
- [ ] Anonymous fetch of `/calendar/event/<token>.ics` returns the calendar (200, not a 302 to login)
- [ ] Subscribe to both feeds (public and personal) in Apple Calendar / Google Calendar against the production hostname — events appear and refresh on TTL; cancelled events show `STATUS:CANCELLED`
- [ ] User dropdown shows **My Agenda** after **My Decks**; dashboard "My events → see all" lands on the agenda; event list header shows the My Agenda outline button next to Calendar / + New Event

🤖 Generated with [Claude Code](https://claude.com/claude-code)