### PR TITLE
:bug: Fix: render format + latestSet at the right spot in deck forms

### DIFF
--- a/templates/deck/edit.html.twig
+++ b/templates/deck/edit.html.twig
@@ -20,6 +20,7 @@
                 <div class="card-body">
                     {{ form_start(form) }}
                         {{ form_row(form.name) }}
+                        {{ form_row(form.format) }}
                         {{ form_row(form.notes) }}
 
                         {# Archetype — React island #}

--- a/templates/deck/new.html.twig
+++ b/templates/deck/new.html.twig
@@ -20,6 +20,7 @@
                 <div class="card-body">
                     {{ form_start(form) }}
                         {{ form_row(form.name) }}
+                        {{ form_row(form.format) }}
                         {{ form_row(form.notes) }}
 
                         {# Archetype — React island #}
@@ -46,6 +47,8 @@
                             <div id="language-select-root"></div>
                             {{ form_widget(form.languages) }}
                         </div>
+
+                        {{ form_row(form.latestSet) }}
 
                         <div class="mb-3">
                             {{ form_row(form.public) }}


### PR DESCRIPTION
## Summary

Both fields were missing from the explicit `form_row` calls in the deck templates, so `form_end(form)` was emitting them after the submit button (or wherever Symfony's auto-render dropped them):

- **`templates/deck/new.html.twig`** was missing both `format` and `latestSet`.
- **`templates/deck/edit.html.twig`** was missing only `format` — `latestSet` was already in the template.

## Fix

- `format` rendered right after `name` on both forms.
- `latestSet` rendered between the languages React island and the `public` checkbox on the new template (matching the edit template's existing position).

## Test plan
- [x] `make twig-cs-check` — all 103 templates clean
- [x] `make test.functional` filtered to `DeckControllerTest` — 28 / 28 pass (covers both new + edit form render and submit)
- [ ] Visual smoke test: `make start`, click "New deck" and "Edit deck" to confirm both fields appear in the right place

🤖 Generated with [Claude Code](https://claude.com/claude-code)