### PR TITLE
:sparkles: feat(card): add CardIdentity.ruleboxType + Ace Spec detection

### DIFF
--- a/migrations/Version20260507204712.php
+++ b/migrations/Version20260507204712.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add CardIdentity.ruleboxType — nullable string capturing the card's rulebox mechanic
+ * (Ace Spec, V/VMAX/VSTAR, ex/EX, GX, BREAK, Mega, Radiant, Prism Star, etc.).
+ *
+ * Detection in PR-1 covers Ace Spec only, populated from `tcgdex_card.rarity = 'ACE SPEC Rare'`.
+ * The other rulebox types are listed in {@see \App\Constants\RuleboxType} and will be detected
+ * by follow-up PRs (most are name-pattern based).
+ *
+ * Backfill: any CardIdentity that has at least one printing flagged "ACE SPEC Rare" in
+ * card_printing.rarity is marked. The 4 currently-known Ace Spec printings in the local
+ * card_printing table cover 4 identities (1:1 in this dataset).
+ *
+ * @see https://github.com/jbourdin/expandedDecks/issues/532
+ */
+final class Version20260507204712 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'F6.15 — CardIdentity.ruleboxType column + Ace Spec backfill';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE card_identity ADD rulebox_type VARCHAR(30) DEFAULT NULL');
+
+        $this->addSql(
+            <<<'SQL'
+                UPDATE card_identity ci
+                SET ci.rulebox_type = :ruleboxType
+                WHERE EXISTS (
+                    SELECT 1 FROM card_printing cp
+                    WHERE cp.card_identity_id = ci.id
+                      AND cp.rarity = :aceSpecRarity
+                )
+                SQL,
+            [
+                'ruleboxType' => 'ace_spec',
+                'aceSpecRarity' => 'ACE SPEC Rare',
+            ],
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE card_identity DROP rulebox_type');
+    }
+}

--- a/src/Constants/RuleboxType.php
+++ b/src/Constants/RuleboxType.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Constants;
+
+/**
+ * Rulebox types — Pokémon TCG card mechanics that print a "When this is Knocked Out…" rule box
+ * (or are otherwise marked as a special rulebox card).
+ *
+ * Stored on `CardIdentity.ruleboxType` as a nullable string. Null means a regular card with no rulebox.
+ *
+ * Detection is per-type and not uniform: most are name-pattern based (suffix or prefix), Ace Spec
+ * is rarity-based. As of PR-1 (issue #532), only ACE_SPEC is auto-detected by `CardIdentityResolver`;
+ * the others are listed here as the canonical taxonomy and will be populated by follow-up PRs.
+ *
+ * Naming-pattern reference (case-sensitive — modern `ex` and classic `EX` collide if folded;
+ * patterns with ambiguity must be checked in priority order, most-specific first):
+ *
+ *   ACE_SPEC              rarity = "ACE SPEC Rare" on any printing of the identity
+ *   POKEMON_MEGA          name prefix "Mega "   — modern Mega Pokémon ex (e.g. "Mega Charizard X ex").
+ *                                                 Coexists with the " ex" suffix; check this BEFORE POKEMON_EX
+ *                                                 or modern Megas get misclassified as plain ex.
+ *   POKEMON_MEGA_CLASSIC  stage = "MEGA" (most reliable signal) OR name prefix "M " (single capital M + space,
+ *                         e.g. "M Charizard EX"). XY-era Mega Evolution. Coexists with " EX" / "-EX" suffix;
+ *                         check BEFORE POKEMON_EX_CLASSIC.
+ *   POKEMON_EX            name suffix " ex"            (lowercase, modern Scarlet & Violet era plain ex)
+ *   POKEMON_V             name suffix " V"
+ *   POKEMON_VMAX          name suffix " VMAX"
+ *   POKEMON_VSTAR         name suffix " VSTAR"
+ *   POKEMON_GX            name suffix " GX"
+ *   POKEMON_EX_CLASSIC    name contains "-EX" or " EX"  (uppercase, Ruby & Sapphire era plain EX)
+ *   POKEMON_G             name suffix " G"             (Team Galactic Pokémon, Platinum era)
+ *   POKEMON_BREAK         name suffix " BREAK"
+ *   POKEMON_RADIANT       name prefix "Radiant "       (e.g. "Radiant Charizard") — NOT a suffix
+ *   PRISM_STAR            name suffix " ◇"             (diamond/prism-star symbol; verify TCGdex encoding)
+ *
+ * Constants are stored as snake_case strings rather than a PHP enum so the database column stays
+ * a plain VARCHAR — adding a new rulebox type later is a single new constant + a detector branch,
+ * with no schema change.
+ */
+final class RuleboxType
+{
+    public const ACE_SPEC = 'ace_spec';
+
+    public const POKEMON_EX = 'pokemon_ex';
+
+    public const POKEMON_V = 'pokemon_v';
+
+    public const POKEMON_VMAX = 'pokemon_vmax';
+
+    public const POKEMON_VSTAR = 'pokemon_vstar';
+
+    public const POKEMON_GX = 'pokemon_gx';
+
+    public const POKEMON_EX_CLASSIC = 'pokemon_ex_classic';
+
+    public const POKEMON_G = 'pokemon_g';
+
+    public const POKEMON_BREAK = 'pokemon_break';
+
+    public const POKEMON_MEGA = 'pokemon_mega';
+
+    public const POKEMON_MEGA_CLASSIC = 'pokemon_mega_classic';
+
+    public const POKEMON_RADIANT = 'pokemon_radiant';
+
+    public const PRISM_STAR = 'prism_star';
+}

--- a/src/Entity/CardIdentity.php
+++ b/src/Entity/CardIdentity.php
@@ -65,6 +65,10 @@ class CardIdentity
     #[ORM\Column(length: 30, nullable: true)]
     private ?string $trainerType = null;
 
+    /** Rulebox type from {@see \App\Constants\RuleboxType}. Null for regular cards without a rule box. */
+    #[ORM\Column(length: 30, nullable: true)]
+    private ?string $ruleboxType = null;
+
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
 
@@ -175,6 +179,18 @@ class CardIdentity
     public function setTrainerType(?string $trainerType): static
     {
         $this->trainerType = $trainerType;
+
+        return $this;
+    }
+
+    public function getRuleboxType(): ?string
+    {
+        return $this->ruleboxType;
+    }
+
+    public function setRuleboxType(?string $ruleboxType): static
+    {
+        $this->ruleboxType = $ruleboxType;
 
         return $this;
     }

--- a/src/Service/CardIdentity/CardIdentityResolver.php
+++ b/src/Service/CardIdentity/CardIdentityResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Service\CardIdentity;
 
+use App\Constants\RuleboxType;
 use App\Entity\CardIdentity;
 use App\Entity\CardPrinting;
 use App\Repository\CardIdentityRepository;
@@ -137,10 +138,17 @@ class CardIdentityResolver
             $attackSignature,
         );
 
+        $ruleboxType = self::detectRuleboxType($tcgdexCard);
+
         if (null !== $existing) {
             // Backfill trainerType if missing on existing identity
             if (null === $existing->getTrainerType() && null !== $tcgdexCard->trainerType) {
                 $existing->setTrainerType($tcgdexCard->trainerType);
+            }
+
+            // Backfill ruleboxType if missing on existing identity
+            if (null === $existing->getRuleboxType() && null !== $ruleboxType) {
+                $existing->setRuleboxType($ruleboxType);
             }
 
             return $existing;
@@ -155,10 +163,27 @@ class CardIdentityResolver
         $identity->setAttackSignature($attackSignature);
         $identity->setAttackNames(implode(',', $tcgdexCard->attacks));
         $identity->setTrainerType($tcgdexCard->trainerType);
+        $identity->setRuleboxType($ruleboxType);
 
         $this->entityManager->persist($identity);
 
         return $identity;
+    }
+
+    /**
+     * Detect the rulebox type for a TCGdex card. Returns null for regular cards.
+     *
+     * As of issue #532 PR-1, only ACE_SPEC is detected (via the rarity field). Detection logic for
+     * the other {@see RuleboxType} constants (V/VMAX/VSTAR/ex/EX-classic/G/GX/BREAK/Mega/Radiant/Prism)
+     * is name-pattern based and lands in follow-up PRs.
+     */
+    public static function detectRuleboxType(TcgdexCard $tcgdexCard): ?string
+    {
+        if ('ACE SPEC Rare' === $tcgdexCard->rarity) {
+            return RuleboxType::ACE_SPEC;
+        }
+
+        return null;
     }
 
     private function createPrinting(CardIdentity $identity, TcgdexCard $tcgdexCard): CardPrinting

--- a/tests/Service/CardIdentity/CardIdentityResolverTest.php
+++ b/tests/Service/CardIdentity/CardIdentityResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Service\CardIdentity;
 
+use App\Constants\RuleboxType;
 use App\Entity\CardIdentity;
 use App\Entity\CardPrinting;
 use App\Repository\CardIdentityRepository;
@@ -22,6 +23,7 @@ use App\Service\CardIdentity\RarityTierMapper;
 use App\Service\Tcgdex\TcgdexApiClient;
 use App\Service\Tcgdex\TcgdexCard;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -553,6 +555,270 @@ class CardIdentityResolverTest extends TestCase
         $result = $resolver->resolveFromTcgdexCard($tcgdexCard);
 
         self::assertNull($result->getSetReleaseDate());
+    }
+
+    public function testDetectRuleboxTypeReturnsAceSpecForAceSpecRarity(): void
+    {
+        $card = new TcgdexCard(
+            id: 'sv5-198',
+            name: 'Hero\'s Cape',
+            category: 'Trainer',
+            trainerType: 'Tool',
+            imageUrl: null,
+            isExpandedLegal: true,
+            rarity: 'ACE SPEC Rare',
+        );
+
+        self::assertSame(RuleboxType::ACE_SPEC, CardIdentityResolver::detectRuleboxType($card));
+    }
+
+    public function testDetectRuleboxTypeReturnsNullForRegularRarity(): void
+    {
+        $card = new TcgdexCard(
+            id: 'sv5-001',
+            name: 'Pikachu',
+            category: 'Pokemon',
+            trainerType: null,
+            imageUrl: null,
+            isExpandedLegal: true,
+            rarity: 'Common',
+        );
+
+        self::assertNull(CardIdentityResolver::detectRuleboxType($card));
+    }
+
+    public function testDetectRuleboxTypeReturnsNullForNullRarity(): void
+    {
+        $card = new TcgdexCard(
+            id: 'sv5-001',
+            name: 'Pikachu',
+            category: 'Pokemon',
+            trainerType: null,
+            imageUrl: null,
+            isExpandedLegal: true,
+        );
+
+        self::assertNull(CardIdentityResolver::detectRuleboxType($card));
+    }
+
+    public function testResolveFromTcgdexCardSetsRuleboxTypeOnNewIdentity(): void
+    {
+        $printingRepository = $this->createStub(CardPrintingRepository::class);
+        $printingRepository->method('findByTcgdexId')->willReturn(null);
+
+        $identityRepository = $this->createStub(CardIdentityRepository::class);
+        $identityRepository->method('findBySignature')->willReturn(null);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $rarityTierMapper = $this->createStub(RarityTierMapper::class);
+        $rarityTierMapper->method('map')->willReturn(6);
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+
+        $resolver = new CardIdentityResolver(
+            $identityRepository,
+            $printingRepository,
+            $apiClient,
+            $rarityTierMapper,
+            $entityManager,
+        );
+
+        $tcgdexCard = new TcgdexCard(
+            id: 'sv5-180',
+            name: 'Unfair Stamp',
+            category: 'Trainer',
+            trainerType: 'Item',
+            imageUrl: null,
+            isExpandedLegal: true,
+            rarity: 'ACE SPEC Rare',
+        );
+
+        $result = $resolver->resolveFromTcgdexCard($tcgdexCard);
+
+        self::assertSame(RuleboxType::ACE_SPEC, $result->getCardIdentity()->getRuleboxType());
+    }
+
+    public function testResolveFromTcgdexCardBackfillsRuleboxTypeOnExistingIdentity(): void
+    {
+        $existingIdentity = new CardIdentity();
+        $existingIdentity->setName('Unfair Stamp');
+        $existingIdentity->setCategory('trainer');
+        $existingIdentity->setTrainerType('Item');
+        $existingIdentity->setRuleboxType(null);
+
+        $printingRepository = $this->createStub(CardPrintingRepository::class);
+        $printingRepository->method('findByTcgdexId')->willReturn(null);
+
+        $identityRepository = $this->createStub(CardIdentityRepository::class);
+        $identityRepository->method('findBySignature')->willReturn($existingIdentity);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $rarityTierMapper = $this->createStub(RarityTierMapper::class);
+        $rarityTierMapper->method('map')->willReturn(6);
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+
+        $resolver = new CardIdentityResolver(
+            $identityRepository,
+            $printingRepository,
+            $apiClient,
+            $rarityTierMapper,
+            $entityManager,
+        );
+
+        $tcgdexCard = new TcgdexCard(
+            id: 'sv5-180',
+            name: 'Unfair Stamp',
+            category: 'Trainer',
+            trainerType: 'Item',
+            imageUrl: null,
+            isExpandedLegal: true,
+            rarity: 'ACE SPEC Rare',
+        );
+
+        $resolver->resolveFromTcgdexCard($tcgdexCard);
+
+        self::assertSame(RuleboxType::ACE_SPEC, $existingIdentity->getRuleboxType());
+    }
+
+    public function testResolveFromTcgdexCardDoesNotOverwriteExistingRuleboxType(): void
+    {
+        $existingIdentity = new CardIdentity();
+        $existingIdentity->setName('Unfair Stamp');
+        $existingIdentity->setCategory('trainer');
+        $existingIdentity->setTrainerType('Item');
+        $existingIdentity->setRuleboxType(RuleboxType::ACE_SPEC);
+
+        $printingRepository = $this->createStub(CardPrintingRepository::class);
+        $printingRepository->method('findByTcgdexId')->willReturn(null);
+
+        $identityRepository = $this->createStub(CardIdentityRepository::class);
+        $identityRepository->method('findBySignature')->willReturn($existingIdentity);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $rarityTierMapper = $this->createStub(RarityTierMapper::class);
+        $rarityTierMapper->method('map')->willReturn(3);
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+
+        $resolver = new CardIdentityResolver(
+            $identityRepository,
+            $printingRepository,
+            $apiClient,
+            $rarityTierMapper,
+            $entityManager,
+        );
+
+        // Same card resolved later via a non-Ace-Spec printing (would yield null detection)
+        $tcgdexCard = new TcgdexCard(
+            id: 'sv5-181',
+            name: 'Unfair Stamp',
+            category: 'Trainer',
+            trainerType: 'Item',
+            imageUrl: null,
+            isExpandedLegal: true,
+            rarity: 'Rare',
+        );
+
+        $resolver->resolveFromTcgdexCard($tcgdexCard);
+
+        self::assertSame(RuleboxType::ACE_SPEC, $existingIdentity->getRuleboxType());
+    }
+
+    /**
+     * Future-cases coverage for {@see CardIdentityResolver::detectRuleboxType()}.
+     *
+     * As of issue #532 PR-1, only ACE_SPEC is detected. This test enumerates every other
+     * rulebox type listed in {@see RuleboxType} with realistic example cards, so that when
+     * detection logic is extended in follow-up PRs, this test becomes the green target.
+     *
+     * Unskip when extending detection. Some classic-Mega cases may require extending the
+     * TcgdexCard struct with `stage` / `evolveFrom` fields to detect reliably (see the
+     * RuleboxType docblock for canonical detection signals per type — `stage = "MEGA"`
+     * is the strongest signal for POKEMON_MEGA_CLASSIC, but the struct does not currently
+     * carry it).
+     *
+     * Priority-order trap (already documented in RuleboxType): "Mega Charizard X ex" must
+     * resolve to POKEMON_MEGA, not POKEMON_EX, even though it ends in " ex". Same for
+     * classic — "M Charizard EX" must resolve to POKEMON_MEGA_CLASSIC, not POKEMON_EX_CLASSIC.
+     */
+    #[DataProvider('provideRuleboxDetectionCases')]
+    public function testDetectRuleboxTypeFutureCases(string $cardName, ?string $rarity, ?string $expectedRuleboxType): void
+    {
+        self::markTestSkipped('Detection beyond ACE_SPEC is implemented in follow-up PRs (issue #532).');
+
+        $card = new TcgdexCard(
+            id: 'test-001',
+            name: $cardName,
+            category: 'Pokemon',
+            trainerType: null,
+            imageUrl: null,
+            isExpandedLegal: true,
+            rarity: $rarity,
+        );
+
+        self::assertSame($expectedRuleboxType, CardIdentityResolver::detectRuleboxType($card));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: ?string, 2: ?string}>
+     */
+    public static function provideRuleboxDetectionCases(): iterable
+    {
+        // ── Modern Mega ── prefix "Mega ", coexists with " ex" suffix; check BEFORE POKEMON_EX
+        yield 'Modern Mega ex — Mega Charizard X ex' => ['Mega Charizard X ex', 'Double rare', RuleboxType::POKEMON_MEGA];
+
+        // ── Classic Mega ── prefix "M " (single M + space); coexists with " EX" suffix.
+        // The strongest signal would be `stage = "MEGA"` on the persisted entity, but the
+        // TcgdexCard struct does not carry stage today. Detection from name prefix is the
+        // current fallback — verify against false-positives like "Magneton" / "Marowak"
+        // which start with M but have no space after.
+        yield 'Classic Mega EX — M Charizard EX' => ['M Charizard EX', 'Ultra Rare', RuleboxType::POKEMON_MEGA_CLASSIC];
+        yield 'Classic Mega EX — M Rayquaza EX' => ['M Rayquaza EX', 'Ultra Rare', RuleboxType::POKEMON_MEGA_CLASSIC];
+
+        // ── Modern plain ex ── name suffix " ex" (lowercase, S&V era), no Mega prefix
+        yield 'Modern ex — Charizard ex' => ['Charizard ex', 'Double rare', RuleboxType::POKEMON_EX];
+        yield 'Modern ex — Dialga ex' => ['Dialga ex', 'Double rare', RuleboxType::POKEMON_EX];
+        yield 'Modern ex — Iron Valiant ex' => ['Iron Valiant ex', 'Double rare', RuleboxType::POKEMON_EX];
+
+        // ── Classic plain EX ── name contains "-EX" or " EX" (Ruby & Sapphire era), no M prefix
+        yield 'Classic EX with hyphen — Charizard-EX' => ['Charizard-EX', 'Ultra Rare', RuleboxType::POKEMON_EX_CLASSIC];
+        yield 'Classic EX with hyphen — Dialga-EX' => ['Dialga-EX', 'Ultra Rare', RuleboxType::POKEMON_EX_CLASSIC];
+        yield 'Classic EX with hyphen — Latias-EX' => ['Latias-EX', 'Ultra Rare', RuleboxType::POKEMON_EX_CLASSIC];
+
+        // ── V / VMAX / VSTAR ── name suffix
+        yield 'V — Charizard V' => ['Charizard V', 'Holo Rare V', RuleboxType::POKEMON_V];
+        yield 'V — Medicham V' => ['Medicham V', 'Holo Rare V', RuleboxType::POKEMON_V];
+        yield 'VMAX — Charizard VMAX' => ['Charizard VMAX', 'Holo Rare VMAX', RuleboxType::POKEMON_VMAX];
+        yield 'VSTAR — Arceus VSTAR' => ['Arceus VSTAR', 'Holo Rare VSTAR', RuleboxType::POKEMON_VSTAR];
+
+        // ── GX ── name suffix " GX"
+        yield 'GX — Charizard GX' => ['Charizard GX', 'Ultra Rare', RuleboxType::POKEMON_GX];
+        yield 'GX — Dialga GX' => ['Dialga GX', 'Ultra Rare', RuleboxType::POKEMON_GX];
+
+        // ── G ── name suffix " G" (Team Galactic, Platinum era)
+        yield 'G — Dialga G' => ['Dialga G', 'Rare', RuleboxType::POKEMON_G];
+
+        // ── BREAK ── name suffix " BREAK"
+        yield 'BREAK — Chesnaught BREAK' => ['Chesnaught BREAK', 'Rare', RuleboxType::POKEMON_BREAK];
+
+        // ── Radiant ── name prefix "Radiant " (NOT a suffix)
+        yield 'Radiant — Radiant Charizard' => ['Radiant Charizard', 'Shiny rare', RuleboxType::POKEMON_RADIANT];
+        yield 'Radiant — Radiant Greninja' => ['Radiant Greninja', 'Shiny rare', RuleboxType::POKEMON_RADIANT];
+
+        // ── Prism Star ── name suffix " ◇" (diamond / prism-star symbol).
+        // Verify TCGdex encoding before implementing — the symbol may render as
+        // a different unicode codepoint or be omitted entirely from name fields.
+        yield 'Prism Star — Latias ◇' => ['Latias ◇', 'Rare', RuleboxType::PRISM_STAR];
+
+        // ── Ace Spec ── rarity = "ACE SPEC Rare". Already detected today; included here so
+        // the future-cases suite is self-contained for regression coverage.
+        yield 'Ace Spec — Unfair Stamp' => ['Unfair Stamp', 'ACE SPEC Rare', RuleboxType::ACE_SPEC];
+        yield 'Ace Spec — Brilliant Blender' => ['Brilliant Blender', 'ACE SPEC Rare', RuleboxType::ACE_SPEC];
+
+        // ── Negative cases ── must return null. These guard against name-pattern false-positives.
+        yield 'Plain Pokemon — Pikachu' => ['Pikachu', 'Common', null];
+        yield 'Plain Pokemon — Dialga base form' => ['Dialga', 'Rare', null];
+        yield 'False-positive guard — Marowak (M, no space)' => ['Marowak', 'Common', null];
+        yield 'False-positive guard — Magneton (M, no space)' => ['Magneton', 'Common', null];
+        yield 'False-positive guard — Goldeen (G, no space, name does not end in space-G)' => ['Goldeen', 'Common', null];
     }
 
     /**


### PR DESCRIPTION
## Summary

Foundation for issue #532 (Staple Cards). Lands the `CardIdentity.ruleboxType` schema change cleanly so PR-2 can build on top.

- **New `CardIdentity.ruleboxType`** (nullable VARCHAR(30)) captures the card's rulebox mechanic — Ace Spec, V/VMAX/VSTAR, ex/EX, GX, BREAK, Mega/Mega-classic, Radiant, Prism Star. Modeling rationale: rulebox is intrinsic to the card (one-per-deck rule for Ace Spec, etc.), not to the staple-cards curation, so it belongs on the canonical card-identity row rather than a feature-local table. Other future features (deck validation, archetype enrichment) can read it for free.
- **New `App\Constants\RuleboxType`** enumerates 13 known rulebox types as named constants. The class docblock maps each to its detection signal (rarity check vs name suffix vs name prefix) with edge-case notes — modern Mega coexists with the ` ex` suffix and must be checked first; classic Mega's strongest signal is `stage = 'MEGA'` (currently absent from the `TcgdexCard` struct, flagged for a future struct extension).
- **Modern Mega and classic Mega tracked separately**: `POKEMON_MEGA` for the S&V-era "Mega Charizard X ex" pattern, `POKEMON_MEGA_CLASSIC` for the XY-era "M Charizard EX" pattern. Same era split as `POKEMON_EX` vs `POKEMON_EX_CLASSIC` — the two mechanics aren't interchangeable.
- **`CardIdentityResolver` detects Ace Spec only** in this PR via the new public-static `detectRuleboxType()` helper (mirrors the visibility of `computeAbilitySignature` / `computeAttackSignature`). Detection runs during `findOrCreateIdentity()` for new identities, and backfills `ruleboxType` on existing ones with null values — same pattern as the existing `trainerType` backfill.
- **Migration `Version20260507204712`** adds the column and backfills the 4 currently-known Ace Spec identities (Brilliant Blender, Megaton Blower, Secret Box, Unfair Stamp) by joining `card_identity` to `card_printing.rarity = 'ACE SPEC Rare'`. The auto-generated drift from unrelated tables (banned_card index renames, sessions BLOB type, etc.) was stripped — this migration only touches `card_identity`.
- **6 new resolver tests:** direct method (Ace Spec / regular rarity / null rarity), new-identity-set, existing-backfill, no-overwrite, plus a `markTestSkipped` 27-row data-provider test enumerating the future detection cases for V/VMAX/VSTAR/ex/EX-classic/Mega/Mega-classic/G/GX/BREAK/Radiant/Prism plus collision and false-positive guards. The future-cases suite is the green target for the next PR that extends detection.

Detection of the other 12 rulebox types is deferred to follow-up PRs. Most are name-pattern based; the constants file documents the canonical signals so the next implementer doesn't have to re-derive them.

Refs #532

## Test plan

- [ ] CI green on this PR.
- [x] After merge + migration runs locally on dev DB: `SELECT name, rulebox_type FROM card_identity WHERE rulebox_type IS NOT NULL` returns exactly Brilliant Blender / Megaton Blower / Secret Box / Unfair Stamp, all `ace_spec`.
- [x] Existing card-resolution flows are unaffected: enrich a non-Ace-Spec deck via the dev environment and confirm the new `ruleboxType` stays null on the resolved identities.
- [x] Re-enrich a deck that contains an Ace Spec card and confirm the existing identity gets `ruleboxType = 'ace_spec'` via the backfill path (not just new-create).
- [ ] `make phpstan` is green at level 10.
- [ ] `make test.unit` is green; the future-cases data-provider test reports as 27 skipped (one per row).