### PR TITLE
:zap: Perf: eager-load staple-cards page relations

### DIFF
--- a/src/Controller/StapleCardController.php
+++ b/src/Controller/StapleCardController.php
@@ -53,14 +53,11 @@ class StapleCardController extends AbstractController
 
         $locale = $request->getLocale();
 
-        $cardsByBucket = [];
+        $cardsByBucket = $stapleCardRepository->findActiveGroupedByBucket(StapleCardBucket::ORDER, $minHotness);
         $imageUrls = [];
         $renderedNotes = [];
 
-        foreach (StapleCardBucket::ORDER as $bucket) {
-            $cards = $stapleCardRepository->findActiveByBucket($bucket, $minHotness);
-            $cardsByBucket[$bucket] = $cards;
-
+        foreach ($cardsByBucket as $cards) {
             foreach ($cards as $card) {
                 $id = $card->getId();
                 if (null === $id) {

--- a/src/Repository/StapleCardRepository.php
+++ b/src/Repository/StapleCardRepository.php
@@ -57,6 +57,64 @@ class StapleCardRepository extends ServiceEntityRepository
     }
 
     /**
+     * Active staples across the given buckets, with the relations needed to render the public
+     * list page eager-loaded in a single query. Returns cards grouped by bucket in the order
+     * the buckets were provided, then by position and cardName within each bucket.
+     *
+     * The eager fetch covers: representativePrinting → tcgdexCard → set → serie, and the
+     * printings collection → cardPrinting → tcgdexCard → set → serie. Without this, rendering
+     * the page issues one query per card for each lazy-loaded relation (N+1).
+     *
+     * @param list<string> $buckets
+     *
+     * @return array<string, list<StapleCard>>
+     */
+    public function findActiveGroupedByBucket(array $buckets, ?int $minHotness = null): array
+    {
+        if ([] === $buckets) {
+            return [];
+        }
+
+        $qb = $this->createQueryBuilder('sc')
+            ->addSelect('representativePrinting', 'representativeTcgdexCard', 'representativeSet', 'representativeSerie')
+            ->addSelect('staplePrinting', 'staplePrintingCard', 'staplePrintingTcgdexCard', 'staplePrintingSet', 'staplePrintingSerie')
+            ->leftJoin('sc.representativePrinting', 'representativePrinting')
+            ->leftJoin('representativePrinting.tcgdexCard', 'representativeTcgdexCard')
+            ->leftJoin('representativeTcgdexCard.set', 'representativeSet')
+            ->leftJoin('representativeSet.serie', 'representativeSerie')
+            ->leftJoin('sc.printings', 'staplePrinting')
+            ->leftJoin('staplePrinting.cardPrinting', 'staplePrintingCard')
+            ->leftJoin('staplePrintingCard.tcgdexCard', 'staplePrintingTcgdexCard')
+            ->leftJoin('staplePrintingTcgdexCard.set', 'staplePrintingSet')
+            ->leftJoin('staplePrintingSet.serie', 'staplePrintingSerie')
+            ->andWhere('sc.bucket IN (:buckets)')
+            ->andWhere('sc.deletedAt IS NULL')
+            ->setParameter('buckets', $buckets)
+            ->orderBy('sc.bucket', 'ASC')
+            ->addOrderBy('sc.position', 'ASC')
+            ->addOrderBy('sc.cardName', 'ASC');
+
+        if (null !== $minHotness) {
+            $qb->andWhere('sc.hotness >= :minHotness')
+                ->setParameter('minHotness', $minHotness);
+        }
+
+        /** @var list<StapleCard> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        /** @var array<string, list<StapleCard>> $grouped */
+        $grouped = array_fill_keys($buckets, []);
+        foreach ($rows as $card) {
+            $bucket = $card->getBucket();
+            if (\array_key_exists($bucket, $grouped)) {
+                $grouped[$bucket][] = $card;
+            }
+        }
+
+        return $grouped;
+    }
+
+    /**
      * Soft-deleted staples ordered by deletion date desc. Used by the admin "history" tab.
      *
      * @return list<StapleCard>


### PR DESCRIPTION
## Summary

The public **/staple-cards** page issued **83 DB queries** to render — a classic N+1 caused by lazy-loading `representativePrinting`, the `printings` collection, and the chained `cardPrinting → tcgdexCard → set → serie` walks inside `StapleCardImageResolver`.

This PR adds `StapleCardRepository::findActiveGroupedByBucket()`, which fetches every active staple across every bucket in **one** DQL with all the relations the controller and image resolver need, and refactors the controller to call it once instead of looping `findActiveByBucket()` seven times.

## Impact (local profile, 37-card fixture)

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| DB queries | 83 | **3** | -96% |
| DB time (local MySQL) | 40.99 ms | 3.13 ms | -92% |
| Steady-state TTFB | ~180 ms | ~95 ms | -47% |
| Cold TTFB | ~270 ms | ~200 ms | -27% |
| Response body | 124,691 B | 124,691 B | byte-identical |

In production the 80 saved round-trips × ~7 ms RTT to Scaleway managed MySQL ≈ **0.5–0.6 s** off the page.

## Why this approach

- Fixing the root cause (eager fetch) over masking it (HTTP cache) avoids the cache-invalidation tax tied to admin staple mutations.
- A single `JOIN FETCH` query has acceptable row width here (~37 cards × few printings) — no Cartesian explosion because there's only one OneToMany branch.

## Test plan

- [x] PHPStan Level 10 — no errors
- [x] PHP-CS-Fixer — clean
- [x] Full PHPUnit suite (2273 tests) — all green
- [x] Local manual verification — Symfony Profiler confirms 3 queries, body is byte-identical pre/post
- [ ] Reviewer: visit `/en/staple-cards` on `expandedtalks.wip` and confirm the grid + modal render unchanged