### PR TITLE
:sparkles: Feature: swipable banned-cards modal + denser grid

### DIFF
--- a/assets/banned-card-list.ts
+++ b/assets/banned-card-list.ts
@@ -1,0 +1,196 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Banned cards public list — modal interactions.
+ *
+ * Populates the shared #bannedCardModal from the clicked trigger's data
+ * attributes, and adds swipe / arrow-key / chevron navigation between
+ * banned cards (mirrors the deck card modal in `shared/card-hover.ts`).
+ *
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+
+const MODAL_ID = 'bannedCardModal';
+const SWIPE_THRESHOLD = 50;
+
+interface PrintingInfo {
+    setCode: string;
+    cardNumber: string;
+}
+
+const modalElement = document.getElementById(MODAL_ID);
+const triggers = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('.banned-card-trigger'),
+);
+
+if (modalElement && triggers.length > 0) {
+    initBannedCardModal(modalElement, triggers);
+}
+
+function initBannedCardModal(modalElement: HTMLElement, triggers: HTMLButtonElement[]): void {
+    let currentIndex = 0;
+
+    const navigate = (direction: number): void => {
+        if (triggers.length <= 1) return;
+        currentIndex = (currentIndex + direction + triggers.length) % triggers.length;
+        populateModal(triggers[currentIndex]);
+    };
+
+    modalElement.addEventListener('show.bs.modal', (event) => {
+        const trigger = (event as Event & { relatedTarget?: HTMLElement | null }).relatedTarget;
+        if (!(trigger instanceof HTMLButtonElement)) return;
+
+        const index = triggers.indexOf(trigger);
+        if (index === -1) return;
+
+        currentIndex = index;
+        populateModal(trigger);
+    });
+
+    document.getElementById('bannedCardModalPrev')?.addEventListener('click', () => navigate(-1));
+    document.getElementById('bannedCardModalNext')?.addEventListener('click', () => navigate(1));
+
+    const showNavControls = triggers.length > 1;
+    const prevButton = document.getElementById('bannedCardModalPrev');
+    const nextButton = document.getElementById('bannedCardModalNext');
+    if (prevButton) prevButton.style.display = showNavControls ? '' : 'none';
+    if (nextButton) nextButton.style.display = showNavControls ? '' : 'none';
+
+    const modalBody = modalElement.querySelector('.modal-body');
+    if (modalBody) {
+        let touchStartX = 0;
+        let touchStartY = 0;
+
+        modalBody.addEventListener('touchstart', (event) => {
+            const touch = (event as TouchEvent).touches[0];
+            touchStartX = touch.clientX;
+            touchStartY = touch.clientY;
+        }, { passive: true });
+
+        modalBody.addEventListener('touchmove', (event) => {
+            const touch = (event as TouchEvent).touches[0];
+            const deltaX = Math.abs(touch.clientX - touchStartX);
+            const deltaY = Math.abs(touch.clientY - touchStartY);
+            // Block vertical scroll; allow horizontal swipe to drive navigation
+            if (deltaY > deltaX) {
+                event.preventDefault();
+            }
+        }, { passive: false });
+
+        modalBody.addEventListener('touchend', (event) => {
+            const touchEndX = (event as TouchEvent).changedTouches[0].clientX;
+            const deltaX = touchEndX - touchStartX;
+            if (Math.abs(deltaX) > SWIPE_THRESHOLD) {
+                navigate(deltaX < 0 ? 1 : -1);
+            }
+        }, { passive: true });
+    }
+
+    modalElement.addEventListener('keydown', (event) => {
+        const key = (event as KeyboardEvent).key;
+        if (key === 'ArrowLeft') navigate(-1);
+        if (key === 'ArrowRight') navigate(1);
+    });
+}
+
+function populateModal(trigger: HTMLButtonElement): void {
+    const name = trigger.dataset.cardName ?? '';
+    const image = trigger.dataset.cardImage ?? '';
+    const effectiveDate = trigger.dataset.cardEffectiveDate ?? '';
+    const sourceUrl = trigger.dataset.cardSourceUrl ?? '';
+    const explanationHtml = trigger.dataset.cardExplanation ?? '';
+    const printingsJson = trigger.dataset.cardPrintings ?? '[]';
+
+    const titleEl = document.getElementById('bannedCardModalLabel');
+    if (titleEl) titleEl.textContent = name;
+
+    let printings: PrintingInfo[] = [];
+    try {
+        const parsed = JSON.parse(printingsJson) as unknown;
+        if (Array.isArray(parsed)) {
+            printings = parsed.filter((entry): entry is PrintingInfo =>
+                typeof entry === 'object'
+                && entry !== null
+                && 'setCode' in entry
+                && 'cardNumber' in entry,
+            );
+        }
+    } catch {
+        printings = [];
+    }
+
+    const printingsList = document.getElementById('bannedCardModalPrintings');
+    if (printingsList) {
+        printingsList.innerHTML = '';
+        printings.forEach((printing) => {
+            const li = document.createElement('li');
+            li.className = 'mb-1';
+            const code = document.createElement('code');
+            code.textContent = `${printing.setCode} ${printing.cardNumber}`;
+            li.appendChild(code);
+            printingsList.appendChild(li);
+        });
+    }
+
+    const imageEl = document.getElementById('bannedCardModalImage') as HTMLImageElement | null;
+    if (imageEl) {
+        if (image) {
+            imageEl.src = image;
+            imageEl.alt = name;
+            imageEl.hidden = false;
+        } else {
+            imageEl.removeAttribute('src');
+            imageEl.hidden = true;
+        }
+    }
+
+    const effectiveDateLabel = document.getElementById('bannedCardModalEffectiveDateLabel');
+    const effectiveDateEl = document.getElementById('bannedCardModalEffectiveDate');
+    if (effectiveDateLabel && effectiveDateEl) {
+        if (effectiveDate) {
+            effectiveDateEl.textContent = effectiveDate;
+            effectiveDateLabel.hidden = false;
+            effectiveDateEl.hidden = false;
+        } else {
+            effectiveDateLabel.hidden = true;
+            effectiveDateEl.hidden = true;
+        }
+    }
+
+    const sourceLabel = document.getElementById('bannedCardModalSourceLabel');
+    const sourceEl = document.getElementById('bannedCardModalSource') as HTMLAnchorElement | null;
+    if (sourceLabel && sourceEl?.parentElement) {
+        if (sourceUrl) {
+            sourceEl.href = sourceUrl;
+            sourceLabel.hidden = false;
+            sourceEl.parentElement.hidden = false;
+        } else {
+            sourceLabel.hidden = true;
+            sourceEl.parentElement.hidden = true;
+        }
+    }
+
+    const explanationLabel = document.getElementById('bannedCardModalExplanationLabel');
+    const explanationEl = document.getElementById('bannedCardModalExplanation');
+    const noExplanationEl = document.getElementById('bannedCardModalNoExplanation');
+    if (explanationLabel && explanationEl && noExplanationEl) {
+        if (explanationHtml) {
+            explanationEl.innerHTML = explanationHtml;
+            explanationLabel.hidden = false;
+            explanationEl.hidden = false;
+            noExplanationEl.hidden = true;
+        } else {
+            explanationEl.innerHTML = '';
+            explanationLabel.hidden = true;
+            explanationEl.hidden = true;
+            noExplanationEl.hidden = false;
+        }
+    }
+}

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -53,6 +53,10 @@ $table-striped-bg: rgb(0 0 0 / 2%);
 $btn-border-radius: .375rem;
 $font-family-sans-serif: system-ui, -apple-system, "Segoe UI", roboto, "Helvetica Neue", arial, sans-serif;
 
+// Bootstrap ships row-cols-{1..6} by default; bump to 9 so the banned-cards
+// grid can pack more cards per row at lg+.
+$grid-row-columns: 9;
+
 @import "~bootstrap/scss/bootstrap";
 @import "~bootstrap-icons/font/bootstrap-icons.css";
 

--- a/templates/banned_card/list.html.twig
+++ b/templates/banned_card/list.html.twig
@@ -40,7 +40,7 @@
     <p class="text-muted mb-4">{{ 'app.banned_card.public.subtitle'|trans }}</p>
 
     {% if bannedCards|length > 0 %}
-        <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-9 g-3">
+        <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 row-cols-lg-9 g-3">
             {% for card in bannedCards %}
                 {% set highResImageUrl = imageUrls[card.id] ?? null %}
                 {% set imageUrl = highResImageUrl ? highResImageUrl|replace({'/high.webp': '/low.webp'}) : null %}
@@ -82,7 +82,9 @@
                         <h5 class="modal-title" id="bannedCardModalLabel"></h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
-                    <div class="modal-body">
+                    <div class="modal-body position-relative">
+                        <button type="button" id="bannedCardModalPrev" class="btn btn-sm btn-outline-secondary position-absolute start-0 top-50 translate-middle-y ms-1" style="z-index: 2;" aria-label="{{ 'app.banned_card.modal.previous'|trans }}">&lsaquo;</button>
+                        <button type="button" id="bannedCardModalNext" class="btn btn-sm btn-outline-secondary position-absolute end-0 top-50 translate-middle-y me-1" style="z-index: 2;" aria-label="{{ 'app.banned_card.modal.next'|trans }}">&rsaquo;</button>
                         <div class="row g-3">
                             <div class="col-md-5 text-center">
                                 <img id="bannedCardModalImage" src="" alt="" class="img-fluid rounded">
@@ -114,90 +116,5 @@
 
 {% block javascripts %}
     {{ parent() }}
-    <script>
-        (function() {
-            var modalEl = document.getElementById('bannedCardModal');
-            if (!modalEl) {
-                return;
-            }
-            modalEl.addEventListener('show.bs.modal', function (event) {
-                var trigger = event.relatedTarget;
-                if (!trigger) {
-                    return;
-                }
-                var name = trigger.getAttribute('data-card-name') || '';
-                var image = trigger.getAttribute('data-card-image') || '';
-                var effectiveDate = trigger.getAttribute('data-card-effective-date') || '';
-                var sourceUrl = trigger.getAttribute('data-card-source-url') || '';
-                var explanationHtml = trigger.getAttribute('data-card-explanation') || '';
-                var printingsJson = trigger.getAttribute('data-card-printings') || '[]';
-
-                document.getElementById('bannedCardModalLabel').textContent = name;
-
-                var printings = [];
-                try {
-                    printings = JSON.parse(printingsJson);
-                } catch (err) {
-                    printings = [];
-                }
-                var printingsList = document.getElementById('bannedCardModalPrintings');
-                printingsList.innerHTML = '';
-                printings.forEach(function (printing) {
-                    var li = document.createElement('li');
-                    li.className = 'mb-1';
-                    var code = document.createElement('code');
-                    code.textContent = printing.setCode + ' ' + printing.cardNumber;
-                    li.appendChild(code);
-                    printingsList.appendChild(li);
-                });
-
-                var imageEl = document.getElementById('bannedCardModalImage');
-                if (image) {
-                    imageEl.src = image;
-                    imageEl.alt = name;
-                    imageEl.hidden = false;
-                } else {
-                    imageEl.removeAttribute('src');
-                    imageEl.hidden = true;
-                }
-
-                var effectiveDateLabel = document.getElementById('bannedCardModalEffectiveDateLabel');
-                var effectiveDateEl = document.getElementById('bannedCardModalEffectiveDate');
-                if (effectiveDate) {
-                    effectiveDateEl.textContent = effectiveDate;
-                    effectiveDateLabel.hidden = false;
-                    effectiveDateEl.hidden = false;
-                } else {
-                    effectiveDateLabel.hidden = true;
-                    effectiveDateEl.hidden = true;
-                }
-
-                var sourceLabel = document.getElementById('bannedCardModalSourceLabel');
-                var sourceEl = document.getElementById('bannedCardModalSource');
-                if (sourceUrl) {
-                    sourceEl.href = sourceUrl;
-                    sourceLabel.hidden = false;
-                    sourceEl.parentElement.hidden = false;
-                } else {
-                    sourceLabel.hidden = true;
-                    sourceEl.parentElement.hidden = true;
-                }
-
-                var explanationLabel = document.getElementById('bannedCardModalExplanationLabel');
-                var explanationEl = document.getElementById('bannedCardModalExplanation');
-                var noExplanationEl = document.getElementById('bannedCardModalNoExplanation');
-                if (explanationHtml) {
-                    explanationEl.innerHTML = explanationHtml;
-                    explanationLabel.hidden = false;
-                    explanationEl.hidden = false;
-                    noExplanationEl.hidden = true;
-                } else {
-                    explanationEl.innerHTML = '';
-                    explanationLabel.hidden = true;
-                    explanationEl.hidden = true;
-                    noExplanationEl.hidden = false;
-                }
-            });
-        })();
-    </script>
+    {{ encore_entry_script_tags('banned_card_list') }}
 {% endblock %}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5260,7 +5260,7 @@
             </trans-unit>
             <trans-unit id="app.empty_channel.message">
                 <source>app.empty_channel.message</source>
-                <target>Togepi is keeping it warm. Something will hatch here soon — pop back later to see what comes out of the shell.</target>
+                <target>Togepi is keeping is waiting. Something will hatch here soon — pop back later to see what comes out of the shell.</target>
                 <note>Empty-channel landing page message (Pokémon-themed teaser, hatching idea)</note>
             </trans-unit>
             <trans-unit id="app.event.show_private_decks">
@@ -5776,6 +5776,16 @@
                 <source>app.banned_card.modal.no_explanation</source>
                 <target>No explanation provided.</target>
                 <note>F6.14 — banned card modal: no-explanation fallback</note>
+            </trans-unit>
+            <trans-unit id="app.banned_card.modal.previous">
+                <source>app.banned_card.modal.previous</source>
+                <target>Previous banned card</target>
+                <note>F6.14 — banned card modal: previous-card aria-label</note>
+            </trans-unit>
+            <trans-unit id="app.banned_card.modal.next">
+                <source>app.banned_card.modal.next</source>
+                <target>Next banned card</target>
+                <note>F6.14 — banned card modal: next-card aria-label</note>
             </trans-unit>
             <trans-unit id="app.admin.banned_card.list_title">
                 <source>app.admin.banned_card.list_title</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -5223,7 +5223,7 @@
             </trans-unit>
             <trans-unit id="app.empty_channel.message">
                 <source>app.empty_channel.message</source>
-                <target>Togepi le couve bien au chaud. Quelque chose va éclore ici très bientôt — repassez plus tard pour voir ce qui sortira de la coquille.</target>
+                <target>Togepi attend. Quelque chose va éclore ici très bientôt — repassez plus tard pour voir ce qui sortira de la coquille.</target>
                 <note>Empty-channel landing page message (Pokémon-themed teaser, hatching idea)</note>
             </trans-unit>
             <trans-unit id="app.event.show_private_decks">
@@ -5739,6 +5739,16 @@
                 <source>app.banned_card.modal.no_explanation</source>
                 <target>Aucune explication fournie.</target>
                 <note>F6.14 — banned card modal: no-explanation fallback</note>
+            </trans-unit>
+            <trans-unit id="app.banned_card.modal.previous">
+                <source>app.banned_card.modal.previous</source>
+                <target>Carte bannie précédente</target>
+                <note>F6.14 — banned card modal: previous-card aria-label</note>
+            </trans-unit>
+            <trans-unit id="app.banned_card.modal.next">
+                <source>app.banned_card.modal.next</source>
+                <target>Carte bannie suivante</target>
+                <note>F6.14 — banned card modal: next-card aria-label</note>
             </trans-unit>
             <trans-unit id="app.admin.banned_card.list_title">
                 <source>app.admin.banned_card.list_title</source>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ Encore
     .addEntry('event_form', './assets/event-form.tsx')
     .addEntry('event_calendar_copy', './assets/event-calendar-copy.ts')
     .addEntry('banned_card_form', './assets/banned-card-form.tsx')
+    .addEntry('banned_card_list', './assets/banned-card-list.ts')
 
     .splitEntryChunks()
     .enableSingleRuntimeChunk()


### PR DESCRIPTION
## Summary

Two UX fixes on the public **Banned cards** page (F6.14):

- **Grid density.** The previous attempt to widen the grid to 9 per row was a no-op because Bootstrap 5 only ships `row-cols-{1..6}` by default. Bumped `$grid-row-columns: 9` so the class actually exists, and raised density at `sm`/`md` (3→4, 4→6) so smaller-than-`lg` viewports stop rendering gigantic cards.
- **Swipable modal.** Extracted the inline `<script>` into a typed module (`assets/banned-card-list.ts`) and added prev/next chevrons, touch swipe (50 px threshold), and ←/→ keyboard navigation across all banned cards in grid order. Mirrors the deck-card modal pattern in `shared/card-hover.ts`.

## Test plan

- [ ] Visit `/en/banned-cards`; resize the browser:
  - ≥ 992 px → 9 cards per row
  - 768–991 px → 6 cards per row
  - 576–767 px → 4 cards per row
  - < 576 px → 3 cards per row
- [ ] Click any banned card → modal opens with the rich content (image, printings, effective date, source, explanation).
- [ ] In the modal, click the right chevron / press → / swipe left → next card; left chevron / ← / swipe right → previous card. Cycles through all cards in the grid.
- [ ] Modal still closes via × or Esc.