### PR TITLE
:sparkles: Feature: empty-channel coming-soon landing page

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -48,9 +48,16 @@ class HomeController extends AbstractController
         HomepageRenderer $homepageRenderer,
     ): Response {
         $locale = $request->getLocale();
+        $channel = $request->attributes->get('_channel');
+
+        // Channel with no feature flags enabled → coming-soon screen, even if
+        // a homepage layout or pages exist. They have nothing meaningful to
+        // link to until at least one feature is turned on.
+        if ($channel instanceof Channel && $this->isChannelEmpty($channel)) {
+            return $this->render('home/empty_channel.html.twig');
+        }
 
         // Use published layout for the current channel if available
-        $channel = $request->attributes->get('_channel');
         $layout = $homepageLayoutRepository->findPublished($channel instanceof Channel ? $channel : null);
         if (null !== $layout) {
             $blocks = $homepageRenderer->resolve($layout, $locale);
@@ -64,11 +71,6 @@ class HomeController extends AbstractController
         // Only redirect to dashboard on channels with decks enabled
         if ($this->getUser() && $channel instanceof Channel && $channel->getEnableDecks()) {
             return $this->redirectToRoute('app_dashboard');
-        }
-
-        // Channel with nothing enabled and no published page → coming-soon screen
-        if ($channel instanceof Channel && $this->isChannelEmpty($channel, $pageRepository, $menuCategoryRepository)) {
-            return $this->render('home/empty_channel.html.twig');
         }
         $welcomePage = $pageRepository->findBySlug('welcome');
         $welcomeHtml = null;
@@ -108,32 +110,19 @@ class HomeController extends AbstractController
     }
 
     /**
-     * A channel is "empty" when none of its feature flags are enabled and it
-     * has no published content (homepage layout already checked by the caller,
-     * plus no published pages assigned to this channel). The coming-soon
-     * landing page is rendered instead of the hardcoded welcome fallback.
+     * A channel is "empty" when none of its feature flags are enabled. The
+     * coming-soon screen short-circuits the homepage even if a HomepageLayout
+     * or Pages exist on the channel — they would have nothing meaningful to
+     * link to until at least one feature is turned on.
      */
-    private function isChannelEmpty(
-        Channel $channel,
-        PageRepository $pageRepository,
-        MenuCategoryRepository $menuCategoryRepository,
-    ): bool {
-        $hasAnyFeature = $channel->getEnableDecks()
-            || $channel->getEnableEvents()
-            || $channel->getEnableBorrows()
-            || $channel->getEnableArchetypes()
-            || $channel->getEnableBannedCards()
-            || $channel->getEnableRegister();
-
-        if ($hasAnyFeature) {
-            return false;
-        }
-
-        if (\count($pageRepository->findPublishedForSitemap($channel)) > 0) {
-            return false;
-        }
-
-        return 0 === \count($menuCategoryRepository->findBy(['channel' => $channel]));
+    private function isChannelEmpty(Channel $channel): bool
+    {
+        return !$channel->getEnableDecks()
+            && !$channel->getEnableEvents()
+            && !$channel->getEnableBorrows()
+            && !$channel->getEnableArchetypes()
+            && !$channel->getEnableBannedCards()
+            && !$channel->getEnableRegister();
     }
 
     /**

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -65,6 +65,11 @@ class HomeController extends AbstractController
         if ($this->getUser() && $channel instanceof Channel && $channel->getEnableDecks()) {
             return $this->redirectToRoute('app_dashboard');
         }
+
+        // Channel with nothing enabled and no published page → coming-soon screen
+        if ($channel instanceof Channel && $this->isChannelEmpty($channel, $pageRepository, $menuCategoryRepository)) {
+            return $this->render('home/empty_channel.html.twig');
+        }
         $welcomePage = $pageRepository->findBySlug('welcome');
         $welcomeHtml = null;
         if (null !== $welcomePage && $welcomePage->isPublished()) {
@@ -100,6 +105,35 @@ class HomeController extends AbstractController
             'newsTotalCount' => $newsTotalCount,
             'locale' => $locale,
         ]);
+    }
+
+    /**
+     * A channel is "empty" when none of its feature flags are enabled and it
+     * has no published content (homepage layout already checked by the caller,
+     * plus no published pages assigned to this channel). The coming-soon
+     * landing page is rendered instead of the hardcoded welcome fallback.
+     */
+    private function isChannelEmpty(
+        Channel $channel,
+        PageRepository $pageRepository,
+        MenuCategoryRepository $menuCategoryRepository,
+    ): bool {
+        $hasAnyFeature = $channel->getEnableDecks()
+            || $channel->getEnableEvents()
+            || $channel->getEnableBorrows()
+            || $channel->getEnableArchetypes()
+            || $channel->getEnableBannedCards()
+            || $channel->getEnableRegister();
+
+        if ($hasAnyFeature) {
+            return false;
+        }
+
+        if (\count($pageRepository->findPublishedForSitemap($channel)) > 0) {
+            return false;
+        }
+
+        return 0 === \count($menuCategoryRepository->findBy(['channel' => $channel]));
     }
 
     /**

--- a/templates/home/empty_channel.html.twig
+++ b/templates/home/empty_channel.html.twig
@@ -13,7 +13,7 @@
 {% block body %}
     <div class="d-flex justify-content-center align-items-center py-5">
         <div class="text-center" style="max-width: 520px;">
-            <img src="/sprites/pokemon/psyduck.png" alt="Psyduck" style="height: 140px;" class="mb-3">
+            <img src="/sprites/pokemon/togepi.png" alt="Togepi" style="height: 140px;" class="mb-3">
             <h1 class="h3 fw-semibold text-primary mb-3">{{ 'app.empty_channel.title'|trans }}</h1>
             <p class="lead text-muted mb-3">{{ 'app.empty_channel.lead'|trans({'%brand%': channel_param('brand_name', 'Expanded Decks')}) }}</p>
             <p class="text-muted mb-4">{{ 'app.empty_channel.message'|trans }}</p>

--- a/templates/home/empty_channel.html.twig
+++ b/templates/home/empty_channel.html.twig
@@ -1,0 +1,22 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #}
+{% extends 'base_error.html.twig' %}
+
+{% block title %}{{ 'app.empty_channel.title'|trans }} — {{ channel_param('brand_name', 'Expanded Decks') }}{% endblock %}
+
+{% block body %}
+    <div class="d-flex justify-content-center align-items-center py-5">
+        <div class="text-center" style="max-width: 520px;">
+            <img src="/sprites/pokemon/psyduck.png" alt="Psyduck" style="height: 140px;" class="mb-3">
+            <h1 class="h3 fw-semibold text-primary mb-3">{{ 'app.empty_channel.title'|trans }}</h1>
+            <p class="lead text-muted mb-3">{{ 'app.empty_channel.lead'|trans({'%brand%': channel_param('brand_name', 'Expanded Decks')}) }}</p>
+            <p class="text-muted mb-4">{{ 'app.empty_channel.message'|trans }}</p>
+        </div>
+    </div>
+{% endblock %}

--- a/tests/Functional/EmptyChannelHomeTest.php
+++ b/tests/Functional/EmptyChannelHomeTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\Entity\Channel;
+use App\Entity\HomepageLayout;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -58,7 +59,7 @@ class EmptyChannelHomeTest extends AbstractFunctionalTest
 
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('h1', 'Coming soon');
-        self::assertSelectorExists('img[alt="Psyduck"]');
+        self::assertSelectorExists('img[alt="Togepi"]');
     }
 
     public function testHomeFallsBackToWelcomePageOnNonEmptyChannel(): void
@@ -79,5 +80,24 @@ class EmptyChannelHomeTest extends AbstractFunctionalTest
 
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('h1', 'Bientôt disponible');
+    }
+
+    public function testEmptyChannelWinsOverPublishedHomepageLayout(): void
+    {
+        $em = $this->getEntityManager();
+        $channel = $this->persistEmptyChannel('empty-with-layout.wip');
+
+        $layout = (new HomepageLayout())
+            ->setChannel($channel)
+            ->setIsPublished(true)
+            ->setBlocks([]);
+        $em->persist($layout);
+        $em->flush();
+
+        $this->client->request('GET', 'https://empty-with-layout.wip/');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'Coming soon');
+        self::assertSelectorExists('img[alt="Togepi"]');
     }
 }

--- a/tests/Functional/EmptyChannelHomeTest.php
+++ b/tests/Functional/EmptyChannelHomeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\Channel;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Renders the coming-soon landing page for channels that have no features
+ * enabled and no published content.
+ */
+class EmptyChannelHomeTest extends AbstractFunctionalTest
+{
+    private function getEntityManager(): EntityManagerInterface
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    private function persistEmptyChannel(string $domain): Channel
+    {
+        $em = $this->getEntityManager();
+        $channel = (new Channel())
+            ->setCode('empty-'.bin2hex(random_bytes(3)))
+            ->setDomain($domain)
+            ->setEnableDecks(false)
+            ->setEnableRegister(false)
+            ->setEnableEvents(false)
+            ->setEnableBorrows(false)
+            ->setEnableArchetypes(false)
+            ->setEnableBannedCards(false)
+            ->setLocales(['en', 'fr'])
+            ->setParameters(['brand_name' => 'Empty Brand']);
+        $em->persist($channel);
+        $em->flush();
+
+        return $channel;
+    }
+
+    public function testHomeShowsComingSoonOnEmptyChannel(): void
+    {
+        $this->persistEmptyChannel('empty.wip');
+
+        $crawler = $this->client->request('GET', 'https://empty.wip/');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'Coming soon');
+        self::assertSelectorExists('img[alt="Psyduck"]');
+    }
+
+    public function testHomeFallsBackToWelcomePageOnNonEmptyChannel(): void
+    {
+        // The default `app` channel has decks/events/etc. enabled — the empty-
+        // channel path must NOT trigger.
+        $this->client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextNotContains('body', 'Coming soon');
+    }
+
+    public function testEmptyChannelRendersEvenInFrench(): void
+    {
+        $this->persistEmptyChannel('empty-fr.wip');
+
+        $crawler = $this->client->request('GET', 'https://empty-fr.wip/fr/');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'Bientôt disponible');
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5255,13 +5255,13 @@
             </trans-unit>
             <trans-unit id="app.empty_channel.lead">
                 <source>app.empty_channel.lead</source>
-                <target>%brand% is still in its Poké Ball.</target>
+                <target>%brand% is still in its Egg.</target>
                 <note>Empty-channel landing page lead — the channel is configured but has nothing to show yet</note>
             </trans-unit>
             <trans-unit id="app.empty_channel.message">
                 <source>app.empty_channel.message</source>
-                <target>Even Psyduck is scratching its head. New decks, events, and stories are on their way — pop back later for the grand opening.</target>
-                <note>Empty-channel landing page message (Pokémon-themed teaser)</note>
+                <target>Togepi is keeping it warm. Something will hatch here soon — pop back later to see what comes out of the shell.</target>
+                <note>Empty-channel landing page message (Pokémon-themed teaser, hatching idea)</note>
             </trans-unit>
             <trans-unit id="app.event.show_private_decks">
                 <source>app.event.show_private_decks</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5248,6 +5248,21 @@
                 <target>Back to home</target>
                 <note>Error page button to return to homepage</note>
             </trans-unit>
+            <trans-unit id="app.empty_channel.title">
+                <source>app.empty_channel.title</source>
+                <target>Coming soon!</target>
+                <note>Empty-channel landing page heading (channel with no features and no published content)</note>
+            </trans-unit>
+            <trans-unit id="app.empty_channel.lead">
+                <source>app.empty_channel.lead</source>
+                <target>%brand% is still in its Poké Ball.</target>
+                <note>Empty-channel landing page lead — the channel is configured but has nothing to show yet</note>
+            </trans-unit>
+            <trans-unit id="app.empty_channel.message">
+                <source>app.empty_channel.message</source>
+                <target>Even Psyduck is scratching its head. New decks, events, and stories are on their way — pop back later for the grand opening.</target>
+                <note>Empty-channel landing page message (Pokémon-themed teaser)</note>
+            </trans-unit>
             <trans-unit id="app.event.show_private_decks">
                 <source>app.event.show_private_decks</source>
                 <target>Show private decks</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -5218,13 +5218,13 @@
             </trans-unit>
             <trans-unit id="app.empty_channel.lead">
                 <source>app.empty_channel.lead</source>
-                <target>%brand% est encore dans sa Poké Ball.</target>
+                <target>%brand% est encore dans son Œuf.</target>
                 <note>Empty-channel landing page lead — the channel is configured but has nothing to show yet</note>
             </trans-unit>
             <trans-unit id="app.empty_channel.message">
                 <source>app.empty_channel.message</source>
-                <target>Même Psykokwak se gratte la tête. De nouveaux decks, événements et nouveautés arrivent — repassez bientôt pour la grande ouverture.</target>
-                <note>Empty-channel landing page message (Pokémon-themed teaser)</note>
+                <target>Togepi le couve bien au chaud. Quelque chose va éclore ici très bientôt — repassez plus tard pour voir ce qui sortira de la coquille.</target>
+                <note>Empty-channel landing page message (Pokémon-themed teaser, hatching idea)</note>
             </trans-unit>
             <trans-unit id="app.event.show_private_decks">
                 <source>app.event.show_private_decks</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -5211,6 +5211,21 @@
                 <target>Retour à l&apos;accueil</target>
                 <note>Error page button to return to homepage</note>
             </trans-unit>
+            <trans-unit id="app.empty_channel.title">
+                <source>app.empty_channel.title</source>
+                <target>Bientôt disponible !</target>
+                <note>Empty-channel landing page heading (channel with no features and no published content)</note>
+            </trans-unit>
+            <trans-unit id="app.empty_channel.lead">
+                <source>app.empty_channel.lead</source>
+                <target>%brand% est encore dans sa Poké Ball.</target>
+                <note>Empty-channel landing page lead — the channel is configured but has nothing to show yet</note>
+            </trans-unit>
+            <trans-unit id="app.empty_channel.message">
+                <source>app.empty_channel.message</source>
+                <target>Même Psykokwak se gratte la tête. De nouveaux decks, événements et nouveautés arrivent — repassez bientôt pour la grande ouverture.</target>
+                <note>Empty-channel landing page message (Pokémon-themed teaser)</note>
+            </trans-unit>
             <trans-unit id="app.event.show_private_decks">
                 <source>app.event.show_private_decks</source>
                 <target>Afficher les decks privés</target>


### PR DESCRIPTION
## Summary
- Channels with **every** `enable_*` flag off now land on a Pokémon-styled coming-soon page instead of the empty welcome fallback (or even an empty published `HomepageLayout`). The page reuses `base_error.html.twig` for a no-services lightweight layout and shows a Togepi sprite with a hatching teaser.
- Detection is `HomeController::isChannelEmpty()` — purely the six `Channel.enable_*` flags. It runs **before** the layout / dashboard-redirect branches, so an admin who configured a layout but hasn't enabled any feature yet still gets the coming-soon screen (the layout would have nothing meaningful to link to anyway).
- Translations `app.empty_channel.{title,lead,message}` in en + fr, hatching metaphor: *"%brand% is still in its Egg. Togepi is keeping it warm. Something will hatch here soon — pop back later to see what comes out of the shell."*
- Four functional tests: empty channel renders the page in en + fr, regular channel still gets its usual fallback, and a regression test pins the empty-channel-wins-over-published-layout precedence.

## Test plan
- [ ] Provision a fresh `Channel` with every `enable_*` off and visit its domain — Togepi screen appears.
- [ ] Toggle one flag on (e.g. `enable_decks`) — the regular fallback / dashboard redirect kicks in.
- [ ] Existing `app` and `content` channels still render their usual homepages.
- [ ] `/en/` and `/fr/` both render the empty-channel page on a brand-new channel.
- [ ] Publish a `HomepageLayout` for an otherwise-empty channel — Togepi screen still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)