### PR TITLE
:sparkles: feat: hide login button on Expanded Talks navbar

### DIFF
--- a/templates/_partials/navbar_unauthenticated.html.twig
+++ b/templates/_partials/navbar_unauthenticated.html.twig
@@ -1,0 +1,22 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #
+ # Default unauthenticated navbar items (login + optional register).
+ # Channels with their own theme can override this partial under
+ # templates/themes/<theme>/_partials/navbar_unauthenticated.html.twig
+ # (see F18.28 — Per-channel theme system).
+ #}
+{% set channel = current_channel() %}
+<li class="nav-item">
+    <a class="nav-link" href="{{ path('app_login', {_target_path: app.request.pathInfo}) }}">{{ 'app.nav.login'|trans }}</a>
+</li>
+{% if channel.enableRegister %}
+    <li class="nav-item">
+        <a class="nav-link" href="{{ path('app_register', {_target_path: app.request.pathInfo}) }}">{{ 'app.nav.register'|trans }}</a>
+    </li>
+{% endif %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -214,14 +214,7 @@
                                 </li>
                             {% endif %}
                             {{ include('_partials/navbar_search.html.twig') }}
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_login', {_target_path: app.request.pathInfo}) }}">{{ 'app.nav.login'|trans }}</a>
-                            </li>
-                            {% if channel.enableRegister %}
-                                <li class="nav-item">
-                                    <a class="nav-link" href="{{ path('app_register', {_target_path: app.request.pathInfo}) }}">{{ 'app.nav.register'|trans }}</a>
-                                </li>
-                            {% endif %}
+                            {{ include('_partials/navbar_unauthenticated.html.twig') }}
                         {% endif %}
                         {% if current_channel().locales|length > 1 %}
                             {% set currentLocale = app.request.locale %}

--- a/templates/themes/expandedtalks/_partials/navbar_unauthenticated.html.twig
+++ b/templates/themes/expandedtalks/_partials/navbar_unauthenticated.html.twig
@@ -1,0 +1,11 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #
+ # Expanded Talks is a content-only channel — no user-facing auth UI in the navbar.
+ # Overrides templates/_partials/navbar_unauthenticated.html.twig (F18.28).
+ #}


### PR DESCRIPTION
## Summary

- Extract the unauthenticated navbar items (login + conditional register) from `base.html.twig` into a new `_partials/navbar_unauthenticated.html.twig`, so themes can override the include via the F18.28 theme path mechanism.
- Add an empty override at `templates/themes/expandedtalks/_partials/navbar_unauthenticated.html.twig` — the Expanded Talks channel is content-only (decks/events/registration already disabled) and now renders no user-facing auth UI in its navbar.
- Default channels keep the exact same login + register markup as before.

This uses the existing channel theme architecture instead of adding a new `Channel::enableLogin` flag — no entity change, no migration, no admin form binding. Future themes can ship their own variant of the unauthenticated nav (e.g. a custom CTA in place of login) by dropping a partial into their theme directory.

## Test plan

- [ ] On the default channel (e.g. `expandeddecks.wip`), unauthenticated users still see the login link and (where `enableRegister`) the register link in the navbar.
- [ ] On `expandedtalks.wip`, unauthenticated users see neither login nor register in the navbar.
- [ ] Authenticated user navbar (other channels) is unchanged.
- [ ] Direct navigation to `/login` still works (only the navbar entry is removed, not the route).