### PR TITLE
:bug: Fix: use channel brand_name on error page navbar and footer

### DIFF
--- a/templates/base_error.html.twig
+++ b/templates/base_error.html.twig
@@ -28,7 +28,7 @@
     <body>
         <nav class="navbar navbar-expand-lg navbar-dark navbar-pokemon">
             <div class="container">
-                <a class="navbar-brand fw-bold" href="/">Expanded Decks</a>
+                <a class="navbar-brand fw-bold" href="/">{{ channel_param('brand_name', 'Expanded Decks') }}</a>
             </div>
         </nav>
 
@@ -38,7 +38,7 @@
 
         <footer class="footer-pokemon py-3 mt-auto">
             <div class="container text-center">
-                &copy; {{ "now"|date("Y") }} Expanded Decks
+                &copy; {{ "now"|date("Y") }} {{ channel_param('brand_name', 'Expanded Decks') }}
             </div>
         </footer>
 


### PR DESCRIPTION
## Summary
- \`base_error.html.twig\` (used by every error page and the empty-channel coming-soon screen) was rendering the literal "Expanded Decks" in the navbar brand link and the footer copyright, ignoring the active channel's \`brand_name\` parameter. Both now go through \`channel_param('brand_name', 'Expanded Decks')\`, matching the title block and \`base.html.twig\`.

## Test plan
- [ ] On the content channel, hit a 404 — navbar reads "Expanded Talks", footer copyright reads "Expanded Talks".
- [ ] On the default channel, same paths still read "Expanded Decks".