### PR TITLE
:rocket: Release: 1.9.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,16 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.9.1] — 2026-05-02
+
+Patch release: respect the channel `brand_name` on every error page.
+
+### Bug Fixes
+
+- **Error page brand name** — `base_error.html.twig` (used by every error page and the empty-channel coming-soon screen) was rendering the literal "Expanded Decks" in the navbar brand link and the footer copyright, ignoring the active channel's `brand_name` parameter. Both now go through `channel_param('brand_name', 'Expanded Decks')`, matching the title block and `base.html.twig`. ([#502](https://github.com/jbourdin/expandedDecks/pull/502))
+
+---
+
 ## [1.9.0] — 2026-05-02
 
 Public banned-cards page with admin CRUD (F6.14), empty-channel coming-soon screen, and a denser 9-per-row card grid across deck mosaics and the banned-cards list.

--- a/templates/base_error.html.twig
+++ b/templates/base_error.html.twig
@@ -28,7 +28,7 @@
     <body>
         <nav class="navbar navbar-expand-lg navbar-dark navbar-pokemon">
             <div class="container">
-                <a class="navbar-brand fw-bold" href="/">Expanded Decks</a>
+                <a class="navbar-brand fw-bold" href="/">{{ channel_param('brand_name', 'Expanded Decks') }}</a>
             </div>
         </nav>
 
@@ -38,7 +38,7 @@
 
         <footer class="footer-pokemon py-3 mt-auto">
             <div class="container text-center">
-                &copy; {{ "now"|date("Y") }} Expanded Decks
+                &copy; {{ "now"|date("Y") }} {{ channel_param('brand_name', 'Expanded Decks') }}
             </div>
         </footer>
 


### PR DESCRIPTION
## Summary
- Release **1.9.1** — patch release fixing the error-page brand name to honour the active channel's \`brand_name\` parameter (was hardcoded to "Expanded Decks").

## Test plan
- [ ] CI passes on the release branch.
- [ ] On the content channel, hit a 404 — navbar reads "Expanded Talks", footer copyright reads "Expanded Talks".