### PR TITLE
:sparkles: feat: add light/dark/auto theme switcher in footer

### DIFF
--- a/assets/app.tsx
+++ b/assets/app.tsx
@@ -10,6 +10,45 @@
 import './styles/app.scss';
 import { Tooltip } from 'bootstrap';
 
+type ThemeMode = 'light' | 'dark' | 'auto';
+
+declare global {
+    interface Window {
+        __edTheme?: {
+            get: () => ThemeMode;
+            apply: (mode: ThemeMode) => void;
+        };
+    }
+}
+
+const initThemeSwitcher = (): void => {
+    const container = document.querySelector<HTMLElement>('[data-theme-switcher]');
+    if (!container || !window.__edTheme) {
+        return;
+    }
+    const buttons = container.querySelectorAll<HTMLButtonElement>('button[data-theme-value]');
+    const markActive = (mode: ThemeMode): void => {
+        buttons.forEach((button) => {
+            const value = button.dataset.themeValue;
+            const isActive = value === mode;
+            button.classList.toggle('active', isActive);
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+    };
+    markActive(window.__edTheme.get());
+    buttons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const value = button.dataset.themeValue as ThemeMode | undefined;
+            if (value !== 'light' && value !== 'dark' && value !== 'auto') {
+                return;
+            }
+            window.__edTheme?.apply(value);
+            markActive(value);
+        });
+    });
+};
+
 document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new Tooltip(el));
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(element => new Tooltip(element));
+    initThemeSwitcher();
 });

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,17 +11,42 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        {# F20.1 — Mirror the OS color scheme onto the document so Bootstrap and Mantine see it before first paint. #}
+        {# F20.1 — Resolve color scheme (stored preference > OS) and mirror it onto the document before first paint. #}
         <script>
             (function () {
+                var STORAGE_KEY = 'ed-theme';
                 var media = window.matchMedia('(prefers-color-scheme: dark)');
-                var apply = function (matches) {
-                    var scheme = matches ? 'dark' : 'light';
+                var readMode = function () {
+                    try {
+                        var stored = window.localStorage.getItem(STORAGE_KEY);
+                        if (stored === 'light' || stored === 'dark' || stored === 'auto') {
+                            return stored;
+                        }
+                    } catch (error) { /* localStorage unavailable (private mode, disabled) — fall through to auto */ }
+                    return 'auto';
+                };
+                var resolve = function (mode) {
+                    if (mode === 'light' || mode === 'dark') { return mode; }
+                    return media.matches ? 'dark' : 'light';
+                };
+                var paint = function (mode) {
+                    var scheme = resolve(mode);
                     document.documentElement.setAttribute('data-bs-theme', scheme);
                     document.documentElement.setAttribute('data-mantine-color-scheme', scheme);
                 };
-                apply(media.matches);
-                media.addEventListener('change', function (event) { apply(event.matches); });
+                var currentMode = readMode();
+                paint(currentMode);
+                media.addEventListener('change', function () {
+                    if (readMode() === 'auto') { paint('auto'); }
+                });
+                window.__edTheme = {
+                    get: readMode,
+                    apply: function (mode) {
+                        if (mode !== 'light' && mode !== 'dark' && mode !== 'auto') { return; }
+                        try { window.localStorage.setItem(STORAGE_KEY, mode); } catch (error) { /* ignore */ }
+                        paint(mode);
+                    }
+                };
             })();
         </script>
         <title>{% block title %}{{ channel_param('brand_name', 'Expanded Decks') }}{% endblock %}</title>
@@ -258,8 +283,8 @@
         <footer class="footer-pokemon py-4 mt-auto">
             <div class="container">
                 {% set footerCategories = footer_categories() %}
-                {% if footerCategories is not empty %}
-                    <div class="row mb-3">
+                <div class="row mb-3">
+                    {% if footerCategories is not empty %}
                         {% for category in footerCategories %}
                             {% set pages = category.pages|filter(p => p.published)|sort((a, b) => a.position <=> b.position) %}
                             {% if pages is not empty %}
@@ -273,7 +298,23 @@
                                 </div>
                             {% endif %}
                         {% endfor %}
+                    {% endif %}
+                    <div class="col-sm-4 col-md-3 ms-md-auto" data-theme-switcher>
+                        <h6 class="text-uppercase mb-2">{{ 'app.theme.heading'|trans }}</h6>
+                        <div class="btn-group btn-group-sm" role="group" aria-label="{{ 'app.theme.aria_label'|trans }}">
+                            <button type="button" class="btn btn-outline-secondary" data-theme-value="light" title="{{ 'app.theme.light'|trans }}" aria-label="{{ 'app.theme.light'|trans }}">
+                                <i class="bi bi-sun-fill" aria-hidden="true"></i>
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary" data-theme-value="auto" title="{{ 'app.theme.auto'|trans }}" aria-label="{{ 'app.theme.auto'|trans }}">
+                                <i class="bi bi-circle-half" aria-hidden="true"></i>
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary" data-theme-value="dark" title="{{ 'app.theme.dark'|trans }}" aria-label="{{ 'app.theme.dark'|trans }}">
+                                <i class="bi bi-moon-stars-fill" aria-hidden="true"></i>
+                            </button>
+                        </div>
                     </div>
+                </div>
+                {% if footerCategories is not empty %}
                     <hr class="my-2">
                 {% endif %}
                 <div class="text-center">

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5932,6 +5932,31 @@
                 <target>An archived row matched these coordinates and was reactivated.</target>
                 <note>F6.14 — admin flash when create reactivates a soft-deleted row</note>
             </trans-unit>
+            <trans-unit id="app.theme.heading">
+                <source>app.theme.heading</source>
+                <target>Theme</target>
+                <note>Footer column heading above the light/dark/auto switcher</note>
+            </trans-unit>
+            <trans-unit id="app.theme.aria_label">
+                <source>app.theme.aria_label</source>
+                <target>Color theme</target>
+                <note>Accessible label for the footer theme switcher button group</note>
+            </trans-unit>
+            <trans-unit id="app.theme.light">
+                <source>app.theme.light</source>
+                <target>Light</target>
+                <note>Footer theme switcher — light mode option</note>
+            </trans-unit>
+            <trans-unit id="app.theme.auto">
+                <source>app.theme.auto</source>
+                <target>Auto (system)</target>
+                <note>Footer theme switcher — follow OS preference</note>
+            </trans-unit>
+            <trans-unit id="app.theme.dark">
+                <source>app.theme.dark</source>
+                <target>Dark</target>
+                <note>Footer theme switcher — dark mode option</note>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -5895,6 +5895,31 @@
                 <target>Une ligne archivée correspondant à ces coordonnées a été réactivée.</target>
                 <note>F6.14 — admin flash when create reactivates a soft-deleted row</note>
             </trans-unit>
+            <trans-unit id="app.theme.heading">
+                <source>app.theme.heading</source>
+                <target>Thème</target>
+                <note>Footer column heading above the light/dark/auto switcher</note>
+            </trans-unit>
+            <trans-unit id="app.theme.aria_label">
+                <source>app.theme.aria_label</source>
+                <target>Thème de couleurs</target>
+                <note>Accessible label for the footer theme switcher button group</note>
+            </trans-unit>
+            <trans-unit id="app.theme.light">
+                <source>app.theme.light</source>
+                <target>Clair</target>
+                <note>Footer theme switcher — light mode option</note>
+            </trans-unit>
+            <trans-unit id="app.theme.auto">
+                <source>app.theme.auto</source>
+                <target>Auto (système)</target>
+                <note>Footer theme switcher — follow OS preference</note>
+            </trans-unit>
+            <trans-unit id="app.theme.dark">
+                <source>app.theme.dark</source>
+                <target>Sombre</target>
+                <note>Footer theme switcher — dark mode option</note>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
## Summary

- New footer column **Theme** with three icon buttons (light, auto, dark) — laid out as a `col-sm-4 col-md-3` matching the existing CMS category columns, pulled bottom-right via `ms-md-auto`. Bootstrap Icons (`bi-sun-fill`, `bi-circle-half`, `bi-moon-stars-fill`), no new dependency.
- The choice persists in `localStorage` under key `ed-theme` (`light` / `dark` / `auto`). The pre-paint `<head>` script in `templates/base.html.twig` now reads the stored preference first and falls back to `prefers-color-scheme` only when the mode is `auto` or unset — no flash of wrong theme on reload.
- The OS-change media listener now only repaints when the active mode is `auto`, so an explicit light/dark choice is no longer flipped by an OS toggle. A small global `window.__edTheme = { get, apply }` is exposed by the inline script; `assets/app.tsx` calls into it from the footer click handler and toggles `.active` + `aria-pressed` on the buttons.
- Mantine sync unchanged: even in `auto` mode the inline script writes a concrete `light`/`dark` to `data-mantine-color-scheme`, so React islands continue to follow the document attribute without provider edits.
- Translations: five new keys in both `messages.en.xlf` and `messages.fr.xlf` (`app.theme.heading`, `aria_label`, `light`, `auto`, `dark`).

## Test plan

- [ ] CI green on this PR.
- [ ] On `expandeddecks.wip` with OS in light mode: footer shows three buttons, **Auto** is active, page is light. DevTools shows `<html data-bs-theme=\"light\" data-mantine-color-scheme=\"light\">`.
- [ ] Click **Dark** → page flips immediately. `localStorage.getItem('ed-theme')` returns `\"dark\"`. Hard reload → no light flash before paint, page comes up dark, **Dark** stays active.
- [ ] Toggle the OS to dark mode while the site is on **Dark** → page does not flip (manual override beats OS).
- [ ] Click **Auto** → `localStorage` value becomes `\"auto\"`. Toggle the OS between dark and light → page tracks live.
- [ ] Click **Light**, close the tab, reopen → page renders light from the first paint.
- [ ] Switch locale to `/fr/...` → button tooltips read \"Clair\", \"Auto (système)\", \"Sombre\"; the column heading reads \"Thème\".
- [ ] Visit a page with a Mantine React island (notification bell, navbar search) under each of the three modes → Mantine components match the chosen theme.
- [ ] On `expandedtalks.wip` (channel theme) → footer switcher renders correctly and both themes still look right.
- [ ] Mobile viewport: theme column stacks below CMS categories rather than colliding (the `ms-md-auto` only kicks in at md+).