### PR TITLE
:rocket: Release: 1.11.0

### DIFF
--- a/assets/components/PlaystyleTagSelect.tsx
+++ b/assets/components/PlaystyleTagSelect.tsx
@@ -22,14 +22,10 @@ interface PlaystyleTagSelectProps {
 }
 
 /**
- * Normalize a tag: only alphanumeric and spaces, title case.
+ * Normalize a tag: only alphanumeric and spaces, casing preserved verbatim.
  */
 function normalizeTag(tag: string): string {
-    const cleaned = tag.replace(/[^a-zA-Z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
-
-    return cleaned.replace(/\w\S*/g, (word) =>
-        word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
-    );
+    return tag.replace(/[^a-zA-Z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
 }
 
 export default function PlaystyleTagSelect({ existingTags, initialValues = [], hiddenInputName, placeholder }: PlaystyleTagSelectProps) {

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -80,6 +80,14 @@ $grid-row-columns: 9;
     --ed-gold: #ffd95e;
     --ed-red: #ff7080;
     --ed-bg: #121826;
+
+    // Dark-only surface tokens — used by the Bootstrap-component overrides
+    // and themed surfaces below.
+    --ed-surface-elevated: #1a2238;
+    --ed-border-faint: rgb(255 255 255 / 12%);
+    --ed-overlay-faint: rgb(255 255 255 / 4%);
+    --ed-overlay-soft: rgb(255 255 255 / 6%);
+    --ed-overlay-medium: rgb(255 255 255 / 8%);
 }
 
 // --- Layout ---
@@ -95,7 +103,7 @@ body {
     // Quincunx (staggered) Fairy energy texture on the body background.
     // Two offset layers of the same tile create the honeycomb-like pattern.
     // Cards and panels sit on top with solid white, making them pop.
-    background-color: $ed-bg;
+    background-color: var(--ed-bg);
     background-image: url('../images/bg_fairy_quincunx.png');
     background-size: 96px 80px;
     background-repeat: repeat;
@@ -752,7 +760,6 @@ footer {
 
 [data-bs-theme="dark"] {
     body {
-        background-color: var(--ed-bg);
         background-image: none;
     }
 
@@ -763,51 +770,51 @@ footer {
     // restore Bootstrap's native dark mode for those surfaces we re-declare
     // the CSS custom properties on the component selectors under dark mode.
     .card {
-        --bs-card-bg: #1a2238;
-        --bs-card-border-color: rgb(255 255 255 / 12%);
-        --bs-card-cap-bg: rgb(255 255 255 / 4%);
+        --bs-card-bg: var(--ed-surface-elevated);
+        --bs-card-border-color: var(--ed-border-faint);
+        --bs-card-cap-bg: var(--ed-overlay-faint);
     }
 
     .dropdown-menu {
-        --bs-dropdown-bg: #1a2238;
-        --bs-dropdown-border-color: rgb(255 255 255 / 12%);
-        --bs-dropdown-link-hover-bg: rgb(255 255 255 / 8%);
-        --bs-dropdown-divider-bg: rgb(255 255 255 / 10%);
+        --bs-dropdown-bg: var(--ed-surface-elevated);
+        --bs-dropdown-border-color: var(--ed-border-faint);
+        --bs-dropdown-link-hover-bg: var(--ed-overlay-medium);
+        --bs-dropdown-divider-bg: var(--ed-border-faint);
     }
 
     .modal-content {
-        --bs-modal-bg: #1a2238;
-        --bs-modal-border-color: rgb(255 255 255 / 12%);
+        --bs-modal-bg: var(--ed-surface-elevated);
+        --bs-modal-border-color: var(--ed-border-faint);
     }
 
     .popover {
-        --bs-popover-bg: #1a2238;
-        --bs-popover-border-color: rgb(255 255 255 / 12%);
+        --bs-popover-bg: var(--ed-surface-elevated);
+        --bs-popover-border-color: var(--ed-border-faint);
     }
 
     .list-group {
-        --bs-list-group-bg: #1a2238;
-        --bs-list-group-border-color: rgb(255 255 255 / 12%);
-        --bs-list-group-action-hover-bg: rgb(255 255 255 / 6%);
+        --bs-list-group-bg: var(--ed-surface-elevated);
+        --bs-list-group-border-color: var(--ed-border-faint);
+        --bs-list-group-action-hover-bg: var(--ed-overlay-soft);
     }
 
     .table {
-        --bs-table-striped-bg: rgb(255 255 255 / 4%);
-        --bs-table-border-color: rgb(255 255 255 / 12%);
+        --bs-table-striped-bg: var(--ed-overlay-faint);
+        --bs-table-border-color: var(--ed-border-faint);
     }
 
     .alert {
-        --bs-alert-border-color: rgb(255 255 255 / 12%);
+        --bs-alert-border-color: var(--ed-border-faint);
     }
 
     .form-control,
     .form-select {
-        background-color: rgb(255 255 255 / 4%);
-        border-color: rgb(255 255 255 / 15%);
+        background-color: var(--ed-overlay-faint);
+        border-color: var(--ed-border-faint);
         color: var(--bs-body-color);
 
         &:focus {
-            background-color: rgb(255 255 255 / 6%);
+            background-color: var(--ed-overlay-soft);
         }
     }
 
@@ -820,7 +827,7 @@ footer {
     }
 
     .card-header-themed {
-        background-color: rgb(255 255 255 / 6%);
+        background-color: var(--ed-overlay-soft);
         border-bottom-color: var(--ed-gold);
 
         .nav-tabs .nav-link.active {
@@ -831,7 +838,7 @@ footer {
     }
 
     .table-themed thead {
-        background-color: rgb(255 255 255 / 6%);
+        background-color: var(--ed-overlay-soft);
     }
 
     .badge-lent {
@@ -851,12 +858,12 @@ footer {
     .mantine-RichTextEditor-content,
     .cms-content {
         th {
-            background-color: rgb(255 255 255 / 8%);
+            background-color: var(--ed-overlay-medium);
         }
     }
 
     /* stylelint-disable-next-line selector-class-pattern */
     .mantine-RichTextEditor-content .selectedCell {
-        background-color: rgb(255 255 255 / 12%);
+        background-color: var(--ed-border-faint);
     }
 }

--- a/assets/styles/themes/expandedtalks/_overrides.scss
+++ b/assets/styles/themes/expandedtalks/_overrides.scss
@@ -150,7 +150,7 @@ a {
     }
 
     .card-header-themed {
-        background: rgba(#fff, .06);
+        background: var(--ed-overlay-soft);
         border-bottom: 2px solid $cs-sand;
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,21 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.11.0] — 2026-05-07
+
+Minor release: case-sensitive archetype playstyle tags, login button removed from the Expanded Talks navbar via theme override, and a dark-mode SCSS DRY pass.
+
+### Features
+
+- **Case-sensitive archetype playstyle tags (F2.15)** — drop the forced title-case normalization on archetype playstyle tags in both the PHP backend (`AdminArchetypeController::normalizeTag`) and the React `PlaystyleTagSelect` component, so editors keep whatever casing they type. Within an archetype, `Control` and `control` are now two distinct tags (strict byte-comparison); the URL filter `?tags[]=Aggro` and `?tags[]=aggro` return different results. The autocomplete suggestion list folds case variants and surfaces the most-frequent casing per case-folded key (ties go to first-seen) so editors don't see noisy duplicates while existing title-cased rows coexist with new mixed-case input. No DB migration: MySQL JSON columns are stored using `utf8mb4_bin` regardless of the table's default collation, so storage and the existing `LIKE`-based tag filter were already case-sensitive — only the application-side normalizers and suggestion folding changed. Existing rows are intentionally left as-is. ([#527](https://github.com/jbourdin/expandedDecks/pull/527))
+- **Themeable unauthenticated navbar with Expanded Talks override (F18.28)** — extract the unauthenticated navbar items (login + conditional register) from `templates/base.html.twig` into a new `_partials/navbar_unauthenticated.html.twig`, so themes can override the include via the existing channel theme path mechanism. Add an empty override at `templates/themes/expandedtalks/_partials/navbar_unauthenticated.html.twig` — the Expanded Talks channel is content-only (decks/events/registration already disabled) and now renders no user-facing auth UI in its navbar. Default channels keep the exact same login + register markup as before. No new `Channel::enableLogin` flag, no migration, no admin form binding; future themes can ship their own variant of the unauthenticated nav (e.g. a custom CTA in place of login) by dropping a partial in their theme directory. ([#528](https://github.com/jbourdin/expandedDecks/pull/528))
+
+### Refactoring
+
+- **DRY dark-mode surfaces with shared CSS tokens (F20.1)** — promote five repeated dark-surface literals in `assets/styles/app.scss` to CSS custom properties declared once on `:root[data-bs-theme="dark"]`, then reference them throughout the dark-mode block: `--ed-surface-elevated` (#1a2238, replaces 5 literals), `--ed-border-faint` (rgb(255 255 255 / 12%), 7 literals), `--ed-overlay-faint` (4%, 3 literals), `--ed-overlay-soft` (6%, 3 literals), `--ed-overlay-medium` (8%, 2 literals). Drop the redundant body `background-color` override by routing it through `var(--ed-bg)`. Affected selectors: `.card`, `.dropdown-menu`, `.modal-content`, `.popover`, `.list-group`, `.table`, `.alert`, `.form-control`, `.form-select`, `.card-header-themed`, `.table-themed thead`. The `expandedtalks` theme dark `.card-header-themed` now picks up `--ed-overlay-soft` for cross-theme consistency, and `.form-control` border opacity unifies at 12% (was 15%, lone outlier among seven 12% borders). Internal-only change; visual output is identical to 1.10.0. ([#526](https://github.com/jbourdin/expandedDecks/pull/526))
+
+---
+
 ## [1.10.0] — 2026-05-06
 
 Minor release: OS-preference dark theme.

--- a/src/Controller/AdminArchetypeController.php
+++ b/src/Controller/AdminArchetypeController.php
@@ -857,16 +857,15 @@ class AdminArchetypeController extends AbstractAppController
     }
 
     /**
-     * Normalize a tag: only alphanumeric and spaces, title case.
+     * Normalize a tag: only alphanumeric and spaces, casing preserved verbatim.
      *
      * @see docs/features.md F2.15 — Archetype playstyle tags
      */
     private static function normalizeTag(string $tag): string
     {
         $cleaned = preg_replace('/[^a-zA-Z0-9 ]/', '', $tag) ?? '';
-        $cleaned = trim(preg_replace('/\s+/', ' ', $cleaned) ?? '');
 
-        return mb_convert_case($cleaned, \MB_CASE_TITLE);
+        return trim(preg_replace('/\s+/', ' ', $cleaned) ?? '');
     }
 
     /**
@@ -905,19 +904,29 @@ class AdminArchetypeController extends AbstractAppController
     }
 
     /**
-     * Collect all unique playstyle tags from existing archetypes.
+     * Collect playstyle tag suggestions from existing archetypes.
+     *
+     * Folds casing variants together: for each case-insensitive key, the most-frequent casing
+     * wins (insertion-order tie-break) so editors see one canonical entry in the autocomplete.
      *
      * @return list<string>
      */
     private function collectExistingTags(ArchetypeRepository $archetypeRepository): array
     {
-        $allTags = [];
+        /** @var array<string, array<string, int>> $buckets */
+        $buckets = [];
         foreach ($archetypeRepository->findBy(['deletedAt' => null]) as $archetype) {
             foreach ($archetype->getPlaystyleTags() as $tag) {
-                $allTags[$tag] = true;
+                $key = mb_strtolower($tag);
+                $buckets[$key][$tag] = ($buckets[$key][$tag] ?? 0) + 1;
             }
         }
-        $tags = array_keys($allTags);
+
+        $tags = [];
+        foreach ($buckets as $casings) {
+            arsort($casings);
+            $tags[] = (string) array_key_first($casings);
+        }
         sort($tags);
 
         return $tags;

--- a/templates/_partials/navbar_unauthenticated.html.twig
+++ b/templates/_partials/navbar_unauthenticated.html.twig
@@ -1,0 +1,22 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #
+ # Default unauthenticated navbar items (login + optional register).
+ # Channels with their own theme can override this partial under
+ # templates/themes/<theme>/_partials/navbar_unauthenticated.html.twig
+ # (see F18.28 — Per-channel theme system).
+ #}
+{% set channel = current_channel() %}
+<li class="nav-item">
+    <a class="nav-link" href="{{ path('app_login', {_target_path: app.request.pathInfo}) }}">{{ 'app.nav.login'|trans }}</a>
+</li>
+{% if channel.enableRegister %}
+    <li class="nav-item">
+        <a class="nav-link" href="{{ path('app_register', {_target_path: app.request.pathInfo}) }}">{{ 'app.nav.register'|trans }}</a>
+    </li>
+{% endif %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -214,14 +214,7 @@
                                 </li>
                             {% endif %}
                             {{ include('_partials/navbar_search.html.twig') }}
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ path('app_login', {_target_path: app.request.pathInfo}) }}">{{ 'app.nav.login'|trans }}</a>
-                            </li>
-                            {% if channel.enableRegister %}
-                                <li class="nav-item">
-                                    <a class="nav-link" href="{{ path('app_register', {_target_path: app.request.pathInfo}) }}">{{ 'app.nav.register'|trans }}</a>
-                                </li>
-                            {% endif %}
+                            {{ include('_partials/navbar_unauthenticated.html.twig') }}
                         {% endif %}
                         {% if current_channel().locales|length > 1 %}
                             {% set currentLocale = app.request.locale %}

--- a/templates/themes/expandedtalks/_partials/navbar_unauthenticated.html.twig
+++ b/templates/themes/expandedtalks/_partials/navbar_unauthenticated.html.twig
@@ -1,0 +1,11 @@
+{#
+ # This file is part of the Expanded Decks project.
+ #
+ # (c) Expanded Decks contributors
+ #
+ # For the full copyright and license information, please view the LICENSE
+ # file that was distributed with this source code.
+ #
+ # Expanded Talks is a content-only channel — no user-facing auth UI in the navbar.
+ # Overrides templates/_partials/navbar_unauthenticated.html.twig (F18.28).
+ #}

--- a/tests/Functional/AdminArchetypeControllerTest.php
+++ b/tests/Functional/AdminArchetypeControllerTest.php
@@ -229,8 +229,8 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
         self::assertResponseRedirects();
 
         $refreshed = $this->getArchetype('Lugia Archeops');
-        self::assertContains('Aggressive', $refreshed->getPlaystyleTags());
-        self::assertContains('Control', $refreshed->getPlaystyleTags());
+        self::assertContains('aggressive', $refreshed->getPlaystyleTags());
+        self::assertContains('control', $refreshed->getPlaystyleTags());
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Minor release — case-sensitive archetype playstyle tags, login button removed from the Expanded Talks navbar via theme override, and a dark-mode SCSS DRY pass.

- **F2.15 — Case-sensitive playstyle tags** — drop forced title-case normalization in both PHP backend and React `PlaystyleTagSelect`; autocomplete folds case variants and surfaces the most-frequent casing. No DB migration needed (MySQL JSON columns are `utf8mb4_bin`).
- **F18.28 — Themeable unauthenticated navbar** — extract login + register into `_partials/navbar_unauthenticated.html.twig`; empty override at `templates/themes/expandedtalks/_partials/` removes user-facing auth UI from the Expanded Talks channel navbar. Default channels unchanged.
- **F20.1 — DRY dark-mode SCSS** — promote five repeated dark-surface literals (`#1a2238` plus four white-overlay opacities) to CSS custom properties on `:root[data-bs-theme="dark"]`; visual output identical.

## Test plan

- [ ] CI green on this PR.
- [ ] On `expandeddecks.wip`: admin tag editor accepts `aggro`/`Aggro`/`AGGRO` as three distinct tags; reload preserves casing exactly.
- [ ] On `expandedtalks.wip`: unauthenticated navbar shows neither login nor register.
- [ ] On `expandeddecks.wip`: unauthenticated navbar still shows login (and register where enabled).
- [ ] Toggle OS dark/light on both channels — surfaces flip identically to v1.10.0.