### PR TITLE
:white_check_mark: Tests: backfill banned-card coverage (#498)

### DIFF
--- a/tests/Command/BannedCardsEnrichCommandTest.php
+++ b/tests/Command/BannedCardsEnrichCommandTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Command;
+
+use App\Command\BannedCardsEnrichCommand;
+use App\Entity\BannedCard;
+use App\Entity\BannedCardPrinting;
+use App\Repository\BannedCardPrintingRepository;
+use App\Repository\BannedCardRepository;
+use App\Repository\CardPrintingRepository;
+use App\Service\BannedCardEnricher;
+use App\Service\CardIdentity\CardIdentityResolver;
+use App\Service\Tcgdex\TcgdexApiClient;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * BannedCardEnricher is final readonly so we drive the command with a real
+ * enricher backed by stubbed dependencies — the command's job is to translate
+ * the [linked, unresolved] tuple into console output.
+ *
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+class BannedCardsEnrichCommandTest extends TestCase
+{
+    public function testCommandReportsLinkedAndUnresolvedCounts(): void
+    {
+        $enricher = $this->buildEnricher(
+            printings: [
+                $this->buildBannedPrinting('LOT', '90', 'Card A'),
+                $this->buildBannedPrinting('PHF', '99', 'Card B'),
+            ],
+        );
+
+        $tester = new CommandTester(new BannedCardsEnrichCommand($enricher));
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Enriched 2', $display);
+        // Both printings unresolved (no local hit, no API hit).
+        self::assertStringContainsString('Linked 0 / 2', $display);
+        self::assertStringContainsString('Could not resolve 2', $display);
+        self::assertStringContainsString('Card A (LOT 90)', $display);
+    }
+
+    public function testCommandWithEmptyEnrichmentSucceeds(): void
+    {
+        $enricher = $this->buildEnricher(printings: []);
+
+        $tester = new CommandTester(new BannedCardsEnrichCommand($enricher));
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Enriched 0', $display);
+        self::assertStringContainsString('Linked 0 / 0', $display);
+    }
+
+    public function testCommandAcceptsForceFlag(): void
+    {
+        $enricher = $this->buildEnricher(printings: []);
+
+        $tester = new CommandTester(new BannedCardsEnrichCommand($enricher));
+        $tester->execute(['--force' => true]);
+
+        self::assertSame(0, $tester->getStatusCode());
+    }
+
+    /**
+     * @param list<BannedCardPrinting> $printings
+     */
+    private function buildEnricher(array $printings): BannedCardEnricher
+    {
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn(null);
+        $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+
+        $cardPrintingRepository = $this->createStub(CardPrintingRepository::class);
+        $cardPrintingRepository->method('findFirstBySetCodeAndCardNumber')->willReturn(null);
+
+        $bannedCardPrintingRepository = $this->createStub(BannedCardPrintingRepository::class);
+        $bannedCardPrintingRepository->method('findAllOrderedBySetAndNumber')->willReturn($printings);
+
+        $bannedCardRepository = $this->createStub(BannedCardRepository::class);
+        $bannedCardRepository->method('findOneByCardIdentity')->willReturn(null);
+
+        return new BannedCardEnricher(
+            $apiClient,
+            $identityResolver,
+            $cardPrintingRepository,
+            $bannedCardPrintingRepository,
+            $bannedCardRepository,
+            $this->createStub(EntityManagerInterface::class),
+        );
+    }
+
+    private function buildBannedPrinting(string $setCode, string $cardNumber, string $cardName): BannedCardPrinting
+    {
+        $parent = new BannedCard();
+        $parent->setCardName($cardName);
+
+        $printing = new BannedCardPrinting();
+        $printing->setSetCode($setCode);
+        $printing->setCardNumber($cardNumber);
+        $parent->addPrinting($printing);
+
+        return $printing;
+    }
+}

--- a/tests/Command/BannedCardsSeedCommandTest.php
+++ b/tests/Command/BannedCardsSeedCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Command;
+
+use App\Command\BannedCardsSeedCommand;
+use App\Entity\BannedCard;
+use App\Entity\BannedCardPrinting;
+use App\Repository\BannedCardRepository;
+use App\Service\BannedCardSeedData;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * BannedCardSeedData is final readonly so we exercise it through a real
+ * instance backed by a stubbed repository.
+ *
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+class BannedCardsSeedCommandTest extends TestCase
+{
+    public function testCommandSucceedsAndReportsCounts(): void
+    {
+        $card = new BannedCard();
+        $card->setCardName('Archeops');
+        $printing = new BannedCardPrinting();
+        $printing->setSetCode('NVI');
+        $printing->setCardNumber('67');
+        $card->addPrinting($printing);
+
+        $repository = $this->createStub(BannedCardRepository::class);
+        $repository->method('findActiveOrderedByEffectiveDate')->willReturn([$card]);
+
+        $seedData = new BannedCardSeedData($repository, $this->createStub(EntityManagerInterface::class));
+
+        $tester = new CommandTester(new BannedCardsSeedCommand($seedData));
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('1 card(s) updated', $display);
+        self::assertStringContainsString('0 skipped', $display);
+    }
+
+    public function testCommandHandlesEmptyResult(): void
+    {
+        $repository = $this->createStub(BannedCardRepository::class);
+        $repository->method('findActiveOrderedByEffectiveDate')->willReturn([]);
+
+        $seedData = new BannedCardSeedData($repository, $this->createStub(EntityManagerInterface::class));
+
+        $tester = new CommandTester(new BannedCardsSeedCommand($seedData));
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('0 card(s) updated', $tester->getDisplay());
+    }
+}

--- a/tests/Form/BannedCardFormTypeTest.php
+++ b/tests/Form/BannedCardFormTypeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Form;
+
+use App\Entity\BannedCard;
+use App\Form\BannedCardFormType;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+/**
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+#[AllowMockObjectsWithoutExpectations]
+class BannedCardFormTypeTest extends TypeTestCase
+{
+    public function testFormBindsToBannedCardClass(): void
+    {
+        $form = $this->factory->create(BannedCardFormType::class);
+
+        self::assertSame(BannedCard::class, $form->getConfig()->getDataClass());
+    }
+
+    public function testFormExposesAllExpectedFields(): void
+    {
+        $form = $this->factory->create(BannedCardFormType::class);
+
+        self::assertTrue($form->has('cardName'));
+        self::assertTrue($form->has('effectiveDate'));
+        self::assertTrue($form->has('sourceUrl'));
+        self::assertTrue($form->has('explanation'));
+    }
+
+    public function testSubmittingValidPayloadMapsToEntity(): void
+    {
+        $card = new BannedCard();
+        $form = $this->factory->create(BannedCardFormType::class, $card);
+
+        $form->submit([
+            'cardName' => 'Pikachu',
+            'effectiveDate' => '2024-04-01',
+            'sourceUrl' => 'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list',
+            'explanation' => 'Some rationale',
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertTrue($form->isValid());
+        self::assertSame('Pikachu', $card->getCardName());
+        self::assertInstanceOf(\DateTimeImmutable::class, $card->getEffectiveDate());
+        self::assertSame('2024-04-01', $card->getEffectiveDate()->format('Y-m-d'));
+        self::assertSame('https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list', $card->getSourceUrl());
+        self::assertSame('Some rationale', $card->getExplanation());
+    }
+
+    public function testSubmittingWithEmptyOptionalFieldsClearsThem(): void
+    {
+        $card = new BannedCard();
+        $card->setSourceUrl('https://existing.example.com');
+        $card->setExplanation('previous');
+
+        $form = $this->factory->create(BannedCardFormType::class, $card);
+        $form->submit([
+            'cardName' => 'Pikachu',
+            'effectiveDate' => '',
+            'sourceUrl' => '',
+            'explanation' => '',
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertNull($card->getEffectiveDate());
+        self::assertNull($card->getSourceUrl());
+        self::assertNull($card->getExplanation());
+    }
+}

--- a/tests/Functional/AdminBannedCardControllerTest.php
+++ b/tests/Functional/AdminBannedCardControllerTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\BannedCard;
+use App\Entity\BannedCardPrinting;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F6.5 — Banned card list management
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+class AdminBannedCardControllerTest extends AbstractFunctionalTest
+{
+    public function testListRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/admin/banned-card');
+
+        self::assertResponseRedirects('/login');
+    }
+
+    public function testListRequiresAdminRole(): void
+    {
+        $this->loginAs('borrower@example.com');
+
+        $this->client->request('GET', '/admin/banned-card');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testListAccessibleForAdmin(): void
+    {
+        $this->loginAs('admin@example.com');
+        $this->persistBannedCard('Pikachu', 'LOT', '90');
+
+        $this->client->request('GET', '/admin/banned-card');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testListShowsActiveTabByDefault(): void
+    {
+        $this->loginAs('admin@example.com');
+        $active = $this->persistBannedCard('Active Card', 'LOT', '90');
+        $deleted = $this->persistBannedCard('Deleted Card', 'LOT', '91', deletedAt: new \DateTimeImmutable());
+
+        $this->client->request('GET', '/admin/banned-card');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('body', $active->getCardName());
+        self::assertSelectorTextNotContains('body', $deleted->getCardName());
+    }
+
+    public function testListHistoryViewShowsDeletedCards(): void
+    {
+        $this->loginAs('admin@example.com');
+        $active = $this->persistBannedCard('Active Card', 'LOT', '90');
+        $deleted = $this->persistBannedCard('Deleted Card', 'LOT', '91', deletedAt: new \DateTimeImmutable());
+
+        $this->client->request('GET', '/admin/banned-card?view=history');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('body', $deleted->getCardName());
+        self::assertSelectorTextNotContains('body', $active->getCardName());
+    }
+
+    public function testListIgnoresUnknownView(): void
+    {
+        $this->loginAs('admin@example.com');
+        $this->persistBannedCard('Active Card', 'LOT', '90');
+
+        $this->client->request('GET', '/admin/banned-card?view=garbage');
+
+        // Should fall back to "active" view rendering successfully.
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('body', 'Active Card');
+    }
+
+    public function testEditFormAccessible(): void
+    {
+        $this->loginAs('admin@example.com');
+        $card = $this->persistBannedCard('Pikachu', 'LOT', '90');
+
+        $this->client->request('GET', '/admin/banned-card/'.$card->getId().'/edit');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('form');
+    }
+
+    public function testEditSavesAndRedirectsBackToEdit(): void
+    {
+        $this->loginAs('admin@example.com');
+        $card = $this->persistBannedCard('Pikachu', 'LOT', '90');
+
+        $crawler = $this->client->request('GET', '/admin/banned-card/'.$card->getId().'/edit');
+        $form = $crawler->selectButton('Save')->form();
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/admin/banned-card/'.$card->getId().'/edit');
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+    }
+
+    public function testDeleteSoftDeletesAndRedirects(): void
+    {
+        $this->loginAs('admin@example.com');
+        $card = $this->persistBannedCard('Pikachu', 'LOT', '90');
+
+        $crawler = $this->client->request('GET', '/admin/banned-card/'.$card->getId().'/edit');
+        $token = $crawler->filter('input[name="_token"][value]')->first()->attr('value');
+
+        $this->client->request('POST', '/admin/banned-card/'.$card->getId().'/delete', [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/admin/banned-card');
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+
+        $em = $this->getEntityManager();
+        $em->clear();
+        $reloaded = $em->getRepository(BannedCard::class)->find($card->getId());
+        self::assertInstanceOf(BannedCard::class, $reloaded);
+        self::assertTrue($reloaded->isDeleted());
+    }
+
+    public function testDeleteWithInvalidCsrfShowsErrorAndDoesNotDelete(): void
+    {
+        $this->loginAs('admin@example.com');
+        $card = $this->persistBannedCard('Pikachu', 'LOT', '90');
+
+        $this->client->request('POST', '/admin/banned-card/'.$card->getId().'/delete', [
+            '_token' => 'wrong',
+        ]);
+
+        self::assertResponseRedirects('/admin/banned-card/'.$card->getId().'/edit');
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-danger');
+
+        $em = $this->getEntityManager();
+        $em->clear();
+        $reloaded = $em->getRepository(BannedCard::class)->find($card->getId());
+        self::assertInstanceOf(BannedCard::class, $reloaded);
+        self::assertFalse($reloaded->isDeleted());
+    }
+
+    public function testRestoreClearsDeletedAtAndRedirectsBackToEdit(): void
+    {
+        $this->loginAs('admin@example.com');
+        $card = $this->persistBannedCard('Pikachu', 'LOT', '90', deletedAt: new \DateTimeImmutable());
+
+        $crawler = $this->client->request('GET', '/admin/banned-card/'.$card->getId().'/edit');
+        $token = $crawler->filter('input[name="_token"][value]')->first()->attr('value');
+
+        $this->client->request('POST', '/admin/banned-card/'.$card->getId().'/restore', [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/admin/banned-card/'.$card->getId().'/edit');
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+
+        $em = $this->getEntityManager();
+        $em->clear();
+        $reloaded = $em->getRepository(BannedCard::class)->find($card->getId());
+        self::assertInstanceOf(BannedCard::class, $reloaded);
+        self::assertFalse($reloaded->isDeleted());
+    }
+
+    public function testRestoreWithInvalidCsrfRedirectsToHistoryWithError(): void
+    {
+        $this->loginAs('admin@example.com');
+        $card = $this->persistBannedCard('Pikachu', 'LOT', '90', deletedAt: new \DateTimeImmutable());
+
+        $this->client->request('POST', '/admin/banned-card/'.$card->getId().'/restore', [
+            '_token' => 'wrong',
+        ]);
+
+        self::assertResponseRedirects('/admin/banned-card?view=history');
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-danger');
+
+        $em = $this->getEntityManager();
+        $em->clear();
+        $reloaded = $em->getRepository(BannedCard::class)->find($card->getId());
+        self::assertInstanceOf(BannedCard::class, $reloaded);
+        self::assertTrue($reloaded->isDeleted());
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    private function persistBannedCard(
+        string $cardName,
+        string $setCode,
+        string $cardNumber,
+        ?\DateTimeImmutable $deletedAt = null,
+    ): BannedCard {
+        $em = $this->getEntityManager();
+
+        $card = new BannedCard();
+        $card->setCardName($cardName);
+        $card->setEffectiveDate(new \DateTimeImmutable('2024-04-01'));
+        $card->setSourceUrl('https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list');
+        if ($deletedAt instanceof \DateTimeImmutable) {
+            $card->setDeletedAt($deletedAt);
+        }
+
+        $printing = new BannedCardPrinting();
+        $printing->setSetCode($setCode);
+        $printing->setCardNumber($cardNumber);
+        $card->addPrinting($printing);
+
+        $em->persist($printing);
+        $em->persist($card);
+        $em->flush();
+
+        return $card;
+    }
+}

--- a/tests/Functional/AdminTechnicalControllerTest.php
+++ b/tests/Functional/AdminTechnicalControllerTest.php
@@ -167,4 +167,56 @@ class AdminTechnicalControllerTest extends AbstractFunctionalTest
 
         self::assertResponseRedirects('/admin/technical');
     }
+
+    public function testBannedCardsEnrichRequiresAuthentication(): void
+    {
+        $this->client->request('POST', '/admin/technical/banned-cards-enrich');
+
+        self::assertResponseRedirects('/login');
+    }
+
+    public function testBannedCardsEnrichRejectsInvalidCsrf(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('POST', '/admin/technical/banned-cards-enrich', [
+            '_token' => 'wrong',
+        ]);
+
+        self::assertResponseRedirects('/admin/technical');
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-danger');
+    }
+
+    public function testBannedCardsEnrichSucceedsWithValidCsrf(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/admin/technical');
+        $csrfToken = $this->getCsrfToken('technical-banned-cards-enrich');
+
+        $this->client->request('POST', '/admin/technical/banned-cards-enrich', [
+            '_token' => $csrfToken,
+        ]);
+
+        self::assertResponseRedirects('/admin/technical');
+        $this->client->followRedirect();
+        // No banned cards in fixtures -> "Linked 0 / 0" success flash, no warning.
+        self::assertSelectorExists('.alert-success');
+    }
+
+    public function testBannedCardsEnrichAcceptsForceFlag(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('GET', '/admin/technical');
+        $csrfToken = $this->getCsrfToken('technical-banned-cards-enrich');
+
+        $this->client->request('POST', '/admin/technical/banned-cards-enrich', [
+            '_token' => $csrfToken,
+            'force' => '1',
+        ]);
+
+        self::assertResponseRedirects('/admin/technical');
+    }
 }

--- a/tests/Functional/BannedCardPrintingRepositoryTest.php
+++ b/tests/Functional/BannedCardPrintingRepositoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\BannedCard;
+use App\Entity\BannedCardPrinting;
+use App\Repository\BannedCardPrintingRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+class BannedCardPrintingRepositoryTest extends AbstractFunctionalTest
+{
+    public function testFindOneBySetCodeAndCardNumberReturnsMatchingRow(): void
+    {
+        $this->persistBannedPrinting('LOT', '90');
+        $this->persistBannedPrinting('LOT', '91');
+
+        $found = $this->getRepository()->findOneBySetCodeAndCardNumber('LOT', '90');
+
+        self::assertInstanceOf(BannedCardPrinting::class, $found);
+        self::assertSame('90', $found->getCardNumber());
+    }
+
+    public function testFindOneBySetCodeAndCardNumberReturnsNullWhenMissing(): void
+    {
+        $this->persistBannedPrinting('LOT', '90');
+
+        self::assertNull($this->getRepository()->findOneBySetCodeAndCardNumber('UNKNOWN', '0'));
+    }
+
+    public function testFindAllOrderedBySetAndNumberSortsLexicographically(): void
+    {
+        $this->persistBannedPrinting('LOT', '91');
+        $this->persistBannedPrinting('AOR', '74');
+        $this->persistBannedPrinting('LOT', '90');
+
+        $all = $this->getRepository()->findAllOrderedBySetAndNumber();
+
+        self::assertCount(3, $all);
+        self::assertSame('AOR', $all[0]->getSetCode());
+        self::assertSame('LOT', $all[1]->getSetCode());
+        self::assertSame('90', $all[1]->getCardNumber());
+        self::assertSame('LOT', $all[2]->getSetCode());
+        self::assertSame('91', $all[2]->getCardNumber());
+    }
+
+    public function testFindAllOrderedBySetAndNumberReturnsEmptyWhenNoRows(): void
+    {
+        self::assertSame([], $this->getRepository()->findAllOrderedBySetAndNumber());
+    }
+
+    private function getRepository(): BannedCardPrintingRepository
+    {
+        /** @var BannedCardPrintingRepository $repository */
+        $repository = static::getContainer()->get(BannedCardPrintingRepository::class);
+
+        return $repository;
+    }
+
+    private function persistBannedPrinting(string $setCode, string $cardNumber): BannedCardPrinting
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $parent = new BannedCard();
+        $parent->setCardName(\sprintf('%s %s', $setCode, $cardNumber));
+
+        $printing = new BannedCardPrinting();
+        $printing->setSetCode($setCode);
+        $printing->setCardNumber($cardNumber);
+        $parent->addPrinting($printing);
+
+        $em->persist($parent);
+        $em->persist($printing);
+        $em->flush();
+
+        return $printing;
+    }
+}

--- a/tests/Functional/CardPrintingRepositoryTest.php
+++ b/tests/Functional/CardPrintingRepositoryTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\CardIdentity;
+use App\Entity\CardPrinting;
+use App\Repository\CardPrintingRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Covers findFirstBySetCodeAndCardNumber, used by BannedCardEnricher's
+ * local-first lookup chain.
+ *
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+class CardPrintingRepositoryTest extends AbstractFunctionalTest
+{
+    public function testFindFirstBySetCodeAndCardNumberReturnsLowestRarityExpandedLegal(): void
+    {
+        $identity = $this->persistIdentity('Pikachu');
+
+        // Three printings sharing (LOT, 90):
+        //   - high-rarity Expanded-legal
+        //   - low-rarity Expanded-legal (this is what we expect)
+        //   - low-rarity NOT Expanded-legal (excluded by ORDER BY isExpandedLegal DESC)
+        $this->persistPrinting($identity, 'LOT', '90', 'lot-90-rare', 5, isExpandedLegal: true);
+        $expected = $this->persistPrinting($identity, 'LOT', '90', 'lot-90-common', 1, isExpandedLegal: true);
+        $this->persistPrinting($identity, 'LOT', '90', 'lot-90-illegal', 1, isExpandedLegal: false);
+
+        $found = $this->getRepository()->findFirstBySetCodeAndCardNumber('LOT', '90');
+
+        self::assertInstanceOf(CardPrinting::class, $found);
+        self::assertSame($expected->getId(), $found->getId());
+    }
+
+    public function testFindFirstBySetCodeAndCardNumberReturnsNullWhenMissing(): void
+    {
+        self::assertNull($this->getRepository()->findFirstBySetCodeAndCardNumber('NOPE', '0'));
+    }
+
+    public function testFindFirstBySetCodeAndCardNumberPrefersExpandedLegalOverLowerTier(): void
+    {
+        // Expanded-legal flag wins over rarity tier in the ORDER BY chain.
+        $identity = $this->persistIdentity('Charizard');
+        $expandedLegalRare = $this->persistPrinting($identity, 'LOT', '5', 'lot-5-a', 6, isExpandedLegal: true);
+        $this->persistPrinting($identity, 'LOT', '5', 'lot-5-b', 1, isExpandedLegal: false);
+
+        $found = $this->getRepository()->findFirstBySetCodeAndCardNumber('LOT', '5');
+
+        self::assertInstanceOf(CardPrinting::class, $found);
+        self::assertSame($expandedLegalRare->getId(), $found->getId());
+    }
+
+    private function getRepository(): CardPrintingRepository
+    {
+        /** @var CardPrintingRepository $repository */
+        $repository = static::getContainer()->get(CardPrintingRepository::class);
+
+        return $repository;
+    }
+
+    private function persistIdentity(string $name): CardIdentity
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $identity = new CardIdentity();
+        $identity->setName($name);
+        $identity->setCategory('pokemon');
+        $em->persist($identity);
+        $em->flush();
+
+        return $identity;
+    }
+
+    private function persistPrinting(
+        CardIdentity $identity,
+        string $setCode,
+        string $cardNumber,
+        string $tcgdexId,
+        int $rarityTier,
+        bool $isExpandedLegal,
+    ): CardPrinting {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $printing = new CardPrinting();
+        $printing->setCardIdentity($identity);
+        $printing->setTcgdexId($tcgdexId);
+        $printing->setSetCode($setCode);
+        $printing->setCardNumber($cardNumber);
+        $printing->setRarityTier($rarityTier);
+        $printing->setIsExpandedLegal($isExpandedLegal);
+        $em->persist($printing);
+        $em->flush();
+
+        return $printing;
+    }
+}

--- a/tests/Service/BannedCardEnricherTest.php
+++ b/tests/Service/BannedCardEnricherTest.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service;
+
+use App\Entity\BannedCard;
+use App\Entity\BannedCardPrinting;
+use App\Entity\CardIdentity;
+use App\Entity\CardPrinting;
+use App\Repository\BannedCardPrintingRepository;
+use App\Repository\BannedCardRepository;
+use App\Repository\CardPrintingRepository;
+use App\Service\BannedCardEnricher;
+use App\Service\CardIdentity\CardIdentityResolver;
+use App\Service\Tcgdex\TcgdexApiClient;
+use App\Service\Tcgdex\TcgdexCard as TcgdexCardDto;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+class BannedCardEnricherTest extends TestCase
+{
+    public function testEnrichPrintingNoOpsWhenAlreadyLinked(): void
+    {
+        $existing = $this->createStub(CardPrinting::class);
+
+        $printing = $this->buildBannedPrinting('LOT', '90', $existing);
+
+        $apiClient = $this->createMock(TcgdexApiClient::class);
+        $apiClient->expects(self::never())->method('findCard');
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient);
+
+        self::assertTrue($enricher->enrichPrinting($printing));
+        self::assertSame($existing, $printing->getCardPrinting());
+    }
+
+    public function testEnrichPrintingHitsLocalRepositoryFirst(): void
+    {
+        $local = $this->createStub(CardPrinting::class);
+
+        $repo = $this->createStub(CardPrintingRepository::class);
+        $repo->method('findFirstBySetCodeAndCardNumber')->willReturn($local);
+
+        $apiClient = $this->createMock(TcgdexApiClient::class);
+        $apiClient->expects(self::never())->method('findCard');
+
+        $printing = $this->buildBannedPrinting('LOT', '90', null);
+
+        $enricher = $this->buildEnricher(cardPrintingRepository: $repo, apiClient: $apiClient);
+
+        self::assertTrue($enricher->enrichPrinting($printing));
+        self::assertSame($local, $printing->getCardPrinting());
+    }
+
+    public function testEnrichPrintingFallsBackToTcgdexApi(): void
+    {
+        $tcgdexCard = $this->buildTcgdexCardDto(imageUrl: 'https://images.example.com/foo.png');
+        $resolved = $this->buildResolvedPrintingWithMutableImageUrl(initialImageUrl: null);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn($tcgdexCard);
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+        $identityResolver->method('resolveFromTcgdexCard')->willReturn($resolved);
+
+        $printing = $this->buildBannedPrinting('LOT', '90', null);
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient, identityResolver: $identityResolver);
+
+        self::assertTrue($enricher->enrichPrinting($printing));
+        self::assertSame($resolved, $printing->getCardPrinting());
+        self::assertSame('https://images.example.com/foo.png', $resolved->getImageUrl());
+    }
+
+    public function testEnrichPrintingDoesNotOverwriteExistingImageUrl(): void
+    {
+        $tcgdexCard = $this->buildTcgdexCardDto(imageUrl: 'https://images.example.com/new.png');
+        $resolved = $this->buildResolvedPrintingWithMutableImageUrl(initialImageUrl: 'https://images.example.com/old.png');
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn($tcgdexCard);
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+        $identityResolver->method('resolveFromTcgdexCard')->willReturn($resolved);
+
+        $printing = $this->buildBannedPrinting('LOT', '90', null);
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient, identityResolver: $identityResolver);
+
+        $enricher->enrichPrinting($printing);
+
+        self::assertSame('https://images.example.com/old.png', $resolved->getImageUrl());
+    }
+
+    public function testEnrichPrintingFallsBackToAliasLookup(): void
+    {
+        $tcgdexCard = $this->buildTcgdexCardDto(imageUrl: null);
+        $resolved = $this->createStub(CardPrinting::class);
+
+        $apiClient = $this->createMock(TcgdexApiClient::class);
+        $apiClient->expects(self::once())->method('findCard')->willReturn(null);
+        $apiClient->expects(self::once())->method('findCardByNameInAliasedSet')->willReturn($tcgdexCard);
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+        $identityResolver->method('resolveFromTcgdexCard')->willReturn($resolved);
+
+        $ban = new BannedCard();
+        $ban->setCardName('Some Card');
+        $printing = $this->buildBannedPrinting('LOT', '90', null);
+        $ban->addPrinting($printing);
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient, identityResolver: $identityResolver);
+
+        self::assertTrue($enricher->enrichPrinting($printing));
+        self::assertSame($resolved, $printing->getCardPrinting());
+    }
+
+    public function testEnrichPrintingReturnsFalseWhenAllSourcesMiss(): void
+    {
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn(null);
+        $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+
+        $ban = new BannedCard();
+        $ban->setCardName('Phantom Card');
+        $printing = $this->buildBannedPrinting('UNKNOWN', '0', null);
+        $ban->addPrinting($printing);
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient);
+
+        self::assertFalse($enricher->enrichPrinting($printing));
+        self::assertNull($printing->getCardPrinting());
+    }
+
+    public function testEnrichAllActiveCollectsLinkedAndUnresolvedAndFlushesOnce(): void
+    {
+        $linkedPrinting = $this->createStub(CardPrinting::class);
+        $linkedPrinting->method('getCardIdentity')->willReturn($this->buildIdentity(1, 'Pikachu'));
+
+        $repo = $this->createStub(CardPrintingRepository::class);
+        $repo->method('findFirstBySetCodeAndCardNumber')->willReturnOnConsecutiveCalls($linkedPrinting, null);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn(null);
+        $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+
+        $ban1 = new BannedCard();
+        $ban1->setCardName('Pikachu');
+        $printing1 = $this->buildBannedPrinting('LOT', '90', null);
+        $ban1->addPrinting($printing1);
+
+        $ban2 = new BannedCard();
+        $ban2->setCardName('Lost Card');
+        $printing2 = $this->buildBannedPrinting('PHF', '99', null);
+        $ban2->addPrinting($printing2);
+
+        $bannedPrintingRepo = $this->createStub(BannedCardPrintingRepository::class);
+        $bannedPrintingRepo->method('findAllOrderedBySetAndNumber')->willReturn([$printing1, $printing2]);
+
+        $bannedRepo = $this->createStub(BannedCardRepository::class);
+        $bannedRepo->method('findOneByCardIdentity')->willReturn(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $enricher = $this->buildEnricher(
+            apiClient: $apiClient,
+            cardPrintingRepository: $repo,
+            bannedCardPrintingRepository: $bannedPrintingRepo,
+            bannedCardRepository: $bannedRepo,
+            entityManager: $entityManager,
+        );
+
+        [$linked, $unresolved] = $enricher->enrichAllActive();
+
+        self::assertSame(1, $linked);
+        self::assertSame(['Lost Card (PHF 99)'], $unresolved);
+    }
+
+    public function testEnrichAllActiveForceModeResetsExistingLink(): void
+    {
+        $stale = $this->createStub(CardPrinting::class);
+
+        $printing = $this->buildBannedPrinting('LOT', '90', $stale);
+        $ban = new BannedCard();
+        $ban->setCardName('Pikachu');
+        $ban->addPrinting($printing);
+
+        $bannedPrintingRepo = $this->createStub(BannedCardPrintingRepository::class);
+        $bannedPrintingRepo->method('findAllOrderedBySetAndNumber')->willReturn([$printing]);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn(null);
+        $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+
+        $enricher = $this->buildEnricher(
+            apiClient: $apiClient,
+            bannedCardPrintingRepository: $bannedPrintingRepo,
+        );
+
+        [$linked, $unresolved] = $enricher->enrichAllActive(force: true);
+
+        self::assertSame(0, $linked);
+        self::assertSame(['Pikachu (LOT 90)'], $unresolved);
+        self::assertNull($printing->getCardPrinting(), 'force mode should reset existing link before re-enriching');
+    }
+
+    public function testReparentPromotesCurrentParentWhenNoCanonicalExists(): void
+    {
+        $identity = $this->buildIdentity(42, 'Pikachu');
+
+        $cardPrinting = $this->createStub(CardPrinting::class);
+        $cardPrinting->method('getCardIdentity')->willReturn($identity);
+
+        $local = $cardPrinting; // local hit returns the stub
+        $repo = $this->createStub(CardPrintingRepository::class);
+        $repo->method('findFirstBySetCodeAndCardNumber')->willReturn($local);
+
+        $ban = new BannedCard();
+        $ban->setCardName(''); // placeholder name (not yet enriched)
+        $printing = $this->buildBannedPrinting('LOT', '90', null);
+        $ban->addPrinting($printing);
+
+        $bannedPrintingRepo = $this->createStub(BannedCardPrintingRepository::class);
+        $bannedPrintingRepo->method('findAllOrderedBySetAndNumber')->willReturn([$printing]);
+
+        $bannedRepo = $this->createStub(BannedCardRepository::class);
+        $bannedRepo->method('findOneByCardIdentity')->willReturn(null);
+
+        $enricher = $this->buildEnricher(
+            cardPrintingRepository: $repo,
+            bannedCardPrintingRepository: $bannedPrintingRepo,
+            bannedCardRepository: $bannedRepo,
+        );
+
+        $enricher->enrichAllActive();
+
+        self::assertSame($identity, $ban->getCardIdentity());
+        self::assertSame('Pikachu', $ban->getCardName());
+    }
+
+    public function testReparentInLoopCacheReusesParentForSameIdentity(): void
+    {
+        // Regression for the unique-constraint trap: two consecutive printings
+        // for the same identity must reuse the parent created in the same loop
+        // (DB lookup still empty since flush happens at the end).
+        $identity = $this->buildIdentity(42, 'Pikachu');
+
+        $local = $this->createStub(CardPrinting::class);
+        $local->method('getCardIdentity')->willReturn($identity);
+
+        $repo = $this->createStub(CardPrintingRepository::class);
+        $repo->method('findFirstBySetCodeAndCardNumber')->willReturn($local);
+
+        // Two distinct parents (placeholders); the second one should end up
+        // empty after reparenting and get removed.
+        $parent1 = new BannedCard();
+        $parent1->setCardName('');
+        $printing1 = $this->buildBannedPrinting('LOT', '90', null);
+        $parent1->addPrinting($printing1);
+
+        $parent2 = new BannedCard();
+        $parent2->setCardName('');
+        $printing2 = $this->buildBannedPrinting('LOT', '91', null);
+        $parent2->addPrinting($printing2);
+
+        $bannedPrintingRepo = $this->createStub(BannedCardPrintingRepository::class);
+        $bannedPrintingRepo->method('findAllOrderedBySetAndNumber')->willReturn([$printing1, $printing2]);
+
+        // bannedCardRepository::findOneByCardIdentity returns null both times —
+        // the in-loop cache is what makes the second one find the parent.
+        $bannedRepo = $this->createStub(BannedCardRepository::class);
+        $bannedRepo->method('findOneByCardIdentity')->willReturn(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('remove')->with($parent2);
+        $entityManager->expects(self::once())->method('flush');
+
+        $enricher = $this->buildEnricher(
+            cardPrintingRepository: $repo,
+            bannedCardPrintingRepository: $bannedPrintingRepo,
+            bannedCardRepository: $bannedRepo,
+            entityManager: $entityManager,
+        );
+
+        $enricher->enrichAllActive();
+
+        // Both printings now live under parent1.
+        self::assertSame($parent1, $printing1->getBannedCard());
+        self::assertSame($parent1, $printing2->getBannedCard());
+        self::assertSame('Pikachu', $parent1->getCardName());
+        self::assertCount(2, $parent1->getPrintings());
+        self::assertCount(0, $parent2->getPrintings());
+    }
+
+    public function testReparentFillsEmptyNameOnExistingCanonicalParent(): void
+    {
+        $identity = $this->buildIdentity(42, 'Pikachu');
+
+        $local = $this->createStub(CardPrinting::class);
+        $local->method('getCardIdentity')->willReturn($identity);
+
+        $repo = $this->createStub(CardPrintingRepository::class);
+        $repo->method('findFirstBySetCodeAndCardNumber')->willReturn($local);
+
+        $canonical = new BannedCard();
+        $canonical->setCardName(''); // empty -> should get filled
+        $canonical->setCardIdentity($identity);
+        $printing = $this->buildBannedPrinting('LOT', '90', null);
+        $canonical->addPrinting($printing);
+
+        $bannedPrintingRepo = $this->createStub(BannedCardPrintingRepository::class);
+        $bannedPrintingRepo->method('findAllOrderedBySetAndNumber')->willReturn([$printing]);
+
+        // canonical IS the currentParent -> the second branch fires
+        $bannedRepo = $this->createStub(BannedCardRepository::class);
+        $bannedRepo->method('findOneByCardIdentity')->willReturn($canonical);
+
+        $enricher = $this->buildEnricher(
+            cardPrintingRepository: $repo,
+            bannedCardPrintingRepository: $bannedPrintingRepo,
+            bannedCardRepository: $bannedRepo,
+        );
+
+        $enricher->enrichAllActive();
+
+        self::assertSame('Pikachu', $canonical->getCardName());
+    }
+
+    private function buildEnricher(
+        ?TcgdexApiClient $apiClient = null,
+        ?CardIdentityResolver $identityResolver = null,
+        ?CardPrintingRepository $cardPrintingRepository = null,
+        ?BannedCardPrintingRepository $bannedCardPrintingRepository = null,
+        ?BannedCardRepository $bannedCardRepository = null,
+        ?EntityManagerInterface $entityManager = null,
+    ): BannedCardEnricher {
+        if (null === $apiClient) {
+            $apiClient = $this->createStub(TcgdexApiClient::class);
+            $apiClient->method('findCard')->willReturn(null);
+            $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+        }
+        if (null === $identityResolver) {
+            $identityResolver = $this->createStub(CardIdentityResolver::class);
+        }
+        if (null === $cardPrintingRepository) {
+            $cardPrintingRepository = $this->createStub(CardPrintingRepository::class);
+            $cardPrintingRepository->method('findFirstBySetCodeAndCardNumber')->willReturn(null);
+        }
+        if (null === $bannedCardPrintingRepository) {
+            $bannedCardPrintingRepository = $this->createStub(BannedCardPrintingRepository::class);
+            $bannedCardPrintingRepository->method('findAllOrderedBySetAndNumber')->willReturn([]);
+        }
+        if (null === $bannedCardRepository) {
+            $bannedCardRepository = $this->createStub(BannedCardRepository::class);
+            $bannedCardRepository->method('findOneByCardIdentity')->willReturn(null);
+        }
+        if (null === $entityManager) {
+            $entityManager = $this->createStub(EntityManagerInterface::class);
+        }
+
+        return new BannedCardEnricher(
+            $apiClient,
+            $identityResolver,
+            $cardPrintingRepository,
+            $bannedCardPrintingRepository,
+            $bannedCardRepository,
+            $entityManager,
+        );
+    }
+
+    private function buildBannedPrinting(string $setCode, string $cardNumber, ?CardPrinting $cardPrinting): BannedCardPrinting
+    {
+        $printing = new BannedCardPrinting();
+        $printing->setSetCode($setCode);
+        $printing->setCardNumber($cardNumber);
+        $printing->setCardPrinting($cardPrinting);
+
+        return $printing;
+    }
+
+    private function buildTcgdexCardDto(?string $imageUrl): TcgdexCardDto
+    {
+        return new TcgdexCardDto(
+            id: 'sm-1',
+            name: 'Pikachu',
+            category: 'Pokemon',
+            trainerType: null,
+            imageUrl: $imageUrl,
+            isExpandedLegal: true,
+        );
+    }
+
+    private function buildIdentity(int $id, string $name): CardIdentity
+    {
+        $identity = $this->createStub(CardIdentity::class);
+        $identity->method('getId')->willReturn($id);
+        $identity->method('getName')->willReturn($name);
+
+        return $identity;
+    }
+
+    private function buildResolvedPrintingWithMutableImageUrl(?string $initialImageUrl): CardPrinting
+    {
+        // We need both getImageUrl (initially returns $initialImageUrl) and
+        // setImageUrl (mutates state). A real CardPrinting works for this.
+        $resolved = new CardPrinting();
+        $resolved->setTcgdexId('sm-1');
+        if (null !== $initialImageUrl) {
+            $resolved->setImageUrl($initialImageUrl);
+        }
+
+        return $resolved;
+    }
+}

--- a/tests/Service/BannedCardImageResolverTest.php
+++ b/tests/Service/BannedCardImageResolverTest.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service;
+
+use App\Entity\BannedCard;
+use App\Entity\BannedCardPrinting;
+use App\Entity\CardPrinting;
+use App\Entity\TcgdexCard;
+use App\Entity\TcgdexSerie;
+use App\Entity\TcgdexSet;
+use App\Repository\TcgdexSetRepository;
+use App\Service\BannedCardImageResolver;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+class BannedCardImageResolverTest extends TestCase
+{
+    public function testReturnsNullWhenBanHasNoRepresentativeAndNoPrintings(): void
+    {
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertNull($resolver->resolveForBan(new BannedCard()));
+    }
+
+    public function testRepresentativePrintingDirectImageUrlWins(): void
+    {
+        $printing = $this->buildCardPrinting(imageUrl: 'https://images.example.com/foo.png');
+
+        $ban = new BannedCard();
+        $ban->setRepresentativePrinting($printing);
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.example.com/foo.png',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testRepresentativePrintingDirectImageUrlIsNormalizedForTcgdexCdn(): void
+    {
+        $printing = $this->buildCardPrinting(
+            imageUrl: 'https://assets.tcgdex.net/en/sm/sm3.5/7/high.webp',
+        );
+
+        $ban = new BannedCard();
+        $ban->setRepresentativePrinting($printing);
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        // Dotted set ID gets stripped to match TCGdex CDN paths.
+        self::assertSame(
+            'https://assets.tcgdex.net/en/sm/sm35/7/high.webp',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testRepresentativePrintingFallsThroughToTcgdexCdnFromTcgdexCard(): void
+    {
+        $printing = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: $this->buildTcgdexCard('sm', 'sm11.5', '42'),
+        );
+
+        $ban = new BannedCard();
+        $ban->setRepresentativePrinting($printing);
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/fr/sm/sm115/42/high.webp',
+            $resolver->resolveForBan($ban, 'fr'),
+        );
+    }
+
+    public function testRepresentativePrintingFallsThroughToTcgdexCdnFromParsedTcgdexId(): void
+    {
+        $printing = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: null,
+            tcgdexId: 'swsh4-100',
+        );
+
+        $ban = new BannedCard();
+        $ban->setRepresentativePrinting($printing);
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/en/swsh/swsh4/100/high.webp',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testRepresentativePrintingFallsThroughToPokemontcgioWhenSerieGuessFails(): void
+    {
+        // Set ID prefix doesn't match any guessable serie -> CDN is null,
+        // PokemonTCG.io takes over.
+        $printing = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: null,
+            tcgdexId: 'mc1-3',
+        );
+
+        $ban = new BannedCard();
+        $ban->setRepresentativePrinting($printing);
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.pokemontcg.io/mc1/3_hires.png',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testRepresentativePrintingFinalFallbackUsesUpstreamSetCodeViaTcgdexSet(): void
+    {
+        $printing = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: null,
+            tcgdexId: 'no-dash-here', // dash makes parse succeed; value irrelevant since serie guess fails
+        );
+        // Force every direct lookup to fail so we hit the upstream-set-code branch.
+        $printingNoTcgdex = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: null,
+            tcgdexId: 'nodash', // no dash -> parseTcgdexId returns null -> CDN + pokemontcg.io fail
+        );
+
+        $ban = new BannedCard();
+        $ban->setRepresentativePrinting($printingNoTcgdex);
+        $ban->addPrinting($this->buildBannedPrinting('LOT', '90', $printingNoTcgdex));
+
+        $set = $this->buildTcgdexSet('sm', 'sm11.5');
+        $resolver = new BannedCardImageResolver($this->buildSetRepository($set));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/en/sm/sm115/90/high.webp',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testRepresentativePrintingFailsThenWalksChildPrintingsByRarity(): void
+    {
+        // Representative resolves to nothing.
+        $representative = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: null,
+            tcgdexId: 'nodash',
+        );
+
+        // Two child printings: high-rarity tier first in collection, but the
+        // resolver should pick the lowest rarity tier.
+        $rare = $this->buildCardPrinting(
+            imageUrl: 'https://images.example.com/rare.png',
+            rarityTier: 5,
+        );
+        $common = $this->buildCardPrinting(
+            imageUrl: 'https://images.example.com/common.png',
+            rarityTier: 1,
+        );
+
+        $ban = new BannedCard();
+        $ban->setRepresentativePrinting($representative);
+        $ban->addPrinting($this->buildBannedPrinting('LOT', '90', $rare));
+        $ban->addPrinting($this->buildBannedPrinting('LOT', '91', $common));
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.example.com/common.png',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testChildWithoutCardPrintingFallsBackToUpstreamSetCode(): void
+    {
+        $set = $this->buildTcgdexSet('xy', 'xy7');
+
+        $ban = new BannedCard();
+        // BannedCardPrinting with null cardPrinting -> directly uses setCode lookup.
+        $ban->addPrinting($this->buildBannedPrinting('PHF', '99', null));
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository($set));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/en/xy/xy7/99/high.webp',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testChildWithoutCardPrintingReturnsNullWhenSetCodeUnknown(): void
+    {
+        $ban = new BannedCard();
+        $ban->addPrinting($this->buildBannedPrinting('UNKNOWN', '1', null));
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertNull($resolver->resolveForBan($ban));
+    }
+
+    public function testNullPrintingsSortedAfterPrintingsWithCardPrintingByMaxIntTier(): void
+    {
+        // A child without CardPrinting has rarity tier PHP_INT_MAX in the sort,
+        // so a child with a CardPrinting wins even when its tier is the default 6.
+        $rare = $this->buildCardPrinting(
+            imageUrl: 'https://images.example.com/rare.png',
+            rarityTier: 6,
+        );
+
+        $ban = new BannedCard();
+        $ban->addPrinting($this->buildBannedPrinting('LOT', '90', null));
+        $ban->addPrinting($this->buildBannedPrinting('LOT', '91', $rare));
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.example.com/rare.png',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testNonTcgdexCdnImageUrlIsReturnedUnchanged(): void
+    {
+        // normalizeTcgdexCdnUrl only mutates URLs starting with the TCGdex CDN base.
+        $printing = $this->buildCardPrinting(
+            imageUrl: 'https://images.pokemontcg.io/sm115/42_hires.png',
+        );
+
+        $ban = new BannedCard();
+        $ban->setRepresentativePrinting($printing);
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.pokemontcg.io/sm115/42_hires.png',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testEmptyImageUrlSkipsDirectAndFallsThrough(): void
+    {
+        $printing = $this->buildCardPrinting(
+            imageUrl: '',
+            tcgdexCard: $this->buildTcgdexCard('bw', 'bw1', '10'),
+        );
+
+        $ban = new BannedCard();
+        $ban->setRepresentativePrinting($printing);
+
+        $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/en/bw/bw1/10/high.webp',
+            $resolver->resolveForBan($ban),
+        );
+    }
+
+    public function testGuessSerieIdSupportsAllKnownPrefixes(): void
+    {
+        $cases = [
+            ['sv8-1', 'sv', 'sv8'],
+            ['swsh10-2', 'swsh', 'swsh10'],
+            ['sm9-3', 'sm', 'sm9'],
+            ['xy3-4', 'xy', 'xy3'],
+            ['bw5-6', 'bw', 'bw5'],
+        ];
+
+        foreach ($cases as [$tcgdexId, $expectedSerie, $expectedSet]) {
+            $printing = $this->buildCardPrinting(
+                imageUrl: null,
+                tcgdexCard: null,
+                tcgdexId: $tcgdexId,
+            );
+
+            $ban = new BannedCard();
+            $ban->setRepresentativePrinting($printing);
+
+            $resolver = new BannedCardImageResolver($this->buildSetRepository(null));
+
+            $expected = \sprintf(
+                'https://assets.tcgdex.net/en/%s/%s/%s/high.webp',
+                $expectedSerie,
+                $expectedSet,
+                explode('-', $tcgdexId)[1],
+            );
+
+            self::assertSame($expected, $resolver->resolveForBan($ban), "tcgdexId $tcgdexId");
+        }
+    }
+
+    private function buildSetRepository(?TcgdexSet $set): TcgdexSetRepository
+    {
+        $repository = $this->createStub(TcgdexSetRepository::class);
+        $repository->method('findByPtcgCode')->willReturn($set);
+
+        return $repository;
+    }
+
+    private function buildCardPrinting(
+        ?string $imageUrl = null,
+        ?TcgdexCard $tcgdexCard = null,
+        string $tcgdexId = 'sm1-1',
+        int $rarityTier = 6,
+    ): CardPrinting {
+        $printing = $this->createStub(CardPrinting::class);
+        $printing->method('getImageUrl')->willReturn($imageUrl);
+        $printing->method('getTcgdexCard')->willReturn($tcgdexCard);
+        $printing->method('getTcgdexId')->willReturn($tcgdexId);
+        $printing->method('getRarityTier')->willReturn($rarityTier);
+
+        return $printing;
+    }
+
+    private function buildTcgdexCard(string $serieId, string $setId, string $localId): TcgdexCard
+    {
+        $set = $this->buildTcgdexSet($serieId, $setId);
+
+        $tcgdexCard = $this->createStub(TcgdexCard::class);
+        $tcgdexCard->method('getSet')->willReturn($set);
+        $tcgdexCard->method('getLocalId')->willReturn($localId);
+
+        return $tcgdexCard;
+    }
+
+    private function buildTcgdexSet(string $serieId, string $setId): TcgdexSet
+    {
+        $serie = $this->createStub(TcgdexSerie::class);
+        $serie->method('getId')->willReturn($serieId);
+
+        $set = $this->createStub(TcgdexSet::class);
+        $set->method('getId')->willReturn($setId);
+        $set->method('getSerie')->willReturn($serie);
+
+        return $set;
+    }
+
+    private function buildBannedPrinting(string $setCode, string $cardNumber, ?CardPrinting $cardPrinting): BannedCardPrinting
+    {
+        $printing = new BannedCardPrinting();
+        $printing->setSetCode($setCode);
+        $printing->setCardNumber($cardNumber);
+        $printing->setCardPrinting($cardPrinting);
+
+        return $printing;
+    }
+}

--- a/tests/Service/BannedCardSeedDataTest.php
+++ b/tests/Service/BannedCardSeedDataTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service;
+
+use App\Entity\BannedCard;
+use App\Entity\BannedCardPrinting;
+use App\Repository\BannedCardRepository;
+use App\Service\BannedCardSeedData;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F6.14 — Banned cards public page
+ */
+class BannedCardSeedDataTest extends TestCase
+{
+    public function testApplyToFillsAllNullFieldsForKnownCardName(): void
+    {
+        $card = $this->buildCard('Archeops', [['NVI', '67']]);
+
+        $seedData = new BannedCardSeedData(
+            $this->buildRepository([]),
+            $this->createStub(EntityManagerInterface::class),
+        );
+        $seedData->applyTo($card);
+
+        self::assertNotNull($card->getEffectiveDate());
+        self::assertNotNull($card->getSourceUrl());
+        self::assertNotNull($card->getExplanation());
+        self::assertSame('2017-08-18', $card->getEffectiveDate()->format('Y-m-d'));
+    }
+
+    public function testApplyToPreservesExistingValues(): void
+    {
+        $card = $this->buildCard('Archeops', [['NVI', '67']]);
+        $card->setEffectiveDate(new \DateTimeImmutable('2099-01-01'));
+        $card->setSourceUrl('https://admin.example.com/manual');
+        $card->setExplanation('Manual override');
+
+        $seedData = new BannedCardSeedData(
+            $this->buildRepository([]),
+            $this->createStub(EntityManagerInterface::class),
+        );
+        $seedData->applyTo($card);
+
+        self::assertSame('2099-01-01', $card->getEffectiveDate()->format('Y-m-d'));
+        self::assertSame('https://admin.example.com/manual', $card->getSourceUrl());
+        self::assertSame('Manual override', $card->getExplanation());
+    }
+
+    public function testApplyToNoOpsForUnknownCardName(): void
+    {
+        $card = $this->buildCard('Phantom Card', [['XYZ', '1']]);
+
+        $seedData = new BannedCardSeedData(
+            $this->buildRepository([]),
+            $this->createStub(EntityManagerInterface::class),
+        );
+        $seedData->applyTo($card);
+
+        self::assertNull($card->getEffectiveDate());
+        self::assertNull($card->getSourceUrl());
+        self::assertNull($card->getExplanation());
+    }
+
+    public function testApplyToUsesPerPrintingSeedForUnownLot90(): void
+    {
+        // LOT 90 → DAMAGE Unown (banned 2019-02-15)
+        $card = $this->buildCard('Unown', [['LOT', '90']]);
+
+        $seedData = new BannedCardSeedData(
+            $this->buildRepository([]),
+            $this->createStub(EntityManagerInterface::class),
+        );
+        $seedData->applyTo($card);
+
+        self::assertNotNull($card->getEffectiveDate());
+        self::assertSame('2019-02-15', $card->getEffectiveDate()->format('Y-m-d'));
+        self::assertStringContainsString('DAMAGE', $card->getExplanation() ?? '');
+    }
+
+    public function testApplyToUsesPerPrintingSeedForUnownLot91(): void
+    {
+        // LOT 91 → distinct ban date (Cosmic Eclipse rationale)
+        $card = $this->buildCard('Unown', [['LOT', '91']]);
+
+        $seedData = new BannedCardSeedData(
+            $this->buildRepository([]),
+            $this->createStub(EntityManagerInterface::class),
+        );
+        $seedData->applyTo($card);
+
+        self::assertNotNull($card->getEffectiveDate());
+        self::assertSame('2019-11-15', $card->getEffectiveDate()->format('Y-m-d'));
+    }
+
+    public function testApplyAllReturnsFilledAndSkippedCountsAndFlushesOnce(): void
+    {
+        $known = $this->buildCard('Archeops', [['NVI', '67']]);
+        $unknown = $this->buildCard('Phantom Card', [['XYZ', '1']]);
+        $alreadyFilled = $this->buildCard('Ghetsis', [['PLF', '101']]);
+        $alreadyFilled->setEffectiveDate(new \DateTimeImmutable('2099-01-01'));
+        $alreadyFilled->setSourceUrl('https://admin.example.com');
+        $alreadyFilled->setExplanation('Manual');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $seedData = new BannedCardSeedData(
+            $this->buildRepository([$known, $unknown, $alreadyFilled]),
+            $entityManager,
+        );
+
+        [$filled, $skipped] = $seedData->applyAll();
+
+        self::assertSame(1, $filled);
+        self::assertSame(2, $skipped);
+        self::assertNotNull($known->getEffectiveDate());
+    }
+
+    public function testApplyAllSkipsCardsWithSeedButAllFieldsAlreadyFilled(): void
+    {
+        $card = $this->buildCard('Archeops', [['NVI', '67']]);
+        $card->setEffectiveDate(new \DateTimeImmutable('2017-08-18'));
+        $card->setSourceUrl('https://www.pokemon.com/seed');
+        $card->setExplanation('seed text');
+
+        $seedData = new BannedCardSeedData(
+            $this->buildRepository([$card]),
+            $this->createStub(EntityManagerInterface::class),
+        );
+
+        [$filled, $skipped] = $seedData->applyAll();
+
+        self::assertSame(0, $filled);
+        self::assertSame(1, $skipped);
+    }
+
+    /**
+     * @param list<array{0: string, 1: string}> $printings
+     */
+    private function buildCard(string $name, array $printings): BannedCard
+    {
+        $card = new BannedCard();
+        $card->setCardName($name);
+
+        foreach ($printings as [$setCode, $cardNumber]) {
+            $printing = new BannedCardPrinting();
+            $printing->setSetCode($setCode);
+            $printing->setCardNumber($cardNumber);
+            $card->addPrinting($printing);
+        }
+
+        return $card;
+    }
+
+    /**
+     * @param list<BannedCard> $cards
+     */
+    private function buildRepository(array $cards): BannedCardRepository
+    {
+        $repository = $this->createStub(BannedCardRepository::class);
+        $repository->method('findActiveOrderedByEffectiveDate')->willReturn($cards);
+
+        return $repository;
+    }
+}

--- a/tests/Service/BannedCardsSyncServiceTest.php
+++ b/tests/Service/BannedCardsSyncServiceTest.php
@@ -280,6 +280,109 @@ class BannedCardsSyncServiceTest extends TestCase
         self::assertStringContainsString('Unknown set', $result->warnings[0]);
     }
 
+    public function testSyncSkipsActiveParentsWithEmptyPrintingsDuringSoftDelete(): void
+    {
+        // Parent with an empty printings collection must be skipped during the
+        // soft-delete pass — otherwise findActiveOrderedByEffectiveDate could
+        // return a transient row that gets mistakenly soft-deleted as "all
+        // printings missing".
+        $html = $this->buildHtml(
+            '<ul><li><a href="#">Archeops</a> (<em>Black &amp; White—Noble Victories</em>, 67/101)</li></ul>',
+        );
+
+        $httpClient = new MockHttpClient([new MockResponse($html)]);
+
+        $emptyParent = new BannedCard();
+        $emptyParent->setCardName('Empty Placeholder');
+
+        $printingRepo = $this->createStub(BannedCardPrintingRepository::class);
+        $printingRepo->method('findOneBySetCodeAndCardNumber')->willReturn(null);
+
+        $bannedCardRepo = $this->createStub(BannedCardRepository::class);
+        $bannedCardRepo->method('findActiveOrderedByEffectiveDate')->willReturn([$emptyParent]);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+
+        $service = new BannedCardsSyncService($httpClient, $bannedCardRepo, $printingRepo, $entityManager, $this->buildEnricherStub(), $this->buildSeedStub());
+        $result = $service->sync();
+
+        self::assertTrue($result->success);
+        self::assertSame(0, $result->removed);
+        self::assertNull($emptyParent->getDeletedAt());
+    }
+
+    public function testSyncReusesParentForRepeatedIdentityViaInLoopCache(): void
+    {
+        // Two distinct (setCode, cardNumber) entries that, after enrichment,
+        // resolve to the same CardIdentity. The first creates a placeholder
+        // parent, the second must find that parent through the in-memory cache
+        // (the DB lookup still returns null since flush is deferred). Both
+        // printings end up under the same parent — the duplicate placeholder
+        // is dropped.
+        $html = $this->buildHtml(
+            '<ul><li><a href="#">Unown</a> (<em>Sun &amp; Moon—Lost Thunder</em>, 90/214 and 91/214)</li></ul>',
+        );
+
+        $httpClient = new MockHttpClient([new MockResponse($html)]);
+
+        $identity = $this->createStub(\App\Entity\CardIdentity::class);
+        $identity->method('getId')->willReturn(42);
+        $identity->method('getName')->willReturn('Unown');
+
+        $local = $this->createStub(\App\Entity\CardPrinting::class);
+        $local->method('getCardIdentity')->willReturn($identity);
+
+        $printingRepo = $this->createStub(BannedCardPrintingRepository::class);
+        $printingRepo->method('findOneBySetCodeAndCardNumber')->willReturn(null);
+
+        // findOneByCardIdentity always returns null — the in-loop cache is the
+        // only thing that prevents creating two parents for the same identity.
+        $bannedCardRepo = $this->createStub(BannedCardRepository::class);
+        $bannedCardRepo->method('findActiveOrderedByEffectiveDate')->willReturn([]);
+        $bannedCardRepo->method('findOneByCardIdentity')->willReturn(null);
+
+        $cardPrintingRepository = $this->createStub(\App\Repository\CardPrintingRepository::class);
+        $cardPrintingRepository->method('findFirstBySetCodeAndCardNumber')->willReturn($local);
+
+        $apiClient = $this->createStub(\App\Service\Tcgdex\TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn(null);
+        $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+
+        $identityResolver = $this->createStub(\App\Service\CardIdentity\CardIdentityResolver::class);
+
+        $enricher = new \App\Service\BannedCardEnricher(
+            $apiClient,
+            $identityResolver,
+            $cardPrintingRepository,
+            $printingRepo,
+            $bannedCardRepo,
+            $this->createStub(EntityManagerInterface::class),
+        );
+
+        // Track parent removals — the duplicate placeholder must be dropped.
+        $removed = [];
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('remove')->willReturnCallback(static function (object $entity) use (&$removed): void {
+            $removed[] = $entity;
+        });
+        $entityManager->expects(self::once())->method('flush');
+
+        $service = new BannedCardsSyncService(
+            $httpClient,
+            $bannedCardRepo,
+            $printingRepo,
+            $entityManager,
+            $enricher,
+            $this->buildSeedStub(),
+        );
+
+        $result = $service->sync();
+
+        self::assertTrue($result->success);
+        self::assertSame(2, $result->added);
+        self::assertCount(1, $removed, 'second placeholder parent should be removed after merge');
+    }
+
     public function testSyncParsesCardNameWithEmTagInAltAttribute(): void
     {
         $html = $this->buildHtml(

--- a/tests/Service/BannedCardsSyncServiceTest.php
+++ b/tests/Service/BannedCardsSyncServiceTest.php
@@ -350,7 +350,7 @@ class BannedCardsSyncServiceTest extends TestCase
 
         $identityResolver = $this->createStub(\App\Service\CardIdentity\CardIdentityResolver::class);
 
-        $enricher = new \App\Service\BannedCardEnricher(
+        $enricher = new BannedCardEnricher(
             $apiClient,
             $identityResolver,
             $cardPrintingRepository,


### PR DESCRIPTION
## Summary

Closes #498 — F6.14 banned-card coverage backfill. PR #497 landed at 42.75 % patch coverage (308 lines uncovered) against the project's 87.48 % target. This branch backfills tests across every file flagged in #498's recommended-order list.

### New test files (62 new tests / +1825 lines of test code)

| Test | Tests | Targets |
|---|---|---|
| `BannedCardImageResolverTest` | 14 | All four URL-resolution branches: direct image URL, TCGdex CDN from `TcgdexCard` / parsed `TcgdexId`, PokemonTCG.io, upstream-set-code via `TcgdexSet`. Plus rarity-tier sort, dot-strip normalize, all `guessSerieIdFromSetId` prefixes (`sv`/`swsh`/`sm`/`xy`/`bw` + default null). |
| `BannedCardEnricherTest` | 11 | Already-linked no-op, local hit, TCGdex API hit (with `imageUrl` overwrite protection), alias fallback, all-null path; `--force` mode reset; reparent identity-cache regression for two consecutive printings sharing one identity (placeholder removal verified). |
| `AdminBannedCardControllerTest` | 12 | Auth + role gates, active / history tabs, garbage view fallback, edit save round-trip, soft-delete + restore happy paths, CSRF rejection on delete and restore. |
| `BannedCardSeedDataTest` | 7 | `applyTo` fills nulls / preserves existing / no-ops on unknown name; per-printing seeds for Unown LOT 90 vs LOT 91 (distinct ban dates); `applyAll` counts filled+skipped, flushes once. |
| `BannedCardsEnrichCommandTest` | 3 | linked + unresolved reporting, empty result, `--force` flag. |
| `BannedCardsSeedCommandTest` | 2 | success + empty repo. |
| `BannedCardPrintingRepositoryTest` | 4 | `findOneBySetCodeAndCardNumber` hit/miss, `findAllOrderedBySetAndNumber` lex order + empty. |
| `CardPrintingRepositoryTest` | 3 | `findFirstBySetCodeAndCardNumber` prefers Expanded-legal then lowest rarity tier; null on miss. |
| `BannedCardFormTypeTest` | 4 | Form binds to `BannedCard`, exposes all fields, valid payload round-trip, empty optional fields clear existing values. |

### Existing tests extended

- `BannedCardsSyncServiceTest`: empty-printings skip during the soft-delete pass; in-loop `parentsByIdentityId` cache (regression for the unique-constraint trap when two upstream entries resolve to the same `CardIdentity` in one sync run).
- `AdminTechnicalControllerTest`: 4 cases for `/admin/technical/banned-cards-enrich` (auth, CSRF rejection, happy path, `force` flag).

### Test totals

| | Before | After |
|---|---|---|
| Unit | 1062 | **1101** (+39) |
| Functional | 982 | **1005** (+23) |
| Total | 2044 | **2106** (+62) |

## Test plan
- [x] `make cs-fix` — clean
- [x] `make phpstan` — level 10, no errors across 275 files
- [x] `make test.unit` — 1101 / 1101 / 2700 assertions pass
- [x] `make test.functional` — 1005 / 1005 (1 skipped) / 3785 assertions pass
- [ ] CI green
- [ ] Codecov patch coverage on this PR ≥ 87.48 %

🤖 Generated with [Claude Code](https://claude.com/claude-code)