### PR TITLE
:memo: Docs: drop milestone-based planning guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,9 +229,9 @@ The project uses a [GitHub Project board](https://github.com/users/jbourdin/proj
 5. **Move the issue** to "Ready for Release" when the user confirms the feature works
 6. **Move the issue** to "Done" only when the release containing it is published
 
-When creating new features or backlog items, create a GitHub issue with the feature ID, assign it to the correct milestone, and add it to the project board. **Always set the status to "Backlog"** when adding an issue to the board — items must never be left without a kanban status.
+When creating new features or backlog items, create a GitHub issue with the feature ID and add it to the project board. **Always set the status to "Backlog"** when adding an issue to the board — items must never be left without a kanban status. Do **not** assign milestones — the phase milestones in the repo are not used as a planning structure.
 
-**Board ordering:** items within each column are manually sorted by **milestone** (Phase A first, then B, C, … J, then no milestone) and then by **priority** (high → medium → low) within a milestone. When adding or moving an issue, place it at the correct position using the `updateProjectV2ItemPosition` GraphQL mutation (`afterId: null` for first position, or `afterId: "<previous-item-id>"` to insert after a specific item).
+**Board ordering:** items within each column are sorted manually by user direction. When adding or moving an issue, place it at the correct position using the `updateProjectV2ItemPosition` GraphQL mutation (`afterId: null` for first position, or `afterId: "<previous-item-id>"` to insert after a specific item).
 
 ## Make Commands
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@
 
 ← Back to [Main Documentation](docs.md) | [Feature List](features.md) | [Changelog](changelog.md) | [README](../README.md)
 
-The [GitHub Project board](https://github.com/users/jbourdin/projects/1) is the roadmap for the Expanded Decks project. All issue prioritization, status, and phase assignment live there — this document provides an overview and links to the relevant views.
+The [GitHub Project board](https://github.com/users/jbourdin/projects/1) is the roadmap for the Expanded Decks project. All issue prioritization and status live there — this document provides an overview and links to the relevant views.
 
 ## Project Board
 
@@ -23,60 +23,7 @@ The Kanban board organizes work into seven columns:
 **Views:**
 
 - [Full board](https://github.com/users/jbourdin/projects/1) — Kanban with all columns
-- [All open issues](https://github.com/jbourdin/expandedDecks/issues) — filterable by label and milestone
-
-## Milestones (Phases)
-
-Each milestone corresponds to a thematic phase of work. Issues are assigned to milestones on creation. Phases are grouped into priority tiers reflecting the current product direction: **content and gameplay experience first**, borrowing and operational refinements later.
-
-### Tier 1 — Content, Discovery & Core Scanning
-
-Priority: content attracts users, SEO makes it findable, search helps them navigate, scanning enables event-day workflows.
-
-| Phase | Name                                | Milestone link |
-|-------|-------------------------------------|----------------|
-| 01    | PDF Labels & Camera Scanning        | [Phase 01](https://github.com/jbourdin/expandedDecks/milestone/3) |
-| 02    | Homepage                            | [Phase 02](https://github.com/jbourdin/expandedDecks/milestone/14) |
-| 03    | SEO & Indexability                  | [Phase 03](https://github.com/jbourdin/expandedDecks/milestone/16) |
-| 04    | Search                              | [Phase 04](https://github.com/jbourdin/expandedDecks/milestone/15) |
-
-### Tier 2 — Gameplay & Event Experience
-
-Priority: enrich events, physical label management, and freeplay matchmaking.
-
-| Phase | Name                                | Milestone link |
-|-------|-------------------------------------|----------------|
-| 05    | Zebra Labels & HID Scanning         | [Phase 05](https://github.com/jbourdin/expandedDecks/milestone/4) |
-| 06    | Event Enrichment                    | [Phase 06](https://github.com/jbourdin/expandedDecks/milestone/2) |
-| 07    | Freeplay Matchmaking                | [Phase 07](https://github.com/jbourdin/expandedDecks/milestone/10) |
-
-### Tier 3 — Ecosystem & Integration
-
-Priority: REST API, MCP server, and LLM-friendly endpoints for third-party tools and AI agents.
-
-| Phase | Name                                | Milestone link |
-|-------|-------------------------------------|----------------|
-| 08    | API Access                          | [Phase 08](https://github.com/jbourdin/expandedDecks/milestone/11) |
-
-### Tier 4 — Operational (defer until pain is felt)
-
-Priority: these address edge cases and operational polish. The borrowing process already works well — refine as pain points surface.
-
-| Phase | Name                                | Milestone link |
-|-------|-------------------------------------|----------------|
-| 09    | UX Polish & Overdue Tracking        | [Phase 09](https://github.com/jbourdin/expandedDecks/milestone/1) |
-| 10    | Operational Excellence              | [Phase 10](https://github.com/jbourdin/expandedDecks/milestone/7) |
-| 11    | Auth Hardening & Delegation         | [Phase 11](https://github.com/jbourdin/expandedDecks/milestone/5) |
-| 12    | Multi-Organizer Events              | [Phase 12](https://github.com/jbourdin/expandedDecks/milestone/9) |
-| 13    | Lost & Found                        | [Phase 13](https://github.com/jbourdin/expandedDecks/milestone/8) |
-| 14    | Play Pokemon QR Integration         | [Phase 14](https://github.com/jbourdin/expandedDecks/milestone/6) |
-
-### Completed
-
-| Phase | Name                                | Milestone link |
-|-------|-------------------------------------|----------------|
-| 0     | Soft Deletion                       | [Phase 0](https://github.com/jbourdin/expandedDecks/milestone/12) |
-| —     | Content Editing Experience          | [Phase L](https://github.com/jbourdin/expandedDecks/milestone/13) |
+- [All open issues](https://github.com/jbourdin/expandedDecks/issues) — filterable by label
 
 ## Feature Catalogue
 


### PR DESCRIPTION
## Summary

- Remove milestone instructions from `CLAUDE.md` (issue creation + board ordering). Add an explicit "do not assign milestones" line.
- Drop the Milestones (Phases) section from `docs/roadmap.md` (4 tier tables + completed list). The kanban board remains the planning surface.

Phase milestones still exist in the repo for now (not closed) but are no longer referenced in the docs and won't be assigned on new issues.

## Test plan

- [ ] Skim `CLAUDE.md` Project Tracking section — reads naturally without milestone references.
- [ ] Skim `docs/roadmap.md` — flows from board overview directly to feature catalogue without orphan links.
- [ ] No remaining "milestone" references in `CLAUDE.md` / `docs/roadmap.md` / `docs/standards/version_control.md` / `docs/standards/release_process.md` (only the explicit "do not assign milestones" line in CLAUDE.md is intentional).