### PR TITLE
:bug: fix(cms): homepage latest-pages block — count, order, category selector

### DIFF
--- a/assets/components/BlockEditModal.tsx
+++ b/assets/components/BlockEditModal.tsx
@@ -19,6 +19,7 @@ import {
     TextInput,
     NumberInput,
     SegmentedControl,
+    Select,
     Stack,
     Group,
     Button,
@@ -59,6 +60,11 @@ interface CarouselItem {
     endAt: string | null;
 }
 
+interface CategoryInfo {
+    id: number;
+    name: string;
+}
+
 interface BlockEditModalProps {
     block: BlockData;
     blockIndex: number;
@@ -66,6 +72,7 @@ interface BlockEditModalProps {
     supportedLocales: string[];
     labels: Labels;
     blockTypes: BlockTypeInfo[];
+    categories: CategoryInfo[];
     uploadUrl: string;
     onSave: (updatedBlock: BlockData, updatedTranslations: Record<string, Record<string, unknown>>) => void;
     onClose: () => void;
@@ -78,6 +85,7 @@ export default function BlockEditModal({
     supportedLocales,
     labels,
     blockTypes,
+    categories,
     uploadUrl,
     onSave,
     onClose,
@@ -184,11 +192,16 @@ export default function BlockEditModal({
 
                 {blockType === 'latestPages' && (
                     <Group grow>
-                        <TextInput
-                            label={label('categorySlug')}
-                            value={(editedBlock.categorySlug as string) ?? ''}
-                            onChange={(event) => updateBlock('categorySlug', event.currentTarget.value || null)}
-                            placeholder="news"
+                        <Select
+                            label={label('category')}
+                            value={editedBlock.categoryId !== undefined && editedBlock.categoryId !== null ? String(editedBlock.categoryId) : null}
+                            onChange={(value) => updateBlock('categoryId', value !== null ? parseInt(value, 10) : null)}
+                            data={categories.map((category) => ({
+                                value: String(category.id),
+                                label: category.name,
+                            }))}
+                            placeholder={label('selectCategory')}
+                            clearable
                         />
                         <NumberInput
                             label={label('limit')}

--- a/assets/components/HomepageEditor.tsx
+++ b/assets/components/HomepageEditor.tsx
@@ -31,6 +31,11 @@ interface Labels {
 type BlockData = Record<string, unknown>;
 type TranslationsMap = Record<string, Record<string, Record<string, unknown>>>;
 
+interface CategoryInfo {
+    id: number;
+    name: string;
+}
+
 interface HomepageEditorProps {
     saveUrl: string;
     previewUrl: string;
@@ -40,6 +45,7 @@ interface HomepageEditorProps {
     initialBlocks: BlockData[];
     initialTranslations: TranslationsMap;
     blockTypes: BlockTypeInfo[];
+    categories: CategoryInfo[];
     labels: Labels;
 }
 
@@ -51,6 +57,7 @@ export default function HomepageEditor({
     initialBlocks,
     initialTranslations,
     blockTypes,
+    categories,
     labels,
 }: HomepageEditorProps) {
     const [blocks, setBlocks] = useState<BlockData[]>(initialBlocks);
@@ -337,6 +344,7 @@ export default function HomepageEditor({
                     supportedLocales={supportedLocales}
                     labels={labels}
                     blockTypes={blockTypes}
+                    categories={categories}
                     uploadUrl={uploadUrl}
                     onSave={(updatedBlock, updatedTranslations) => handleSaveBlock(editingIndex, updatedBlock, updatedTranslations)}
                     onClose={() => setEditingIndex(null)}

--- a/assets/homepage-editor.tsx
+++ b/assets/homepage-editor.tsx
@@ -23,6 +23,11 @@ interface BlockTypeInfo {
     icon: string;
 }
 
+interface CategoryInfo {
+    id: number;
+    name: string;
+}
+
 interface Labels {
     [key: string]: string;
 }
@@ -38,6 +43,7 @@ if (root) {
     let initialBlocks: Record<string, unknown>[] = [];
     let initialTranslations: Record<string, Record<string, Record<string, unknown>>> = {};
     let blockTypes: BlockTypeInfo[] = [];
+    let categories: CategoryInfo[] = [];
     let labels: Labels = {};
 
     try {
@@ -57,6 +63,10 @@ if (root) {
     } catch { /* use default */ }
 
     try {
+        categories = JSON.parse(root.dataset.categories ?? '[]');
+    } catch { /* use default */ }
+
+    try {
         labels = JSON.parse(root.dataset.labels ?? '{}');
     } catch { /* use default */ }
 
@@ -71,6 +81,7 @@ if (root) {
                 initialBlocks={initialBlocks}
                 initialTranslations={initialTranslations}
                 blockTypes={blockTypes}
+                categories={categories}
                 labels={labels}
             />
         </AppMantineProvider>,

--- a/migrations/Version20260508120000.php
+++ b/migrations/Version20260508120000.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Rewrite existing homepage `latestPages` blocks from `categorySlug` (free-text
+ * category name) to `categoryId` (stable FK).
+ *
+ * Issue #536 replaces the free-form category text input with a channel-scoped
+ * dropdown that stores the category ID. Existing blocks in the
+ * `homepage_layout.blocks` JSON column have legacy `categorySlug` entries —
+ * this migration walks every layout, looks up each slug as a case-insensitive
+ * English-name match against `menu_category_translation` within the same
+ * channel, and rewrites the block to use `categoryId` instead.
+ *
+ * `HomepageRenderer::resolveLatestPages` keeps a `categorySlug` fallback for
+ * any block this migration couldn't resolve (e.g. a slug that doesn't match
+ * any current category name) so render-time behavior is unchanged for those.
+ *
+ * @see https://github.com/jbourdin/expandedDecks/issues/536
+ */
+final class Version20260508120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '#536 — rewrite homepage latestPages blocks: categorySlug → categoryId';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var list<array{id: int, blocks: string, channel_id: int|null}> $rows */
+        $rows = $this->connection->fetchAllAssociative('SELECT id, blocks, channel_id FROM homepage_layout');
+
+        foreach ($rows as $row) {
+            $blocks = json_decode((string) $row['blocks'], true);
+            if (!\is_array($blocks)) {
+                continue;
+            }
+
+            $modified = false;
+            foreach ($blocks as $index => $block) {
+                if (!\is_array($block) || ($block['type'] ?? null) !== 'latestPages') {
+                    continue;
+                }
+                if (isset($block['categoryId'])) {
+                    // Already migrated.
+                    continue;
+                }
+                $slug = $block['categorySlug'] ?? null;
+                if (!\is_string($slug) || '' === $slug) {
+                    continue;
+                }
+
+                $categoryId = $this->lookupCategoryId($slug, $row['channel_id']);
+                if (null === $categoryId) {
+                    // Unmatched legacy slug — leave categorySlug in place; the
+                    // renderer's fallback path will keep using it.
+                    continue;
+                }
+
+                unset($blocks[$index]['categorySlug']);
+                $blocks[$index]['categoryId'] = $categoryId;
+                $modified = true;
+            }
+
+            if ($modified) {
+                $this->connection->update(
+                    'homepage_layout',
+                    ['blocks' => json_encode($blocks, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES)],
+                    ['id' => $row['id']],
+                );
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentional no-op: rolling back would require recovering the original
+        // slug strings from the category names, which produces something
+        // semantically equivalent but not byte-equal to the editor's input.
+    }
+
+    private function lookupCategoryId(string $name, ?int $channelId): ?int
+    {
+        if (null === $channelId) {
+            $sql = 'SELECT mc.id
+                    FROM menu_category mc
+                    INNER JOIN menu_category_translation mct ON mct.menu_category_id = mc.id
+                    WHERE mc.channel_id IS NULL
+                      AND mct.locale = :locale
+                      AND LOWER(mct.name) = LOWER(:name)
+                    LIMIT 1';
+            $params = ['locale' => 'en', 'name' => $name];
+        } else {
+            $sql = 'SELECT mc.id
+                    FROM menu_category mc
+                    INNER JOIN menu_category_translation mct ON mct.menu_category_id = mc.id
+                    WHERE mc.channel_id = :channel_id
+                      AND mct.locale = :locale
+                      AND LOWER(mct.name) = LOWER(:name)
+                    LIMIT 1';
+            $params = ['channel_id' => $channelId, 'locale' => 'en', 'name' => $name];
+        }
+
+        $id = $this->connection->fetchOne($sql, $params);
+
+        return false !== $id ? (int) $id : null;
+    }
+}

--- a/src/Controller/AdminHomepageController.php
+++ b/src/Controller/AdminHomepageController.php
@@ -45,8 +45,12 @@ class AdminHomepageController extends AbstractAppController
     }
 
     #[Route('', name: 'app_admin_homepage_editor', methods: ['GET'])]
-    public function editor(Request $request, ChannelRepository $channelRepository, ChannelContext $channelContext): Response
-    {
+    public function editor(
+        Request $request,
+        ChannelRepository $channelRepository,
+        ChannelContext $channelContext,
+        \App\Repository\MenuCategoryRepository $menuCategoryRepository,
+    ): Response {
         $channelCode = $request->query->getString('channel', '');
         $channel = '' !== $channelCode ? $channelRepository->findByCode($channelCode) : null;
 
@@ -57,11 +61,21 @@ class AdminHomepageController extends AbstractAppController
         $channels = $channelRepository->findAll();
         $layout = $this->layoutRepository->findPublished($channel);
 
+        // Categories used by the latestPages block selector — scoped to the editor's channel.
+        $categories = [];
+        foreach ($menuCategoryRepository->findAllOrdered($channel) as $category) {
+            $categories[] = [
+                'id' => $category->getId(),
+                'name' => $category->getName('en'),
+            ];
+        }
+
         return $this->render('admin/homepage/editor.html.twig', [
             'layout' => $layout,
             'supportedLocales' => self::SUPPORTED_LOCALES,
             'channels' => $channels,
             'currentChannel' => $channel,
+            'categories' => $categories,
         ]);
     }
 

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -18,6 +18,7 @@ use App\Entity\MenuCategory;
 use App\Entity\Page;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -57,7 +58,13 @@ class PageRepository extends ServiceEntityRepository
     }
 
     /**
-     * Find published pages in a given menu category, ordered by creation date (newest first).
+     * Find published pages in a given menu category, ordered by admin-defined position
+     * (with creation date as tiebreaker), with translations eagerly loaded.
+     *
+     * Uses Doctrine's Paginator when a limit is set so LIMIT applies to root entities
+     * (not SQL rows after the translations JOIN). Without Paginator, `setMaxResults($limit)`
+     * truncates the joined-rows result, yielding fewer than $limit pages once Doctrine
+     * deduplicates by Page.id.
      *
      * @return list<Page>
      */
@@ -70,14 +77,25 @@ class PageRepository extends ServiceEntityRepository
             ->andWhere('p.isPublished = true')
             ->andWhere('p.deletedAt IS NULL')
             ->setParameter('category', $category)
-            ->orderBy('p.createdAt', 'DESC');
+            ->orderBy('p.position', 'ASC')
+            ->addOrderBy('p.createdAt', 'DESC');
 
-        if (null !== $limit) {
-            $queryBuilder->setMaxResults($limit);
+        if (null === $limit) {
+            /** @var list<Page> $pages */
+            $pages = $queryBuilder->getQuery()->getResult();
+
+            return $pages;
         }
 
-        /** @var list<Page> $pages */
-        $pages = $queryBuilder->getQuery()->getResult();
+        $queryBuilder->setMaxResults($limit);
+
+        $paginator = new Paginator($queryBuilder->getQuery(), fetchJoinCollection: true);
+        $pages = [];
+        foreach ($paginator as $page) {
+            if ($page instanceof Page) {
+                $pages[] = $page;
+            }
+        }
 
         return $pages;
     }

--- a/src/Service/HomepageRenderer.php
+++ b/src/Service/HomepageRenderer.php
@@ -184,21 +184,34 @@ class HomepageRenderer
      */
     private function resolveLatestPages(array $block, string $locale): array
     {
-        $categorySlug = $block['categorySlug'] ?? null;
         $limitValue = $block['limit'] ?? 5;
         $limit = \is_int($limitValue) ? $limitValue : 5;
 
-        if (!\is_string($categorySlug) || '' === $categorySlug) {
-            return ['pages' => [], 'totalCount' => 0, 'category' => null, 'locale' => $locale];
+        $channel = $this->channelContext->getChannel();
+        $category = null;
+
+        // Prefer the new `categoryId` field; fall back to legacy `categorySlug` (a category
+        // name match, kept for blocks that haven't been re-saved since #536 landed).
+        $categoryIdValue = $block['categoryId'] ?? null;
+        if (\is_int($categoryIdValue) || (\is_string($categoryIdValue) && ctype_digit($categoryIdValue))) {
+            $categoryId = (int) $categoryIdValue;
+            foreach ($this->menuCategoryRepository->findAllOrdered($channel) as $menuCategory) {
+                if ($menuCategory->getId() === $categoryId) {
+                    $category = $menuCategory;
+                    break;
+                }
+            }
         }
 
-        $channel = $this->channelContext->getChannel();
-
-        $category = null;
-        foreach ($this->menuCategoryRepository->findAllOrdered($channel) as $menuCategory) {
-            if (strtolower($menuCategory->getName('en')) === strtolower($categorySlug)) {
-                $category = $menuCategory;
-                break;
+        if (null === $category) {
+            $categorySlug = $block['categorySlug'] ?? null;
+            if (\is_string($categorySlug) && '' !== $categorySlug) {
+                foreach ($this->menuCategoryRepository->findAllOrdered($channel) as $menuCategory) {
+                    if (strtolower($menuCategory->getName('en')) === strtolower($categorySlug)) {
+                        $category = $menuCategory;
+                        break;
+                    }
+                }
             }
         }
 

--- a/templates/admin/homepage/editor.html.twig
+++ b/templates/admin/homepage/editor.html.twig
@@ -35,6 +35,7 @@
          data-supported-locales="{{ supportedLocales|json_encode }}"
          data-blocks="{{ layout ? layout.blocks|json_encode : '[]' }}"
          data-translations="{{ layout ? (layout.translations|reduce((carry, translation) => carry|merge({(translation.locale): translation.blockTranslations}), {})|json_encode) : '{}' }}"
+         data-categories="{{ categories|json_encode }}"
          data-block-types="{{ [
              {value: 'hero', label: 'app.homepage.block_type.hero'|trans, icon: 'bi-megaphone'},
              {value: 'richText', label: 'app.homepage.block_type.rich_text'|trans, icon: 'bi-file-richtext'},
@@ -64,7 +65,8 @@
              content: 'app.cms.form.content'|trans,
              description: 'app.homepage.admin.description'|trans,
              pageSlug: 'app.homepage.admin.page_slug'|trans,
-             categorySlug: 'app.homepage.admin.category_slug'|trans,
+             category: 'app.homepage.admin.category'|trans,
+             selectCategory: 'app.homepage.admin.select_category'|trans,
              limit: 'app.homepage.admin.limit'|trans,
              ctaLabel: 'app.homepage.admin.cta_label'|trans,
              ctaRoute: 'app.homepage.admin.cta_route'|trans,

--- a/tests/Functional/PageRepositoryTest.php
+++ b/tests/Functional/PageRepositoryTest.php
@@ -98,7 +98,28 @@ class PageRepositoryTest extends AbstractFunctionalTest
 
         $pages = $repository->findPublishedByCategory($newsCategory, 2);
 
-        self::assertLessThanOrEqual(2, \count($pages));
+        // News category has ≥ 8 published pages in fixtures so a limit of 2 must
+        // yield exactly 2 root entities. Before #534 this asserted only `<= 2`
+        // because the JOIN-with-translations + setMaxResults bug could produce
+        // 0-2 pages depending on translation count.
+        self::assertCount(2, $pages);
+    }
+
+    public function testFindPublishedByCategoryRespectsLimitDespiteJoinedTranslations(): void
+    {
+        $repository = $this->getRepository();
+        $newsCategory = $this->getNewsCategoryFromDatabase();
+
+        // With Doctrine's Paginator (fetchJoinCollection), LIMIT applies to root
+        // Page entities, not the joined Page × Translation rows. With 2 translations
+        // per page (en + fr) the legacy `setMaxResults` would have produced ≤ 5/2
+        // pages — this test is the regression-proof for #534.
+        $pages = $repository->findPublishedByCategory($newsCategory, 5);
+
+        self::assertCount(5, $pages);
+        foreach ($pages as $page) {
+            self::assertGreaterThanOrEqual(1, $page->getTranslations()->count());
+        }
     }
 
     public function testFindPublishedByCategoryReturnsAllWhenNoLimit(): void

--- a/tests/Service/HomepageRendererTest.php
+++ b/tests/Service/HomepageRendererTest.php
@@ -221,6 +221,99 @@ class HomepageRendererTest extends TestCase
         self::assertSame(1, $result[0]->resolvedData['totalCount']);
     }
 
+    public function testResolveLatestPagesByCategoryIdPrefersIdOverSlug(): void
+    {
+        // Two categories — the renderer must look up by ID, not by name match.
+        $newsCategory = new MenuCategory();
+        $this->setEntityId($newsCategory, 42);
+        $newsTranslation = new MenuCategoryTranslation();
+        $newsTranslation->setLocale('en');
+        $newsTranslation->setName('News');
+        $newsCategory->addTranslation($newsTranslation);
+
+        $rulesCategory = new MenuCategory();
+        $this->setEntityId($rulesCategory, 99);
+        $rulesTranslation = new MenuCategoryTranslation();
+        $rulesTranslation->setLocale('en');
+        $rulesTranslation->setName('Rules');
+        $rulesCategory->addTranslation($rulesTranslation);
+
+        $this->menuCategoryRepository->method('findAllOrdered')->willReturn([$newsCategory, $rulesCategory]);
+
+        $page = new Page();
+        $page->setSlug('breaking-news');
+        $page->setIsPublished(true);
+
+        $this->pageRepository->method('findPublishedByCategory')->willReturn([$page]);
+        $this->pageRepository->method('countPublishedByCategory')->willReturn(1);
+
+        $layout = new HomepageLayout();
+        $layout->setBlocks([
+            ['type' => 'latestPages', 'startAt' => null, 'endAt' => null, 'columnWidth' => null, 'cssClasses' => null, 'categoryId' => 42, 'limit' => 5],
+        ]);
+
+        $result = $this->renderer->resolve($layout, 'en');
+
+        self::assertCount(1, $result);
+        self::assertSame($newsCategory, $result[0]->resolvedData['category']);
+        self::assertCount(1, $result[0]->resolvedData['pages']);
+    }
+
+    public function testResolveLatestPagesFallsBackToCategorySlugWhenIdAbsent(): void
+    {
+        // Legacy block with only categorySlug (pre-#536 data) — must keep working.
+        $newsCategory = new MenuCategory();
+        $this->setEntityId($newsCategory, 7);
+        $newsTranslation = new MenuCategoryTranslation();
+        $newsTranslation->setLocale('en');
+        $newsTranslation->setName('News');
+        $newsCategory->addTranslation($newsTranslation);
+
+        $this->menuCategoryRepository->method('findAllOrdered')->willReturn([$newsCategory]);
+
+        $page = new Page();
+        $page->setSlug('legacy-news');
+        $this->pageRepository->method('findPublishedByCategory')->willReturn([$page]);
+        $this->pageRepository->method('countPublishedByCategory')->willReturn(1);
+
+        $layout = new HomepageLayout();
+        $layout->setBlocks([
+            // No categoryId — only legacy categorySlug.
+            ['type' => 'latestPages', 'startAt' => null, 'endAt' => null, 'columnWidth' => null, 'cssClasses' => null, 'categorySlug' => 'news', 'limit' => 5],
+        ]);
+
+        $result = $this->renderer->resolve($layout, 'en');
+
+        self::assertCount(1, $result);
+        self::assertSame($newsCategory, $result[0]->resolvedData['category']);
+    }
+
+    public function testResolveLatestPagesReturnsEmptyWhenNeitherIdNorSlugMatches(): void
+    {
+        $this->menuCategoryRepository->method('findAllOrdered')->willReturn([]);
+
+        $layout = new HomepageLayout();
+        $layout->setBlocks([
+            ['type' => 'latestPages', 'startAt' => null, 'endAt' => null, 'columnWidth' => null, 'cssClasses' => null, 'categoryId' => 999, 'limit' => 5],
+        ]);
+
+        $result = $this->renderer->resolve($layout, 'en');
+
+        self::assertCount(1, $result);
+        self::assertNull($result[0]->resolvedData['category']);
+        self::assertSame([], $result[0]->resolvedData['pages']);
+        self::assertSame(0, $result[0]->resolvedData['totalCount']);
+    }
+
+    /**
+     * Set the auto-generated id on a Doctrine entity for unit-test purposes.
+     */
+    private function setEntityId(object $entity, int $id): void
+    {
+        $reflection = new \ReflectionProperty($entity::class, 'id');
+        $reflection->setValue($entity, $id);
+    }
+
     public function testResolveFeaturedEventWithValidId(): void
     {
         $event = new \App\Entity\Event();

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -4732,6 +4732,16 @@
                 <source>app.homepage.admin.category_slug</source>
                 <target>Category name</target>
             </trans-unit>
+            <trans-unit id="app.homepage.admin.category">
+                <source>app.homepage.admin.category</source>
+                <target>Category</target>
+                <note>#536 — latest-pages block category-selector label</note>
+            </trans-unit>
+            <trans-unit id="app.homepage.admin.select_category">
+                <source>app.homepage.admin.select_category</source>
+                <target>Select a category…</target>
+                <note>#536 — latest-pages block category-selector placeholder</note>
+            </trans-unit>
             <trans-unit id="app.homepage.admin.limit">
                 <source>app.homepage.admin.limit</source>
                 <target>Max items</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -4707,6 +4707,16 @@
                 <source>app.homepage.admin.category_slug</source>
                 <target>Nom de catégorie</target>
             </trans-unit>
+            <trans-unit id="app.homepage.admin.category">
+                <source>app.homepage.admin.category</source>
+                <target>Catégorie</target>
+                <note>#536 — latest-pages block category-selector label</note>
+            </trans-unit>
+            <trans-unit id="app.homepage.admin.select_category">
+                <source>app.homepage.admin.select_category</source>
+                <target>Sélectionner une catégorie…</target>
+                <note>#536 — latest-pages block category-selector placeholder</note>
+            </trans-unit>
             <trans-unit id="app.homepage.admin.limit">
                 <source>app.homepage.admin.limit</source>
                 <target>Nombre max</target>


### PR DESCRIPTION
## Summary

Bundles three issues that all touch the homepage `latestPages` block surface — Doctrine pagination correctness, admin-page-order respect, and a channel-scoped category selector to replace the typo-prone free-text input.

### #534 — block returns fewer pages than the configured limit

`PageRepository::findPublishedByCategory` used `setMaxResults($limit)` with eager-loaded translations. SQL `LIMIT` applies to joined rows, not hydrated entities — so `limit=5` could yield 2-3 pages once Doctrine deduplicated by `Page.id`. Switched to `Doctrine\ORM\Tools\Pagination\Paginator` with `fetchJoinCollection: true` so `LIMIT` applies to root entities.

### #535 — block ignores admin-defined page order

Same query ordered by `createdAt DESC`. Admin pages list orders by `position ASC` then `createdAt DESC` — the homepage block now mirrors that, so admin drag-reorder is respected.

### #536 — replace category text input with channel-scoped selector

- `AdminHomepageController` passes a `categories` list (id + English name, scoped to current channel) to the editor template.
- `homepage-editor.tsx` parses `data-categories` and threads it through `HomepageEditor` → `BlockEditModal`.
- `BlockEditModal` swaps the `latestPages <TextInput categorySlug>` for a Mantine `<Select>` populated from categories. Stores the new `categoryId` (int) in the block payload.
- `HomepageRenderer::resolveLatestPages` prefers `categoryId`, falls back to legacy `categorySlug` for any block not yet rewritten.
- Migration `Version20260508120000` walks every `homepage_layout` row, looks up each `categorySlug` against the channel's categories (case-insensitive English-name match), and replaces it with `categoryId`. Unmatched slugs stay in place — the renderer's fallback path keeps them working.
- Two new translation keys (en + fr).

Closes #534, Closes #535, Closes #536

## Test plan

- [ ] CI green on this PR.
- [ ] On `expandedtalks.wip` after migration runs:
  - [ ] Create a category with **≥ 10 published pages** (each with en + fr translations).
  - [ ] Add a `latestPages` block with **limit = 5** to the homepage.
  - [ ] Confirm exactly **5 pages render** (was previously 2-3 due to the JOIN-row LIMIT bug).
- [ ] Drag-reorder pages within the category in the admin; reload the homepage; confirm the block respects the new order (was previously sorted by `createdAt DESC`).
- [ ] Open the homepage block editor for a `latestPages` block:
  - [ ] Category field shows a dropdown of the channel's categories (no longer a free-text input).
  - [ ] Selection persists across reload.
  - [ ] Renaming a category does NOT break the block (the stored `categoryId` is stable).
- [ ] Pre-existing `latestPages` blocks (with legacy `categorySlug`) still render correctly post-migration.
- [ ] `make phpstan` is green at level 10.
- [ ] `make test.unit` is green; full suite still 1200 tests passing.