### PR TITLE
:bug: fix(cms): rich text external links open in new tab

### DIFF
--- a/src/Service/MarkdownRenderer.php
+++ b/src/Service/MarkdownRenderer.php
@@ -17,6 +17,7 @@ use League\CommonMark\Environment\Environment;
 use League\CommonMark\Exception\CommonMarkException;
 use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
 
@@ -33,10 +34,20 @@ class MarkdownRenderer
         $environment = new Environment([
             'html_input' => 'strip',
             'allow_unsafe_links' => false,
+            // External links open in a new tab and gain rel="noopener noreferrer" to
+            // prevent tab-nabbing. Internal links (no host or matching one of the
+            // hosts in `internal_hosts`) keep their default in-tab behaviour.
+            'external_link' => [
+                'open_in_new_window' => true,
+                'nofollow' => '',
+                'noopener' => 'external',
+                'noreferrer' => 'external',
+            ],
         ]);
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new TableExtension());
         $environment->addExtension(new AttributesExtension());
+        $environment->addExtension(new ExternalLinkExtension());
 
         $this->converter = new MarkdownConverter($environment);
     }

--- a/tests/Service/MarkdownRendererTest.php
+++ b/tests/Service/MarkdownRendererTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service;
+
+use App\Service\MarkdownRenderer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see https://github.com/jbourdin/expandedDecks/issues/537
+ */
+class MarkdownRendererTest extends TestCase
+{
+    public function testExternalLinkGetsTargetBlankAndRel(): void
+    {
+        $renderer = new MarkdownRenderer();
+
+        $html = $renderer->render('[example](https://example.com)');
+
+        self::assertStringContainsString('target="_blank"', $html);
+        self::assertStringContainsString('rel="noopener noreferrer"', $html);
+        self::assertStringContainsString('href="https://example.com"', $html);
+    }
+
+    public function testExternalLinkPreservesNoopenerNoreferrer(): void
+    {
+        $renderer = new MarkdownRenderer();
+
+        // Inspect the full rel attribute value — order isn't guaranteed by CommonMark
+        // so check both tokens are present.
+        $html = $renderer->render('See [the docs](https://docs.example.org/foo).');
+
+        self::assertMatchesRegularExpression('/rel="[^"]*\bnoopener\b/', $html);
+        self::assertMatchesRegularExpression('/rel="[^"]*\bnoreferrer\b/', $html);
+    }
+
+    public function testRelativeLinkDoesNotGetTargetBlank(): void
+    {
+        $renderer = new MarkdownRenderer();
+
+        // Internal/relative links should NOT open in a new tab — only external ones.
+        $html = $renderer->render('[contact](/contact)');
+
+        self::assertStringNotContainsString('target="_blank"', $html);
+        self::assertStringContainsString('href="/contact"', $html);
+    }
+
+    public function testJavascriptLinkIsStripped(): void
+    {
+        $renderer = new MarkdownRenderer();
+
+        // `allow_unsafe_links: false` (kept from the previous config) prevents
+        // javascript: hrefs from being rendered as a usable link.
+        $html = $renderer->render('[click](javascript:alert(1))');
+
+        self::assertStringNotContainsString('javascript:', $html);
+    }
+}


### PR DESCRIPTION
## Summary

The rich text editor's "open in new tab" per-link option was being stripped on render. Links rendered via `MarkdownRenderer` came out as plain `<a href="...">` with no `target` or `rel`, regardless of the editor's choice.

Fix: add `League\CommonMark\Extension\ExternalLink\ExternalLinkExtension` to the renderer, configured to:

- `open_in_new_window: true` — every external link renders with `target="_blank"`.
- `noopener: 'external'` + `noreferrer: 'external'` — `rel="noopener noreferrer"` prevents tab-nabbing on external links.

External is anything whose host doesn't match the (currently empty) `internal_hosts` list. Relative links and same-host links keep their default in-tab behaviour.

This sidesteps the per-link "open in new tab" UI question entirely — external links always open externally, which matches reader expectations from CMS-rendered content. Internal links behave as before.

Closes #537

## Test plan

- [ ] CI green on this PR.
- [ ] In the homepage rich-text block (or any CMS page using `MarkdownRenderer`), add an external link (e.g. `https://example.com`) and a relative link (e.g. `/contact`).
- [ ] Save and reload the public page.
- [ ] Inspect the rendered `<a>` tags:
  - [ ] External link has `target="_blank"` AND `rel="noopener noreferrer"`.
  - [ ] Relative link has neither (still opens in current tab).
- [ ] Unit tests pass: `MarkdownRendererTest` covers external-link target+rel, relative-link no-target, and that javascript: hrefs are still stripped by the existing `allow_unsafe_links: false`.