### PR TITLE
:rocket: Release: 1.12.0

### DIFF
--- a/assets/app.tsx
+++ b/assets/app.tsx
@@ -10,6 +10,45 @@
 import './styles/app.scss';
 import { Tooltip } from 'bootstrap';
 
+type ThemeMode = 'light' | 'dark' | 'auto';
+
+declare global {
+    interface Window {
+        __edTheme?: {
+            get: () => ThemeMode;
+            apply: (mode: ThemeMode) => void;
+        };
+    }
+}
+
+const initThemeSwitcher = (): void => {
+    const container = document.querySelector<HTMLElement>('[data-theme-switcher]');
+    if (!container || !window.__edTheme) {
+        return;
+    }
+    const buttons = container.querySelectorAll<HTMLButtonElement>('button[data-theme-value]');
+    const markActive = (mode: ThemeMode): void => {
+        buttons.forEach((button) => {
+            const value = button.dataset.themeValue;
+            const isActive = value === mode;
+            button.classList.toggle('active', isActive);
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+    };
+    markActive(window.__edTheme.get());
+    buttons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const value = button.dataset.themeValue as ThemeMode | undefined;
+            if (value !== 'light' && value !== 'dark' && value !== 'auto') {
+                return;
+            }
+            window.__edTheme?.apply(value);
+            markActive(value);
+        });
+    });
+};
+
 document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new Tooltip(el));
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(element => new Tooltip(element));
+    initThemeSwitcher();
 });

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,16 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.12.0] — 2026-05-07
+
+Minor release: user-controlled light/dark/auto theme override — visitors can pin the site to light or dark from a footer switcher, or keep the OS-following behavior.
+
+### Features
+
+- **User-controlled theme switcher (F20.1)** — add a Light/Auto/Dark icon button group to the footer as a new `col-sm-4 col-md-3` column pulled bottom-right via `ms-md-auto`, matching the rhythm of the existing CMS category columns (Bootstrap Icons `bi-sun-fill` / `bi-circle-half` / `bi-moon-stars-fill`, no new dependency). The choice persists in `localStorage` under key `ed-theme` (`light` / `dark` / `auto`). The pre-paint inline `<head>` script in `templates/base.html.twig` now resolves *stored preference > `prefers-color-scheme`*, and the OS-change media listener only repaints when the active mode is `auto` — explicit light/dark choices survive OS toggles. A small `window.__edTheme = { get, apply }` bridge exposed by the inline script lets `assets/app.tsx` toggle the mode on click, mark the active button with `.active` + `aria-pressed`, and update `localStorage` without duplicating the resolution logic across the inline script and the bundle. Mantine sync unchanged: even in `auto` mode the inline script writes a concrete `light`/`dark` to `data-mantine-color-scheme`, so React islands keep following the document attribute without provider edits. Five new translation keys (`app.theme.heading`, `aria_label`, `light`, `auto`, `dark`) in `messages.en.xlf` and `messages.fr.xlf`. ([#530](https://github.com/jbourdin/expandedDecks/pull/530))
+
+---
+
 ## [1.11.0] — 2026-05-07
 
 Minor release: case-sensitive archetype playstyle tags, login button removed from the Expanded Talks navbar via theme override, and a dark-mode SCSS DRY pass.

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,17 +11,42 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        {# F20.1 — Mirror the OS color scheme onto the document so Bootstrap and Mantine see it before first paint. #}
+        {# F20.1 — Resolve color scheme (stored preference > OS) and mirror it onto the document before first paint. #}
         <script>
             (function () {
+                var STORAGE_KEY = 'ed-theme';
                 var media = window.matchMedia('(prefers-color-scheme: dark)');
-                var apply = function (matches) {
-                    var scheme = matches ? 'dark' : 'light';
+                var readMode = function () {
+                    try {
+                        var stored = window.localStorage.getItem(STORAGE_KEY);
+                        if (stored === 'light' || stored === 'dark' || stored === 'auto') {
+                            return stored;
+                        }
+                    } catch (error) { /* localStorage unavailable (private mode, disabled) — fall through to auto */ }
+                    return 'auto';
+                };
+                var resolve = function (mode) {
+                    if (mode === 'light' || mode === 'dark') { return mode; }
+                    return media.matches ? 'dark' : 'light';
+                };
+                var paint = function (mode) {
+                    var scheme = resolve(mode);
                     document.documentElement.setAttribute('data-bs-theme', scheme);
                     document.documentElement.setAttribute('data-mantine-color-scheme', scheme);
                 };
-                apply(media.matches);
-                media.addEventListener('change', function (event) { apply(event.matches); });
+                var currentMode = readMode();
+                paint(currentMode);
+                media.addEventListener('change', function () {
+                    if (readMode() === 'auto') { paint('auto'); }
+                });
+                window.__edTheme = {
+                    get: readMode,
+                    apply: function (mode) {
+                        if (mode !== 'light' && mode !== 'dark' && mode !== 'auto') { return; }
+                        try { window.localStorage.setItem(STORAGE_KEY, mode); } catch (error) { /* ignore */ }
+                        paint(mode);
+                    }
+                };
             })();
         </script>
         <title>{% block title %}{{ channel_param('brand_name', 'Expanded Decks') }}{% endblock %}</title>
@@ -258,8 +283,8 @@
         <footer class="footer-pokemon py-4 mt-auto">
             <div class="container">
                 {% set footerCategories = footer_categories() %}
-                {% if footerCategories is not empty %}
-                    <div class="row mb-3">
+                <div class="row mb-3">
+                    {% if footerCategories is not empty %}
                         {% for category in footerCategories %}
                             {% set pages = category.pages|filter(p => p.published)|sort((a, b) => a.position <=> b.position) %}
                             {% if pages is not empty %}
@@ -273,7 +298,23 @@
                                 </div>
                             {% endif %}
                         {% endfor %}
+                    {% endif %}
+                    <div class="col-sm-4 col-md-3 ms-md-auto" data-theme-switcher>
+                        <h6 class="text-uppercase mb-2">{{ 'app.theme.heading'|trans }}</h6>
+                        <div class="btn-group btn-group-sm" role="group" aria-label="{{ 'app.theme.aria_label'|trans }}">
+                            <button type="button" class="btn btn-outline-secondary" data-theme-value="light" title="{{ 'app.theme.light'|trans }}" aria-label="{{ 'app.theme.light'|trans }}">
+                                <i class="bi bi-sun-fill" aria-hidden="true"></i>
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary" data-theme-value="auto" title="{{ 'app.theme.auto'|trans }}" aria-label="{{ 'app.theme.auto'|trans }}">
+                                <i class="bi bi-circle-half" aria-hidden="true"></i>
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary" data-theme-value="dark" title="{{ 'app.theme.dark'|trans }}" aria-label="{{ 'app.theme.dark'|trans }}">
+                                <i class="bi bi-moon-stars-fill" aria-hidden="true"></i>
+                            </button>
+                        </div>
                     </div>
+                </div>
+                {% if footerCategories is not empty %}
                     <hr class="my-2">
                 {% endif %}
                 <div class="text-center">

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5932,6 +5932,31 @@
                 <target>An archived row matched these coordinates and was reactivated.</target>
                 <note>F6.14 — admin flash when create reactivates a soft-deleted row</note>
             </trans-unit>
+            <trans-unit id="app.theme.heading">
+                <source>app.theme.heading</source>
+                <target>Theme</target>
+                <note>Footer column heading above the light/dark/auto switcher</note>
+            </trans-unit>
+            <trans-unit id="app.theme.aria_label">
+                <source>app.theme.aria_label</source>
+                <target>Color theme</target>
+                <note>Accessible label for the footer theme switcher button group</note>
+            </trans-unit>
+            <trans-unit id="app.theme.light">
+                <source>app.theme.light</source>
+                <target>Light</target>
+                <note>Footer theme switcher — light mode option</note>
+            </trans-unit>
+            <trans-unit id="app.theme.auto">
+                <source>app.theme.auto</source>
+                <target>Auto (system)</target>
+                <note>Footer theme switcher — follow OS preference</note>
+            </trans-unit>
+            <trans-unit id="app.theme.dark">
+                <source>app.theme.dark</source>
+                <target>Dark</target>
+                <note>Footer theme switcher — dark mode option</note>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -5895,6 +5895,31 @@
                 <target>Une ligne archivée correspondant à ces coordonnées a été réactivée.</target>
                 <note>F6.14 — admin flash when create reactivates a soft-deleted row</note>
             </trans-unit>
+            <trans-unit id="app.theme.heading">
+                <source>app.theme.heading</source>
+                <target>Thème</target>
+                <note>Footer column heading above the light/dark/auto switcher</note>
+            </trans-unit>
+            <trans-unit id="app.theme.aria_label">
+                <source>app.theme.aria_label</source>
+                <target>Thème de couleurs</target>
+                <note>Accessible label for the footer theme switcher button group</note>
+            </trans-unit>
+            <trans-unit id="app.theme.light">
+                <source>app.theme.light</source>
+                <target>Clair</target>
+                <note>Footer theme switcher — light mode option</note>
+            </trans-unit>
+            <trans-unit id="app.theme.auto">
+                <source>app.theme.auto</source>
+                <target>Auto (système)</target>
+                <note>Footer theme switcher — follow OS preference</note>
+            </trans-unit>
+            <trans-unit id="app.theme.dark">
+                <source>app.theme.dark</source>
+                <target>Sombre</target>
+                <note>Footer theme switcher — dark mode option</note>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
## Summary

Release 1.12.0 — user-controlled light/dark/auto theme switcher in the footer (F20.1 follow-up). See `docs/changelog.md` for details.

## Test plan

- [ ] CI green on this PR.
- [ ] `docs/changelog.md` 1.12.0 entry reads correctly and references PR #530.
- [ ] Manual smoke on `expandeddecks.wip` and `expandedtalks.wip`: switcher renders, persists, and survives reload (already verified on PR #530).