### PR TITLE
:wrench: Chore: bump CLI memory_limit to 512M + fix Togepi typo

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,2 @@
+[PHP]
+memory_limit = 512M

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5260,7 +5260,7 @@
             </trans-unit>
             <trans-unit id="app.empty_channel.message">
                 <source>app.empty_channel.message</source>
-                <target>Togepi is keeping is waiting. Something will hatch here soon — pop back later to see what comes out of the shell.</target>
+                <target>Togepi is waiting. Something will hatch here soon — pop back later to see what comes out of the shell.</target>
                 <note>Empty-channel landing page message (Pokémon-themed teaser, hatching idea)</note>
             </trans-unit>
             <trans-unit id="app.event.show_private_decks">


### PR DESCRIPTION
## Summary
- Add a project-root `php.ini` setting `memory_limit = 512M`. The Symfony CLI auto-loads it for `symfony php` / `symfony console`, fixing OOMs on `cache:clear` (peaks ~150–170 MB during the two-phase compile-and-swap, above the default 128M).
- Fix typo in `app.empty_channel.message`: drop the stray "keeping is" so the English copy mirrors the French ("Togepi attend.") with a clean "Togepi is waiting."

## Test plan
- [ ] `symfony php -r 'echo ini_get("memory_limit");'` reports `512M`
- [ ] `symfony console cache:clear` succeeds without `-d memory_limit=...`
- [ ] `make lint-i18n` passes
- [ ] Empty-channel landing page renders the corrected English copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)