### PR TITLE
:rocket: Release: 1.12.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,16 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.12.1] — 2026-05-08
+
+Patch release: eliminate the N+1 on the public **Staple Cards** page.
+
+### Performance
+
+- **Eager-load relations on `/staple-cards`** — the public list page issued **83 DB queries** to render a 7-bucket / ~37-card layout, dominated by per-card lazy loads of `representativePrinting`, the `printings` collection, and the `cardPrinting → tcgdexCard → set → serie` walks inside `StapleCardImageResolver`. New `StapleCardRepository::findActiveGroupedByBucket()` fetches every active staple across every bucket in **one** DQL with `LEFT JOIN`s on the full relation graph the controller and image resolver consume; `StapleCardController::list` calls it once instead of looping `findActiveByBucket()` per bucket. Local profile: 83 → **3** queries (-96%), TTFB 180 → 95 ms. On Scaleway managed MySQL the ~80 saved round-trips × ~7 ms RTT shave **~0.5–0.6 s** off page load. Response body is byte-identical pre/post. ([#542](https://github.com/jbourdin/expandedDecks/pull/542))
+
+---
+
 ## [1.12.0] — 2026-05-08
 
 Minor release: editor-curated **Staple Cards** (F6.15) ship as a full feature — admin CRUD, public per-bucket grids, technical re-enrich, 36 seeded entries from the editor team. Plus the user-controlled **light/dark/auto theme switcher** (F20.1 follow-up), four homepage / CMS bug fixes (latest-pages block accuracy, ordering, category selector, rich text new-tab links), and a dark-mode heading fix.

--- a/src/Controller/StapleCardController.php
+++ b/src/Controller/StapleCardController.php
@@ -53,14 +53,11 @@ class StapleCardController extends AbstractController
 
         $locale = $request->getLocale();
 
-        $cardsByBucket = [];
+        $cardsByBucket = $stapleCardRepository->findActiveGroupedByBucket(StapleCardBucket::ORDER, $minHotness);
         $imageUrls = [];
         $renderedNotes = [];
 
-        foreach (StapleCardBucket::ORDER as $bucket) {
-            $cards = $stapleCardRepository->findActiveByBucket($bucket, $minHotness);
-            $cardsByBucket[$bucket] = $cards;
-
+        foreach ($cardsByBucket as $cards) {
             foreach ($cards as $card) {
                 $id = $card->getId();
                 if (null === $id) {

--- a/src/Repository/StapleCardRepository.php
+++ b/src/Repository/StapleCardRepository.php
@@ -57,6 +57,64 @@ class StapleCardRepository extends ServiceEntityRepository
     }
 
     /**
+     * Active staples across the given buckets, with the relations needed to render the public
+     * list page eager-loaded in a single query. Returns cards grouped by bucket in the order
+     * the buckets were provided, then by position and cardName within each bucket.
+     *
+     * The eager fetch covers: representativePrinting → tcgdexCard → set → serie, and the
+     * printings collection → cardPrinting → tcgdexCard → set → serie. Without this, rendering
+     * the page issues one query per card for each lazy-loaded relation (N+1).
+     *
+     * @param list<string> $buckets
+     *
+     * @return array<string, list<StapleCard>>
+     */
+    public function findActiveGroupedByBucket(array $buckets, ?int $minHotness = null): array
+    {
+        if ([] === $buckets) {
+            return [];
+        }
+
+        $qb = $this->createQueryBuilder('sc')
+            ->addSelect('representativePrinting', 'representativeTcgdexCard', 'representativeSet', 'representativeSerie')
+            ->addSelect('staplePrinting', 'staplePrintingCard', 'staplePrintingTcgdexCard', 'staplePrintingSet', 'staplePrintingSerie')
+            ->leftJoin('sc.representativePrinting', 'representativePrinting')
+            ->leftJoin('representativePrinting.tcgdexCard', 'representativeTcgdexCard')
+            ->leftJoin('representativeTcgdexCard.set', 'representativeSet')
+            ->leftJoin('representativeSet.serie', 'representativeSerie')
+            ->leftJoin('sc.printings', 'staplePrinting')
+            ->leftJoin('staplePrinting.cardPrinting', 'staplePrintingCard')
+            ->leftJoin('staplePrintingCard.tcgdexCard', 'staplePrintingTcgdexCard')
+            ->leftJoin('staplePrintingTcgdexCard.set', 'staplePrintingSet')
+            ->leftJoin('staplePrintingSet.serie', 'staplePrintingSerie')
+            ->andWhere('sc.bucket IN (:buckets)')
+            ->andWhere('sc.deletedAt IS NULL')
+            ->setParameter('buckets', $buckets)
+            ->orderBy('sc.bucket', 'ASC')
+            ->addOrderBy('sc.position', 'ASC')
+            ->addOrderBy('sc.cardName', 'ASC');
+
+        if (null !== $minHotness) {
+            $qb->andWhere('sc.hotness >= :minHotness')
+                ->setParameter('minHotness', $minHotness);
+        }
+
+        /** @var list<StapleCard> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        /** @var array<string, list<StapleCard>> $grouped */
+        $grouped = array_fill_keys($buckets, []);
+        foreach ($rows as $card) {
+            $bucket = $card->getBucket();
+            if (\array_key_exists($bucket, $grouped)) {
+                $grouped[$bucket][] = $card;
+            }
+        }
+
+        return $grouped;
+    }
+
+    /**
      * Soft-deleted staples ordered by deletion date desc. Used by the admin "history" tab.
      *
      * @return list<StapleCard>


### PR DESCRIPTION
## Summary

Patch release: eliminate the N+1 on the public **Staple Cards** page.

### Performance

- **Eager-load relations on `/staple-cards`** ([#542](https://github.com/jbourdin/expandedDecks/pull/542)) — public list page dropped from **83 DB queries to 3** (-96%), TTFB 180 → 95 ms locally. On Scaleway managed MySQL the ~80 saved round-trips × ~7 ms RTT shave ~0.5–0.6 s off page load. Response body is byte-identical pre/post.

## Test plan

- [x] CI green on the source PR (#542)
- [x] PHPStan Level 10, PHP-CS-Fixer, full PHPUnit suite (2273 tests)
- [x] Local profiler verification (3 queries, byte-identical body)