### PR TITLE
:sparkles: Feature: event custody flag, organizer handover, form fixes

### DIFF
--- a/migrations/Version20260501170000.php
+++ b/migrations/Version20260501170000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add event.allow_custody (organizer accepts staff custody of player decks).
+ *
+ * @see docs/features.md F4.8 — Staff-delegated lending
+ */
+final class Version20260501170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add event.allow_custody flag — gates the staff-delegation action';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event ADD allow_custody TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event DROP allow_custody');
+    }
+}

--- a/migrations/Version20260501180000.php
+++ b/migrations/Version20260501180000.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add pending-transfer columns to event for the two-step organizer handover.
+ *
+ * @see docs/features.md F3.23 — Organizer handover
+ */
+final class Version20260501180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add event.pending_transfer_to_id + pending_transfer_requested_at for organizer handover';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event ADD pending_transfer_to_id INT DEFAULT NULL, ADD pending_transfer_requested_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE event ADD CONSTRAINT FK_event_pending_transfer_to FOREIGN KEY (pending_transfer_to_id) REFERENCES user (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_event_pending_transfer_to ON event (pending_transfer_to_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event DROP FOREIGN KEY FK_event_pending_transfer_to');
+        $this->addSql('DROP INDEX IDX_event_pending_transfer_to ON event');
+        $this->addSql('ALTER TABLE event DROP pending_transfer_to_id, DROP pending_transfer_requested_at');
+    }
+}

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -463,6 +463,154 @@ class EventController extends AbstractAppController
         return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
     }
 
+    /**
+     * Initiate handover: organizer picks a target user. The target must
+     * accept on the event page before the transfer takes effect.
+     *
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    #[Route('/{id}/transfer/initiate', name: 'app_event_transfer_initiate', methods: ['POST'], requirements: ['id' => '\d+'])]
+    #[IsGranted('ROLE_ORGANIZER')]
+    public function transferInitiate(
+        Event $event,
+        Request $request,
+        EntityManagerInterface $em,
+        UserRepository $userRepository,
+        EventNotificationService $notificationService,
+    ): Response {
+        $this->denyAccessUnlessOrganizer($event);
+
+        if (!$this->isCsrfTokenValid('event-transfer-initiate-'.$event->getId(), $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.flash.invalid_token');
+
+            return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+        }
+
+        $targetQuery = trim($request->getPayload()->getString('target'));
+
+        if ('' === $targetQuery) {
+            $this->addFlash('warning', 'app.flash.event.transfer.target_required');
+
+            return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+        }
+
+        $target = $userRepository->findByMultiField($targetQuery);
+
+        /** @var User $currentOrganizer */
+        $currentOrganizer = $this->getUser();
+
+        if (null === $target || $target->getId() === $currentOrganizer->getId()) {
+            $this->addFlash('warning', 'app.flash.event.transfer.target_invalid');
+
+            return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+        }
+
+        $event->requestTransferTo($target);
+        $em->flush();
+
+        $notificationService->notifyTransferRequested($event, $target, $currentOrganizer);
+
+        $this->addFlash('success', 'app.flash.event.transfer.initiated', ['%name%' => $target->getScreenName()]);
+
+        return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+    }
+
+    /**
+     * Current organizer cancels a pending handover.
+     *
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    #[Route('/{id}/transfer/cancel', name: 'app_event_transfer_cancel', methods: ['POST'], requirements: ['id' => '\d+'])]
+    #[IsGranted('ROLE_ORGANIZER')]
+    public function transferCancel(Event $event, Request $request, EntityManagerInterface $em): Response
+    {
+        $this->denyAccessUnlessOrganizer($event);
+
+        if (!$this->isCsrfTokenValid('event-transfer-cancel-'.$event->getId(), $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.flash.invalid_token');
+
+            return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+        }
+
+        if (!$event->hasPendingTransfer()) {
+            return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+        }
+
+        $event->clearPendingTransfer();
+        $em->flush();
+
+        $this->addFlash('success', 'app.flash.event.transfer.cancelled');
+
+        return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+    }
+
+    /**
+     * Target accepts the handover — they become the new organizer.
+     *
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    #[Route('/{id}/transfer/accept', name: 'app_event_transfer_accept', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function transferAccept(
+        Event $event,
+        Request $request,
+        EntityManagerInterface $em,
+        EventNotificationService $notificationService,
+    ): Response {
+        /** @var User $user */
+        $user = $this->getUser();
+        $this->denyAccessUnlessTransferTarget($event, $user);
+
+        if (!$this->isCsrfTokenValid('event-transfer-accept-'.$event->getId(), $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.flash.invalid_token');
+
+            return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+        }
+
+        $previousOrganizer = $event->getOrganizer();
+        $event->setOrganizer($user);
+        $event->clearPendingTransfer();
+        $em->flush();
+
+        $notificationService->notifyTransferAccepted($event, $previousOrganizer, $user);
+
+        $this->addFlash('success', 'app.flash.event.transfer.accepted', ['%name%' => $event->getName()]);
+
+        return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+    }
+
+    /**
+     * Target declines the handover — the previous organizer stays.
+     *
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    #[Route('/{id}/transfer/decline', name: 'app_event_transfer_decline', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function transferDecline(
+        Event $event,
+        Request $request,
+        EntityManagerInterface $em,
+        EventNotificationService $notificationService,
+    ): Response {
+        /** @var User $user */
+        $user = $this->getUser();
+        $this->denyAccessUnlessTransferTarget($event, $user);
+
+        if (!$this->isCsrfTokenValid('event-transfer-decline-'.$event->getId(), $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.flash.invalid_token');
+
+            return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+        }
+
+        $organizer = $event->getOrganizer();
+        $event->clearPendingTransfer();
+        $em->flush();
+
+        $notificationService->notifyTransferDeclined($event, $organizer, $user);
+
+        $this->addFlash('success', 'app.flash.event.transfer.declined');
+
+        return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+    }
+
     #[Route('/{id}/delete', name: 'app_event_delete', methods: ['POST'], requirements: ['id' => '\d+'])]
     #[IsGranted('ROLE_ADMIN')]
     public function delete(Event $event, Request $request, EntityManagerInterface $em): Response
@@ -1019,6 +1167,13 @@ class EventController extends AbstractAppController
             return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
         }
 
+        // Cannot enable delegation when the organizer hasn't accepted custody for this event.
+        if (!$registration->isDelegateToStaff() && !$event->isAllowCustody()) {
+            $this->addFlash('warning', 'app.flash.event.delegation_not_allowed');
+
+            return $this->redirectToRoute('app_event_show', ['id' => $event->getId()]);
+        }
+
         $registration->setDelegateToStaff(!$registration->isDelegateToStaff());
         $em->flush();
 
@@ -1271,6 +1426,18 @@ class EventController extends AbstractAppController
 
         if ($event->getOrganizer()->getId() !== $user->getId()) {
             throw $this->createAccessDeniedException('You are not the organizer of this event.');
+        }
+    }
+
+    /**
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    private function denyAccessUnlessTransferTarget(Event $event, User $user): void
+    {
+        $target = $event->getPendingTransferTo();
+
+        if (null === $target || $target->getId() !== $user->getId()) {
+            throw $this->createAccessDeniedException('You are not the recipient of a pending transfer for this event.');
         }
     }
 

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -327,6 +327,7 @@ MARKDOWN;
         $event->setRegistrationLink('https://pokemon-lyon.example.com/events/42');
         $event->setTournamentStructure(TournamentStructure::Swiss);
         $event->setFormat('Expanded');
+        $event->setAllowCustody(true);
 
         $manager->persist($event);
 

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -117,6 +117,22 @@ class Event
     #[ORM\Column]
     private bool $isInvitationOnly = false;
 
+    /**
+     * @see docs/features.md F4.8 — Staff-delegated lending
+     */
+    #[ORM\Column(options: ['default' => false])]
+    private bool $allowCustody = false;
+
+    /**
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?User $pendingTransferTo = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $pendingTransferRequestedAt = null;
+
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
 
@@ -418,6 +434,55 @@ class Event
     public function setIsInvitationOnly(bool $isInvitationOnly): static
     {
         $this->isInvitationOnly = $isInvitationOnly;
+
+        return $this;
+    }
+
+    /**
+     * @see docs/features.md F4.8 — Staff-delegated lending
+     */
+    public function isAllowCustody(): bool
+    {
+        return $this->allowCustody;
+    }
+
+    public function setAllowCustody(bool $allowCustody): static
+    {
+        $this->allowCustody = $allowCustody;
+
+        return $this;
+    }
+
+    /**
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    public function getPendingTransferTo(): ?User
+    {
+        return $this->pendingTransferTo;
+    }
+
+    public function getPendingTransferRequestedAt(): ?\DateTimeImmutable
+    {
+        return $this->pendingTransferRequestedAt;
+    }
+
+    public function hasPendingTransfer(): bool
+    {
+        return null !== $this->pendingTransferTo;
+    }
+
+    public function requestTransferTo(User $target): static
+    {
+        $this->pendingTransferTo = $target;
+        $this->pendingTransferRequestedAt = new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    public function clearPendingTransfer(): static
+    {
+        $this->pendingTransferTo = null;
+        $this->pendingTransferRequestedAt = null;
 
         return $this;
     }

--- a/src/Enum/NotificationType.php
+++ b/src/Enum/NotificationType.php
@@ -32,6 +32,9 @@ enum NotificationType: string
     case EventReminder = 'event_reminder';
     case EventEndingPhase = 'event_ending_phase';
     case EventCustodyPickup = 'event_custody_pickup';
+    case EventTransferRequested = 'event_transfer_requested';
+    case EventTransferAccepted = 'event_transfer_accepted';
+    case EventTransferDeclined = 'event_transfer_declined';
     case DeckFound = 'deck_found';
 
     public function isBorrowType(): bool

--- a/src/Form/EventFormType.php
+++ b/src/Form/EventFormType.php
@@ -149,6 +149,11 @@ class EventFormType extends AbstractType
                 'label' => 'app.form.label.invitation_only',
                 'required' => false,
             ])
+            ->add('allowCustody', CheckboxType::class, [
+                'label' => 'app.form.label.allow_custody',
+                'help' => 'app.form.help.allow_custody',
+                'required' => false,
+            ])
             ->add('tagsInput', HiddenType::class, [
                 'mapped' => false,
                 'required' => false,

--- a/src/Service/EventNotificationService.php
+++ b/src/Service/EventNotificationService.php
@@ -260,6 +260,63 @@ class EventNotificationService
     }
 
     /**
+     * Notify the target that the current organizer wants to hand the event over.
+     *
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    public function notifyTransferRequested(Event $event, User $target, User $fromOrganizer): void
+    {
+        $this->createNotification(
+            $target,
+            NotificationType::EventTransferRequested,
+            $this->trans('app.notification.event.transfer_requested_title', [], $target),
+            $this->trans('app.notification.event.transfer_requested_message', [
+                '%event%' => $event->getName(),
+                '%name%' => $fromOrganizer->getScreenName(),
+            ], $target),
+            $event,
+        );
+    }
+
+    /**
+     * Notify the previous organizer that the target accepted the handover.
+     *
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    public function notifyTransferAccepted(Event $event, User $previousOrganizer, User $newOrganizer): void
+    {
+        $this->createNotification(
+            $previousOrganizer,
+            NotificationType::EventTransferAccepted,
+            $this->trans('app.notification.event.transfer_accepted_title', [], $previousOrganizer),
+            $this->trans('app.notification.event.transfer_accepted_message', [
+                '%event%' => $event->getName(),
+                '%name%' => $newOrganizer->getScreenName(),
+            ], $previousOrganizer),
+            $event,
+        );
+    }
+
+    /**
+     * Notify the organizer that the target declined the handover.
+     *
+     * @see docs/features.md F3.23 — Organizer handover
+     */
+    public function notifyTransferDeclined(Event $event, User $organizer, User $target): void
+    {
+        $this->createNotification(
+            $organizer,
+            NotificationType::EventTransferDeclined,
+            $this->trans('app.notification.event.transfer_declined_title', [], $organizer),
+            $this->trans('app.notification.event.transfer_declined_message', [
+                '%event%' => $event->getName(),
+                '%name%' => $target->getScreenName(),
+            ], $organizer),
+            $event,
+        );
+    }
+
+    /**
      * @param array<string, string> $params
      */
     private function trans(string $key, array $params, User $recipient): string

--- a/templates/event/edit.html.twig
+++ b/templates/event/edit.html.twig
@@ -74,7 +74,10 @@
                             <div class="col-md-6">{{ form_row(form.entryFeeCurrency) }}</div>
                         </div>
 
+                        {{ form_row(form.visibility) }}
+                        {{ form_row(form.isInvitationOnly) }}
                         {{ form_row(form.isDecklistMandatory) }}
+                        {{ form_row(form.allowCustody) }}
 
                         {% include 'event/_tag_selector.html.twig' with {form: form, existingTagNames: existingTagNames, initialTagNames: initialTagNames} only %}
 

--- a/templates/event/new.html.twig
+++ b/templates/event/new.html.twig
@@ -74,7 +74,10 @@
                             <div class="col-md-6">{{ form_row(form.entryFeeCurrency) }}</div>
                         </div>
 
+                        {{ form_row(form.visibility) }}
+                        {{ form_row(form.isInvitationOnly) }}
                         {{ form_row(form.isDecklistMandatory) }}
+                        {{ form_row(form.allowCustody) }}
 
                         {% include 'event/_tag_selector.html.twig' with {form: form, existingTagNames: existingTagNames, initialTagNames: initialTagNames} only %}
 

--- a/templates/event/show.html.twig
+++ b/templates/event/show.html.twig
@@ -122,6 +122,62 @@
         </div>
     </div>
 
+    {# F3.23 — Organizer handover banner / form #}
+    {% if app.user and event.hasPendingTransfer and event.pendingTransferTo.id == app.user.id %}
+        <div class="alert alert-info d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+            <div>
+                <strong>{{ 'app.event.transfer.target_banner_title'|trans }}</strong>
+                <div class="small">{{ 'app.event.transfer.target_banner_body'|trans({'%name%': event.organizer.screenName}) }}</div>
+            </div>
+            <div class="d-flex gap-2">
+                <form method="post" action="{{ path('app_event_transfer_accept', {id: event.id}) }}" class="d-inline">
+                    <input type="hidden" name="_token" value="{{ csrf_token('event-transfer-accept-' ~ event.id) }}">
+                    <button type="submit" class="btn btn-sm btn-success">{{ 'app.event.transfer.accept'|trans }}</button>
+                </form>
+                <form method="post" action="{{ path('app_event_transfer_decline', {id: event.id}) }}" class="d-inline">
+                    <input type="hidden" name="_token" value="{{ csrf_token('event-transfer-decline-' ~ event.id) }}">
+                    <button type="submit" class="btn btn-sm btn-outline-secondary">{{ 'app.event.transfer.decline'|trans }}</button>
+                </form>
+            </div>
+        </div>
+    {% endif %}
+
+    {% if isOrganizer and not event.cancelledAt %}
+        <div class="card shadow-sm mb-3">
+            <div class="card-header card-header-themed">
+                <h6 class="mb-0">{{ 'app.event.transfer.section_title'|trans }}</h6>
+            </div>
+            <div class="card-body">
+                {% if event.hasPendingTransfer %}
+                    <p class="mb-2">{{ 'app.event.transfer.pending_body'|trans({'%name%': event.pendingTransferTo.screenName}) }}</p>
+                    <form method="post" action="{{ path('app_event_transfer_cancel', {id: event.id}) }}" class="d-inline">
+                        <input type="hidden" name="_token" value="{{ csrf_token('event-transfer-cancel-' ~ event.id) }}">
+                        <button type="submit" class="btn btn-sm btn-outline-danger">{{ 'app.event.transfer.cancel'|trans }}</button>
+                    </form>
+                {% else %}
+                    <p class="text-muted small mb-2">{{ 'app.event.transfer.help'|trans }}</p>
+                    <form method="post" action="{{ path('app_event_transfer_initiate', {id: event.id}) }}" class="d-flex gap-2 align-items-start inline-confirm-form">
+                        <input type="hidden" name="_token" value="{{ csrf_token('event-transfer-initiate-' ~ event.id) }}">
+                        <div class="flex-grow-1"
+                             data-staff-autocomplete
+                             data-search-url="{{ path('app_user_search') }}"
+                             data-hidden-input="target"
+                             data-placeholder="{{ 'app.event.transfer.placeholder'|trans }}">
+                        </div>
+                        <button type="button" class="btn btn-outline-primary inline-confirm-trigger">
+                            {{ 'app.event.transfer.initiate'|trans }}
+                        </button>
+                        <span class="inline-confirm-actions d-none d-flex gap-1 align-items-center">
+                            <span class="small text-muted me-1">{{ 'app.event.transfer.confirm'|trans }}</span>
+                            <button type="submit" class="btn btn-sm btn-primary">{{ 'app.common.yes'|trans }}</button>
+                            <button type="button" class="btn btn-sm btn-outline-secondary inline-confirm-cancel">{{ 'app.common.cancel'|trans }}</button>
+                        </span>
+                    </form>
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
+
     {% if isOrganizer and not event.cancelledAt %}
         <div id="staff" class="card shadow-sm mb-3">
             <div class="card-header card-header-themed">
@@ -353,7 +409,8 @@
                                                 <button type="submit" class="btn btn-sm btn-outline-warning" {{ (not isRegistered or deckWithStaff) ? 'disabled' }}
                                                     {% if deckWithStaff %}title="Cannot revoke — deck is currently with staff"{% endif %}>{{ 'app.event.revoke'|trans }}</button>
                                             {% else %}
-                                                <button type="submit" class="btn btn-sm btn-outline-info" {{ not isRegistered ? 'disabled' }}>{{ 'app.event.delegate'|trans }}</button>
+                                                <button type="submit" class="btn btn-sm btn-outline-info" {{ (not isRegistered or not event.allowCustody) ? 'disabled' }}
+                                                    {% if not event.allowCustody %}title="{{ 'app.event.delegate_disabled_reason'|trans }}"{% endif %}>{{ 'app.event.delegate'|trans }}</button>
                                             {% endif %}
                                         </form>
                                     </td>
@@ -423,7 +480,8 @@
                                         {% set deckWithStaff = regInfo.staffReceivedAt and not regInfo.staffReturnedAt %}
                                         <button type="submit" class="btn btn-sm btn-outline-warning" {{ (not isRegistered or deckWithStaff) ? 'disabled' }}>{{ 'app.event.revoke'|trans }}</button>
                                     {% else %}
-                                        <button type="submit" class="btn btn-sm btn-outline-info" {{ not isRegistered ? 'disabled' }}>{{ 'app.event.delegate'|trans }}</button>
+                                        <button type="submit" class="btn btn-sm btn-outline-info" {{ (not isRegistered or not event.allowCustody) ? 'disabled' }}
+                                            {% if not event.allowCustody %}title="{{ 'app.event.delegate_disabled_reason'|trans }}"{% endif %}>{{ 'app.event.delegate'|trans }}</button>
                                     {% endif %}
                                 </form>
                                 {% if isDelegated %}
@@ -927,4 +985,36 @@
         {{ encore_entry_script_tags('staff_autocomplete') }}
     {% endif %}
     {{ encore_entry_script_tags('toggle_private_decks') }}
+    <script>
+        /**
+         * Inline confirmation toggle for destructive actions.
+         * Clicking the trigger hides it and reveals Yes/Cancel buttons.
+         * Cancel or timeout (5 s) resets to the initial state.
+         *
+         * @see docs/features.md F3.23 — Organizer handover
+         */
+        document.querySelectorAll('.inline-confirm-form').forEach((form) => {
+            const trigger = form.querySelector('.inline-confirm-trigger');
+            const actions = form.querySelector('.inline-confirm-actions');
+            const cancel = form.querySelector('.inline-confirm-cancel');
+
+            if (!trigger || !actions || !cancel) return;
+
+            let timeout;
+
+            const reset = () => {
+                trigger.classList.remove('d-none');
+                actions.classList.add('d-none');
+                clearTimeout(timeout);
+            };
+
+            trigger.addEventListener('click', () => {
+                trigger.classList.add('d-none');
+                actions.classList.remove('d-none');
+                timeout = setTimeout(reset, 5000);
+            });
+
+            cancel.addEventListener('click', reset);
+        });
+    </script>
 {% endblock %}

--- a/tests/Functional/EventCustodyAndHandoverTest.php
+++ b/tests/Functional/EventCustodyAndHandoverTest.php
@@ -1,0 +1,368 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\Deck;
+use App\Entity\Event;
+use App\Entity\EventDeckRegistration;
+use App\Entity\EventEngagement;
+use App\Entity\User;
+use App\Enum\EngagementState;
+use App\Repository\DeckRepository;
+use App\Repository\EventDeckRegistrationRepository;
+use App\Repository\EventRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * @see docs/features.md F4.8 — Staff-delegated lending (allow_custody gate)
+ * @see docs/features.md F3.23 — Organizer handover
+ */
+class EventCustodyAndHandoverTest extends AbstractFunctionalTest
+{
+    public function testNewEventStartsWithCustodyDisabled(): void
+    {
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', '/event/new');
+        $this->client->submitForm('Create Event', [
+            'event_form[name]' => 'Custody Default Event',
+            'event_form[date]' => '2026-09-15T14:00',
+            'event_form[timezone]' => 'UTC',
+            'event_form[registrationLink]' => 'https://example.com/custody-default',
+        ]);
+
+        self::assertResponseRedirects();
+
+        $event = $this->eventRepository()->findOneBy(['name' => 'Custody Default Event']);
+        self::assertNotNull($event);
+        self::assertFalse($event->isAllowCustody());
+    }
+
+    public function testEditCanEnableAllowCustody(): void
+    {
+        $event = $this->createOrganizedEvent($this->getUser('admin@example.com'), 'Toggle Custody Event');
+        $eventId = $event->getId();
+        self::assertNotNull($eventId);
+
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', \sprintf('/event/%d/edit', $eventId));
+        $this->client->submitForm('Save', [
+            'event_form[allowCustody]' => '1',
+        ]);
+
+        self::assertResponseRedirects();
+        $this->em()->clear();
+
+        /** @var Event $reloaded */
+        $reloaded = $this->eventRepository()->find($eventId);
+        self::assertTrue($reloaded->isAllowCustody());
+    }
+
+    public function testDelegationIsRejectedWhenAllowCustodyIsOff(): void
+    {
+        $organizer = $this->getUser('admin@example.com');
+        $player = $this->getUser('borrower@example.com');
+
+        $event = $this->createOrganizedEvent($organizer, 'No-Custody Event');
+        // No allowCustody — default false.
+
+        $deck = $this->getFirstActiveDeck($player);
+        $this->registerPlayerWithDeck($event, $player, $deck);
+
+        $this->loginAs('borrower@example.com');
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $token = $this->extractTokenFromForm($crawler, '/toggle-delegation');
+
+        $this->client->request('POST', \sprintf('/event/%d/toggle-delegation', $event->getId()), [
+            '_token' => $token,
+            'deck_id' => (string) $deck->getId(),
+        ]);
+
+        self::assertResponseRedirects();
+        $this->em()->clear();
+
+        $registration = $this->registrationRepository()->findOneByEventAndDeck(
+            $this->eventRepository()->find($event->getId()),
+            $this->deckRepository()->find($deck->getId()),
+        );
+        self::assertNotNull($registration);
+        self::assertFalse($registration->isDelegateToStaff());
+    }
+
+    public function testDelegationIsAcceptedWhenAllowCustodyIsOn(): void
+    {
+        $organizer = $this->getUser('admin@example.com');
+        $player = $this->getUser('borrower@example.com');
+
+        $event = $this->createOrganizedEvent($organizer, 'With-Custody Event');
+        $event->setAllowCustody(true);
+        $deck = $this->getFirstActiveDeck($player);
+        $this->registerPlayerWithDeck($event, $player, $deck);
+        $this->em()->flush();
+
+        $this->loginAs('borrower@example.com');
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $token = $this->extractTokenFromForm($crawler, '/toggle-delegation');
+
+        $this->client->request('POST', \sprintf('/event/%d/toggle-delegation', $event->getId()), [
+            '_token' => $token,
+            'deck_id' => (string) $deck->getId(),
+        ]);
+
+        self::assertResponseRedirects();
+        $this->em()->clear();
+
+        $registration = $this->registrationRepository()->findOneByEventAndDeck(
+            $this->eventRepository()->find($event->getId()),
+            $this->deckRepository()->find($deck->getId()),
+        );
+        self::assertNotNull($registration);
+        self::assertTrue($registration->isDelegateToStaff());
+    }
+
+    public function testTransferInitiateSetsPendingTarget(): void
+    {
+        $organizer = $this->getUser('admin@example.com');
+        $event = $this->createOrganizedEvent($organizer, 'Transfer Initiate Event');
+
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $token = $this->extractTokenFromForm($crawler, '/transfer/initiate');
+
+        $this->client->request('POST', \sprintf('/event/%d/transfer/initiate', $event->getId()), [
+            '_token' => $token,
+            'target' => 'organizer@example.com',
+        ]);
+
+        self::assertResponseRedirects();
+        $this->em()->clear();
+
+        /** @var Event $reloaded */
+        $reloaded = $this->eventRepository()->find($event->getId());
+        self::assertTrue($reloaded->hasPendingTransfer());
+        self::assertSame('organizer@example.com', $reloaded->getPendingTransferTo()?->getEmail());
+    }
+
+    public function testTransferTargetCannotBeOrganizerThemselves(): void
+    {
+        $organizer = $this->getUser('admin@example.com');
+        $event = $this->createOrganizedEvent($organizer, 'Self-Transfer Event');
+
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $token = $this->extractTokenFromForm($crawler, '/transfer/initiate');
+
+        $this->client->request('POST', \sprintf('/event/%d/transfer/initiate', $event->getId()), [
+            '_token' => $token,
+            'target' => 'admin@example.com',
+        ]);
+
+        self::assertResponseRedirects();
+        $this->em()->clear();
+
+        /** @var Event $reloaded */
+        $reloaded = $this->eventRepository()->find($event->getId());
+        self::assertFalse($reloaded->hasPendingTransfer());
+    }
+
+    public function testTransferAcceptSwapsOrganizer(): void
+    {
+        $organizer = $this->getUser('admin@example.com');
+        $target = $this->getUser('organizer@example.com');
+
+        $event = $this->createOrganizedEvent($organizer, 'Transfer Accept Event');
+        $event->requestTransferTo($target);
+        $this->em()->flush();
+
+        $this->loginAs('organizer@example.com');
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $token = $this->extractTokenFromForm($crawler, '/transfer/accept');
+
+        $this->client->request('POST', \sprintf('/event/%d/transfer/accept', $event->getId()), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects();
+        $this->em()->clear();
+
+        /** @var Event $reloaded */
+        $reloaded = $this->eventRepository()->find($event->getId());
+        self::assertSame('organizer@example.com', $reloaded->getOrganizer()->getEmail());
+        self::assertFalse($reloaded->hasPendingTransfer());
+    }
+
+    public function testTransferDeclineKeepsOrganizer(): void
+    {
+        $organizer = $this->getUser('admin@example.com');
+        $target = $this->getUser('organizer@example.com');
+
+        $event = $this->createOrganizedEvent($organizer, 'Transfer Decline Event');
+        $event->requestTransferTo($target);
+        $this->em()->flush();
+
+        $this->loginAs('organizer@example.com');
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $token = $this->extractTokenFromForm($crawler, '/transfer/decline');
+
+        $this->client->request('POST', \sprintf('/event/%d/transfer/decline', $event->getId()), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects();
+        $this->em()->clear();
+
+        /** @var Event $reloaded */
+        $reloaded = $this->eventRepository()->find($event->getId());
+        self::assertSame('admin@example.com', $reloaded->getOrganizer()->getEmail());
+        self::assertFalse($reloaded->hasPendingTransfer());
+    }
+
+    public function testTransferAcceptDeniedForNonTarget(): void
+    {
+        $organizer = $this->getUser('admin@example.com');
+        $target = $this->getUser('organizer@example.com');
+
+        $event = $this->createOrganizedEvent($organizer, 'Transfer Wrong-User Event');
+        $event->requestTransferTo($target);
+        $this->em()->flush();
+
+        // borrower@example.com is neither organizer nor target — access check
+        // runs before CSRF, so a bogus token still produces 403.
+        $this->loginAs('borrower@example.com');
+        $this->client->request('POST', \sprintf('/event/%d/transfer/accept', $event->getId()), [
+            '_token' => 'irrelevant',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testTransferCancelClearsPendingTarget(): void
+    {
+        $organizer = $this->getUser('admin@example.com');
+        $target = $this->getUser('organizer@example.com');
+
+        $event = $this->createOrganizedEvent($organizer, 'Transfer Cancel Event');
+        $event->requestTransferTo($target);
+        $this->em()->flush();
+
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', \sprintf('/event/%d', $event->getId()));
+        $token = $this->extractTokenFromForm($crawler, '/transfer/cancel');
+
+        $this->client->request('POST', \sprintf('/event/%d/transfer/cancel', $event->getId()), [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects();
+        $this->em()->clear();
+
+        /** @var Event $reloaded */
+        $reloaded = $this->eventRepository()->find($event->getId());
+        self::assertFalse($reloaded->hasPendingTransfer());
+    }
+
+    private function extractTokenFromForm(Crawler $crawler, string $actionSuffix): string
+    {
+        $form = $crawler->filter(\sprintf('form[action$="%s"]', $actionSuffix));
+        self::assertGreaterThan(0, $form->count(), 'Expected to find form with action ending in '.$actionSuffix);
+        $token = $form->first()->filter('input[name="_token"]')->attr('value');
+        self::assertNotEmpty($token);
+
+        return $token;
+    }
+
+    private function createOrganizedEvent(User $organizer, string $name): Event
+    {
+        $event = new Event();
+        $event->setName($name);
+        $event->setDate(new \DateTimeImmutable('+10 days'));
+        $event->setTimezone('UTC');
+        $event->setOrganizer($organizer);
+        $event->setRegistrationLink('https://example.com/'.bin2hex(random_bytes(4)));
+        $event->setFormat('Expanded');
+
+        $this->em()->persist($event);
+        $this->em()->flush();
+
+        return $event;
+    }
+
+    private function registerPlayerWithDeck(Event $event, User $player, Deck $deck): void
+    {
+        $engagement = new EventEngagement();
+        $engagement->setEvent($event);
+        $engagement->setUser($player);
+        $engagement->setState(EngagementState::RegisteredPlaying);
+        $this->em()->persist($engagement);
+
+        $registration = new EventDeckRegistration();
+        $registration->setEvent($event);
+        $registration->setDeck($deck);
+        $this->em()->persist($registration);
+
+        $this->em()->flush();
+    }
+
+    private function getFirstActiveDeck(User $owner): Deck
+    {
+        $deck = $this->deckRepository()->findOneBy(['owner' => $owner]);
+        self::assertNotNull($deck, 'Fixture must include at least one deck for '.$owner->getEmail());
+
+        return $deck;
+    }
+
+    private function getUser(string $email): User
+    {
+        /** @var UserRepository $repo */
+        $repo = static::getContainer()->get(UserRepository::class);
+
+        $user = $repo->findOneBy(['email' => $email]);
+        self::assertNotNull($user);
+
+        return $user;
+    }
+
+    private function eventRepository(): EventRepository
+    {
+        /** @var EventRepository $repo */
+        $repo = static::getContainer()->get(EventRepository::class);
+
+        return $repo;
+    }
+
+    private function registrationRepository(): EventDeckRegistrationRepository
+    {
+        /** @var EventDeckRegistrationRepository $repo */
+        $repo = static::getContainer()->get(EventDeckRegistrationRepository::class);
+
+        return $repo;
+    }
+
+    private function deckRepository(): DeckRepository
+    {
+        /** @var DeckRepository $repo */
+        $repo = static::getContainer()->get(DeckRepository::class);
+
+        return $repo;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        return $em;
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1594,6 +1594,126 @@
                 <target>Delegate</target>
                 <note>Button to delegate deck to staff</note>
             </trans-unit>
+            <trans-unit id="app.event.delegate_disabled_reason">
+                <source>app.event.delegate_disabled_reason</source>
+                <target>The organizer hasn't accepted deck custody for this event.</target>
+                <note>Tooltip on the disabled Delegate button when allow_custody is off</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.section_title">
+                <source>app.event.transfer.section_title</source>
+                <target>Hand over organization</target>
+                <note>Card title for the F3.23 organizer-handover section on the event page</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.help">
+                <source>app.event.transfer.help</source>
+                <target>Pick a user to take over as organizer. They'll need to accept on their side before the transfer takes effect.</target>
+                <note>Helper text above the handover form</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.placeholder">
+                <source>app.event.transfer.placeholder</source>
+                <target>Screen name, email, or Pokemon ID</target>
+                <note>Placeholder for the user-picker on the handover form</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.initiate">
+                <source>app.event.transfer.initiate</source>
+                <target>Send handover request</target>
+                <note>Button that initiates the organizer handover request</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.confirm">
+                <source>app.event.transfer.confirm</source>
+                <target>Send a handover request to this user? You'll stay organizer until they accept.</target>
+                <note>Confirmation prompt before initiating an organizer handover</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.pending_body">
+                <source>app.event.transfer.pending_body</source>
+                <target>Waiting for %name% to accept the handover.</target>
+                <note>Status line on the organizer's handover card while a transfer is pending</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.cancel">
+                <source>app.event.transfer.cancel</source>
+                <target>Cancel handover</target>
+                <note>Button that cancels a pending handover request</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.target_banner_title">
+                <source>app.event.transfer.target_banner_title</source>
+                <target>You've been asked to take over as organizer.</target>
+                <note>Banner shown to the target of a pending handover</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.target_banner_body">
+                <source>app.event.transfer.target_banner_body</source>
+                <target>%name% wants you to manage this event. Accept to take over, decline to leave them as organizer.</target>
+                <note>Body of the target banner</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.accept">
+                <source>app.event.transfer.accept</source>
+                <target>Accept handover</target>
+                <note>Button shown to the transfer target</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.decline">
+                <source>app.event.transfer.decline</source>
+                <target>Decline</target>
+                <note>Button shown to the transfer target</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.initiated">
+                <source>app.flash.event.transfer.initiated</source>
+                <target>Handover request sent to %name%.</target>
+                <note>Flash after the organizer initiates a handover</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.cancelled">
+                <source>app.flash.event.transfer.cancelled</source>
+                <target>Handover request cancelled.</target>
+                <note>Flash after the organizer cancels a pending handover</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.accepted">
+                <source>app.flash.event.transfer.accepted</source>
+                <target>You're now the organizer of "%name%".</target>
+                <note>Flash to the new organizer after accepting a handover</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.declined">
+                <source>app.flash.event.transfer.declined</source>
+                <target>Handover declined.</target>
+                <note>Flash after the target declines a handover</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.target_required">
+                <source>app.flash.event.transfer.target_required</source>
+                <target>Pick a user to hand the event over to.</target>
+                <note>Flash when the organizer submits the handover form without picking a target</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.target_invalid">
+                <source>app.flash.event.transfer.target_invalid</source>
+                <target>Couldn't find a user matching that name.</target>
+                <note>Flash when the handover target query doesn't resolve to a different user</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_requested_title">
+                <source>app.notification.event.transfer_requested_title</source>
+                <target>Event handover requested</target>
+                <note>Notification title when the user is asked to take over an event</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_requested_message">
+                <source>app.notification.event.transfer_requested_message</source>
+                <target>%name% wants to hand over "%event%" to you. Open the event to accept or decline.</target>
+                <note>Notification body when the user is asked to take over an event</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_accepted_title">
+                <source>app.notification.event.transfer_accepted_title</source>
+                <target>Event handover accepted</target>
+                <note>Notification title to the previous organizer when the target accepts</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_accepted_message">
+                <source>app.notification.event.transfer_accepted_message</source>
+                <target>%name% accepted the handover of "%event%" and is now the organizer.</target>
+                <note>Notification body to the previous organizer when the target accepts</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_declined_title">
+                <source>app.notification.event.transfer_declined_title</source>
+                <target>Event handover declined</target>
+                <note>Notification title when the target declines a handover</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_declined_message">
+                <source>app.notification.event.transfer_declined_message</source>
+                <target>%name% declined the handover of "%event%". You're still the organizer.</target>
+                <note>Notification body when the target declines a handover</note>
+            </trans-unit>
             <trans-unit id="app.event.deck_selection">
                 <source>app.event.deck_selection</source>
                 <target>Deck Selection</target>
@@ -2337,6 +2457,11 @@
                 <target>Staff delegation disabled for &quot;%name%&quot;.</target>
                 <note>Success flash after disabling staff delegation. %name% = deck name</note>
             </trans-unit>
+            <trans-unit id="app.flash.event.delegation_not_allowed">
+                <source>app.flash.event.delegation_not_allowed</source>
+                <target>The organizer hasn't accepted deck custody for this event.</target>
+                <note>Warning flash when a player tries to delegate while allow_custody is off</note>
+            </trans-unit>
             <trans-unit id="app.flash.event.cannot_revoke_delegation_in_custody">
                 <source>app.flash.event.cannot_revoke_delegation_in_custody</source>
                 <target>Cannot revoke delegation for &quot;%name%&quot; — the deck is currently with staff. Staff must return it first.</target>
@@ -2711,6 +2836,16 @@
                 <source>app.form.label.invitation_only</source>
                 <target>Invitation only</target>
                 <note>Form label for invitation-only checkbox</note>
+            </trans-unit>
+            <trans-unit id="app.form.label.allow_custody">
+                <source>app.form.label.allow_custody</source>
+                <target>Accept deck custody</target>
+                <note>Event form: organizer agrees to take custody of delegated decks</note>
+            </trans-unit>
+            <trans-unit id="app.form.help.allow_custody">
+                <source>app.form.help.allow_custody</source>
+                <target>If enabled, players can delegate their deck to event staff (you or your team) for the day. Leave off if you don't want to be responsible for player decks.</target>
+                <note>Event form: helper text under allow_custody</note>
             </trans-unit>
             <trans-unit id="app.form.label.visibility">
                 <source>app.form.label.visibility</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -1584,6 +1584,126 @@
                 <target>Déléguer</target>
                 <note>Button to delegate deck to staff</note>
             </trans-unit>
+            <trans-unit id="app.event.delegate_disabled_reason">
+                <source>app.event.delegate_disabled_reason</source>
+                <target>L'organisateur n'a pas accepté la garde des decks pour cet événement.</target>
+                <note>Tooltip on the disabled Delegate button when allow_custody is off</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.section_title">
+                <source>app.event.transfer.section_title</source>
+                <target>Transférer l'organisation</target>
+                <note>Card title for the F3.23 organizer-handover section on the event page</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.help">
+                <source>app.event.transfer.help</source>
+                <target>Choisis un utilisateur pour reprendre l'organisation. Il devra accepter de son côté avant que le transfert ne prenne effet.</target>
+                <note>Helper text above the handover form</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.placeholder">
+                <source>app.event.transfer.placeholder</source>
+                <target>Pseudo, e-mail ou Pokemon ID</target>
+                <note>Placeholder for the user-picker on the handover form</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.initiate">
+                <source>app.event.transfer.initiate</source>
+                <target>Envoyer la demande</target>
+                <note>Button that initiates the organizer handover request</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.confirm">
+                <source>app.event.transfer.confirm</source>
+                <target>Envoyer une demande de transfert à cet utilisateur ? Tu restes organisateur tant qu'il n'a pas accepté.</target>
+                <note>Confirmation prompt before initiating an organizer handover</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.pending_body">
+                <source>app.event.transfer.pending_body</source>
+                <target>En attente de la réponse de %name%.</target>
+                <note>Status line on the organizer's handover card while a transfer is pending</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.cancel">
+                <source>app.event.transfer.cancel</source>
+                <target>Annuler le transfert</target>
+                <note>Button that cancels a pending handover request</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.target_banner_title">
+                <source>app.event.transfer.target_banner_title</source>
+                <target>On te propose de reprendre l'organisation.</target>
+                <note>Banner shown to the target of a pending handover</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.target_banner_body">
+                <source>app.event.transfer.target_banner_body</source>
+                <target>%name% souhaite que tu gères cet événement. Accepte pour reprendre, refuse pour le laisser organisateur.</target>
+                <note>Body of the target banner</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.accept">
+                <source>app.event.transfer.accept</source>
+                <target>Accepter</target>
+                <note>Button shown to the transfer target</note>
+            </trans-unit>
+            <trans-unit id="app.event.transfer.decline">
+                <source>app.event.transfer.decline</source>
+                <target>Refuser</target>
+                <note>Button shown to the transfer target</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.initiated">
+                <source>app.flash.event.transfer.initiated</source>
+                <target>Demande de transfert envoyée à %name%.</target>
+                <note>Flash after the organizer initiates a handover</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.cancelled">
+                <source>app.flash.event.transfer.cancelled</source>
+                <target>Demande de transfert annulée.</target>
+                <note>Flash after the organizer cancels a pending handover</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.accepted">
+                <source>app.flash.event.transfer.accepted</source>
+                <target>Tu es désormais l'organisateur(rice) de « %name% ».</target>
+                <note>Flash to the new organizer after accepting a handover</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.declined">
+                <source>app.flash.event.transfer.declined</source>
+                <target>Transfert refusé.</target>
+                <note>Flash after the target declines a handover</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.target_required">
+                <source>app.flash.event.transfer.target_required</source>
+                <target>Choisis un utilisateur à qui transférer l'événement.</target>
+                <note>Flash when the organizer submits the handover form without picking a target</note>
+            </trans-unit>
+            <trans-unit id="app.flash.event.transfer.target_invalid">
+                <source>app.flash.event.transfer.target_invalid</source>
+                <target>Aucun utilisateur trouvé pour ce nom.</target>
+                <note>Flash when the handover target query doesn't resolve to a different user</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_requested_title">
+                <source>app.notification.event.transfer_requested_title</source>
+                <target>Demande de transfert d'événement</target>
+                <note>Notification title when the user is asked to take over an event</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_requested_message">
+                <source>app.notification.event.transfer_requested_message</source>
+                <target>%name% souhaite te transférer l'événement « %event% ». Ouvre l'événement pour accepter ou refuser.</target>
+                <note>Notification body when the user is asked to take over an event</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_accepted_title">
+                <source>app.notification.event.transfer_accepted_title</source>
+                <target>Transfert accepté</target>
+                <note>Notification title to the previous organizer when the target accepts</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_accepted_message">
+                <source>app.notification.event.transfer_accepted_message</source>
+                <target>%name% a accepté le transfert de « %event% » et en est désormais organisateur(rice).</target>
+                <note>Notification body to the previous organizer when the target accepts</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_declined_title">
+                <source>app.notification.event.transfer_declined_title</source>
+                <target>Transfert refusé</target>
+                <note>Notification title when the target declines a handover</note>
+            </trans-unit>
+            <trans-unit id="app.notification.event.transfer_declined_message">
+                <source>app.notification.event.transfer_declined_message</source>
+                <target>%name% a refusé le transfert de « %event% ». Tu restes organisateur(rice).</target>
+                <note>Notification body when the target declines a handover</note>
+            </trans-unit>
             <trans-unit id="app.event.deck_selection">
                 <source>app.event.deck_selection</source>
                 <target>Sélection de deck</target>
@@ -2327,6 +2447,11 @@
                 <target>Délégation au staff désactivée pour « %name% ».</target>
                 <note>Success flash after disabling staff delegation. %name% = deck name</note>
             </trans-unit>
+            <trans-unit id="app.flash.event.delegation_not_allowed">
+                <source>app.flash.event.delegation_not_allowed</source>
+                <target>L'organisateur n'a pas accepté la garde des decks pour cet événement.</target>
+                <note>Warning flash when a player tries to delegate while allow_custody is off</note>
+            </trans-unit>
             <trans-unit id="app.flash.event.cannot_revoke_delegation_in_custody">
                 <source>app.flash.event.cannot_revoke_delegation_in_custody</source>
                 <target>Impossible de révoquer la délégation pour « %name% » — le deck est actuellement entre les mains du staff. Le staff doit d&apos;abord le rendre.</target>
@@ -2696,6 +2821,16 @@
                 <source>app.form.label.invitation_only</source>
                 <target>Sur invitation uniquement</target>
                 <note>Form label for invitation-only checkbox</note>
+            </trans-unit>
+            <trans-unit id="app.form.label.allow_custody">
+                <source>app.form.label.allow_custody</source>
+                <target>Accepter la garde des decks</target>
+                <note>Event form: organizer agrees to take custody of delegated decks</note>
+            </trans-unit>
+            <trans-unit id="app.form.help.allow_custody">
+                <source>app.form.help.allow_custody</source>
+                <target>Si activé, les joueurs peuvent confier leur deck au staff de l'événement (toi ou ton équipe) pour la journée. Laisse désactivé si tu ne veux pas être responsable des decks des joueurs.</target>
+                <note>Event form: helper text under allow_custody</note>
             </trans-unit>
             <trans-unit id="app.form.label.visibility">
                 <source>app.form.label.visibility</source>


### PR DESCRIPTION
## Summary

### Form rendering
- `Visibility` and `Invitation only` were leaking past the submit button on `event/new.html.twig` and `event/edit.html.twig` because they weren't rendered explicitly. Now placed between `tournamentStructure` and `isDecklistMandatory`.

### Allow custody (gates F4.8 delegation)
- New `Event.allowCustody` boolean (default false) + migration `Version20260501170000`. `EventFormType` exposes a checkbox with helper text.
- `EventController::toggleDelegate` refuses to enable delegation when the organizer hasn't accepted custody, and the **Delegate** button on `event/show.html.twig` is `disabled` with an explanatory tooltip in that state.

### Organizer handover (F3.23)
- `Event` gains `pendingTransferTo` + `pendingTransferRequestedAt` (migration `Version20260501180000`) plus `requestTransferTo()` / `clearPendingTransfer()` / `hasPendingTransfer()` helpers.
- Four routes on `EventController` under `/event/{id}/transfer/`:
  - `initiate` and `cancel` for the organizer
  - `accept` and `decline` for the target
  - all protected by a new `denyAccessUnlessTransferTarget` gate
- The target must accept on their side before the organizer is swapped — a declined transfer is a no-op.
- New `NotificationType` cases (`EventTransferRequested` / `EventTransferAccepted` / `EventTransferDeclined`) + matching `EventNotificationService` methods deliver in-app notifications to whichever side needs to act.
- `event/show.html.twig` surfaces a target-side accept/decline banner above the staff card, plus an organizer-side "Hand over organization" card with the user-picker (reusing the staff autocomplete) and a pending-state line with **Cancel**.

### Confirmation UX
- The "Send handover request" button uses the project's inline-confirm pattern (mirror of `deck/versions.html.twig`) instead of `confirm()` — browser modal dialogs were getting blocked.

### Plumbing
- Translations under `app.form.label.allow_custody`, `app.event.transfer.*`, `app.flash.event.transfer.*`, and `app.notification.event.transfer_*` in en + fr.
- `EventCustodyAndHandoverTest` (10 functional cases) covers: custody default off, custody enable via edit, delegation refused / accepted depending on flag, transfer initiate, self-transfer rejected, accept swaps organizer, decline keeps organizer, accept by non-target → 403, cancel clears pending.

## Test plan

- [ ] `make migrations` then visit an event you organize:
  - Visibility and Invitation only render inside the form (not after the submit button).
  - Toggle Accept deck custody on/off via the edit form.
  - With it off, registered players see a disabled **Delegate** button with the tooltip "The organizer hasn't accepted deck custody for this event."
  - With it on, players can delegate as before.
- [ ] On the same event, scroll to "Hand over organization":
  - Pick a user via the autocomplete, click **Send handover request**, confirm via the inline Yes/Cancel pattern.
  - The card now shows "Waiting for X to accept the handover." with a Cancel button.
  - Log in as X, open the event — the "You've been asked to take over" banner appears with **Accept handover** / **Decline**.
  - Accept: organizer swaps to X, banner disappears, in-app notification reaches the previous organizer.
  - Decline (separate run): organizer stays, in-app notification reaches the original organizer.
- [ ] Try `/event/{id}/transfer/accept` as a third user (neither organizer nor target) → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)