### PR TITLE
:sparkles: feat: case-sensitive archetype playstyle tags

### DIFF
--- a/assets/components/PlaystyleTagSelect.tsx
+++ b/assets/components/PlaystyleTagSelect.tsx
@@ -22,14 +22,10 @@ interface PlaystyleTagSelectProps {
 }
 
 /**
- * Normalize a tag: only alphanumeric and spaces, title case.
+ * Normalize a tag: only alphanumeric and spaces, casing preserved verbatim.
  */
 function normalizeTag(tag: string): string {
-    const cleaned = tag.replace(/[^a-zA-Z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
-
-    return cleaned.replace(/\w\S*/g, (word) =>
-        word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
-    );
+    return tag.replace(/[^a-zA-Z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
 }
 
 export default function PlaystyleTagSelect({ existingTags, initialValues = [], hiddenInputName, placeholder }: PlaystyleTagSelectProps) {

--- a/src/Controller/AdminArchetypeController.php
+++ b/src/Controller/AdminArchetypeController.php
@@ -857,16 +857,15 @@ class AdminArchetypeController extends AbstractAppController
     }
 
     /**
-     * Normalize a tag: only alphanumeric and spaces, title case.
+     * Normalize a tag: only alphanumeric and spaces, casing preserved verbatim.
      *
      * @see docs/features.md F2.15 — Archetype playstyle tags
      */
     private static function normalizeTag(string $tag): string
     {
         $cleaned = preg_replace('/[^a-zA-Z0-9 ]/', '', $tag) ?? '';
-        $cleaned = trim(preg_replace('/\s+/', ' ', $cleaned) ?? '');
 
-        return mb_convert_case($cleaned, \MB_CASE_TITLE);
+        return trim(preg_replace('/\s+/', ' ', $cleaned) ?? '');
     }
 
     /**
@@ -905,19 +904,29 @@ class AdminArchetypeController extends AbstractAppController
     }
 
     /**
-     * Collect all unique playstyle tags from existing archetypes.
+     * Collect playstyle tag suggestions from existing archetypes.
+     *
+     * Folds casing variants together: for each case-insensitive key, the most-frequent casing
+     * wins (insertion-order tie-break) so editors see one canonical entry in the autocomplete.
      *
      * @return list<string>
      */
     private function collectExistingTags(ArchetypeRepository $archetypeRepository): array
     {
-        $allTags = [];
+        /** @var array<string, array<string, int>> $buckets */
+        $buckets = [];
         foreach ($archetypeRepository->findBy(['deletedAt' => null]) as $archetype) {
             foreach ($archetype->getPlaystyleTags() as $tag) {
-                $allTags[$tag] = true;
+                $key = mb_strtolower($tag);
+                $buckets[$key][$tag] = ($buckets[$key][$tag] ?? 0) + 1;
             }
         }
-        $tags = array_keys($allTags);
+
+        $tags = [];
+        foreach ($buckets as $casings) {
+            arsort($casings);
+            $tags[] = (string) array_key_first($casings);
+        }
         sort($tags);
 
         return $tags;

--- a/tests/Functional/AdminArchetypeControllerTest.php
+++ b/tests/Functional/AdminArchetypeControllerTest.php
@@ -229,8 +229,8 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
         self::assertResponseRedirects();
 
         $refreshed = $this->getArchetype('Lugia Archeops');
-        self::assertContains('Aggressive', $refreshed->getPlaystyleTags());
-        self::assertContains('Control', $refreshed->getPlaystyleTags());
+        self::assertContains('aggressive', $refreshed->getPlaystyleTags());
+        self::assertContains('control', $refreshed->getPlaystyleTags());
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Drop the forced title-case normalization on archetype playstyle tags in both the PHP backend (`AdminArchetypeController::normalizeTag`) and the React `PlaystyleTagSelect` component, so editors keep whatever casing they type.
- Fold case variants in the autocomplete suggestion list (`collectExistingTags`) — most-frequent casing per case-folded key wins, ties go to first-seen — so editors don't see noisy duplicates while existing title-cased rows coexist with new mixed-case input.
- Update `testEditPlaystyleTags` to assert verbatim casing round-trip.

No DB migration: MySQL JSON columns are stored using `utf8mb4_bin` regardless of table collation, so storage and the existing `LIKE`-based tag filter are already case-sensitive. Existing rows (uniformly title-cased) are intentionally left as-is — editors can re-cast over time.

Behavioural consequences:
- Within an archetype, `Control` and `control` are now two distinct tags (strict byte-comparison).
- The URL filter `?tags[]=Aggro` and `?tags[]=aggro` will now return different results.

## Test plan

- [ ] Admin: open an archetype, add `aggro`, `AGGRO`, `Aggro` → save → reload. All three persist as separate tags (used to collapse to `Aggro`).
- [ ] Admin: type a lowercase tag, save, reload → comes back lowercase.
- [ ] Public: visit `/en/archetypes/<slug>` → badge text matches what was typed exactly.
- [ ] Public: filter the archetype list with `?tags[]=aggro` vs `?tags[]=Aggro` → results differ.
- [ ] Admin autocomplete: with both `Aggro` and `aggro` somewhere in the dataset, only one (the most frequent) appears in the suggestion list.