### PR TITLE
:sparkles: feat: editable intro block on banned/staple cards pages

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,6 +20,10 @@ for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 0.5
 done
 
+# Seed reserved CMS pages backing the banned/staple listing intro blocks.
+# Idempotent: skips channels that already have the page.
+php bin/console app:listings:seed-intros --env=prod --no-debug 2>/dev/null || true
+
 # Rebuild search indexes from MySQL (ephemeral disk — index lost on restart)
 php bin/console app:search:reindex --env=prod --no-debug 2>/dev/null || true
 

--- a/src/Command/CreateListingIntroPagesCommand.php
+++ b/src/Command/CreateListingIntroPagesCommand.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Constants\ListingIntroPage;
+use App\Entity\Channel;
+use App\Entity\Page;
+use App\Entity\PageTranslation;
+use App\Repository\ChannelRepository;
+use App\Repository\PageRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Idempotently seeds the editable intro Page entries that back the banned-cards
+ * and staple-cards listing pages. Run on cold-start (docker-entrypoint.sh) so a
+ * fresh database always renders something under the H1, and re-runnable any
+ * time without producing duplicates.
+ *
+ * Banned cards intros are seeded only on channels with `enableBannedCards`,
+ * staple intros only on channels with `enableStaples`.
+ */
+#[AsCommand(
+    name: 'app:listings:seed-intros',
+    description: 'Create the banned-cards and staple-cards intro pages on each channel where missing.',
+)]
+class CreateListingIntroPagesCommand extends Command
+{
+    /**
+     * Default copy used as the initial Markdown body for each intro page.
+     * Mirrors the previous static subtitles, so existing channels see no
+     * UX regression after the seed.
+     *
+     * @var array<string, array<string, array{title: string, content: string}>>
+     */
+    private const array DEFAULT_TRANSLATIONS = [
+        ListingIntroPage::BANNED_CARDS_SLUG => [
+            'en' => [
+                'title' => 'Banned cards',
+                'content' => 'Cards currently banned in the Expanded format. Click any card for details and the official announcement.',
+            ],
+            'fr' => [
+                'title' => 'Cartes bannies',
+                'content' => 'Cartes actuellement bannies du format Étendu. Cliquez sur une carte pour voir le détail et l\'annonce officielle.',
+            ],
+        ],
+        ListingIntroPage::STAPLE_CARDS_SLUG => [
+            'en' => [
+                'title' => 'Staple Cards',
+                'content' => 'Editor-curated cards that anchor most Expanded decks, grouped by card type.',
+            ],
+            'fr' => [
+                'title' => 'Staple Cards',
+                'content' => 'Cartes incontournables choisies par les éditeurs, triées par type.',
+            ],
+        ],
+    ];
+
+    public function __construct(
+        private readonly ChannelRepository $channelRepository,
+        private readonly PageRepository $pageRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $created = 0;
+        $skipped = 0;
+
+        foreach ($this->channelRepository->findAll() as $channel) {
+            if ($channel->getEnableBannedCards()) {
+                $this->ensureIntroPage($channel, ListingIntroPage::BANNED_CARDS_SLUG, $created, $skipped);
+            }
+            if ($channel->getEnableStaples()) {
+                $this->ensureIntroPage($channel, ListingIntroPage::STAPLE_CARDS_SLUG, $created, $skipped);
+            }
+        }
+
+        $this->entityManager->flush();
+
+        $io->success(\sprintf('Listing intro pages: %d created, %d already present.', $created, $skipped));
+
+        return Command::SUCCESS;
+    }
+
+    private function ensureIntroPage(Channel $channel, string $slug, int &$created, int &$skipped): void
+    {
+        if (null !== $this->pageRepository->findBySlug($slug, $channel)) {
+            ++$skipped;
+
+            return;
+        }
+
+        $page = new Page();
+        $page->setSlug($slug);
+        $page->setChannel($channel);
+        $page->setIsPublished(true);
+        $page->setNoIndex(false);
+
+        $defaults = self::DEFAULT_TRANSLATIONS[$slug];
+        foreach ($channel->getLocales() as $locale) {
+            $entry = $defaults[$locale] ?? $defaults['en'];
+
+            $translation = new PageTranslation();
+            $translation->setLocale($locale);
+            $translation->setTitle($entry['title']);
+            $translation->setContent($entry['content']);
+            $page->addTranslation($translation);
+        }
+
+        $this->entityManager->persist($page);
+        ++$created;
+    }
+}

--- a/src/Constants/ListingIntroPage.php
+++ b/src/Constants/ListingIntroPage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Constants;
+
+/**
+ * Reserved CMS page slugs that back the editable intro block on the
+ * banned-cards and staple-cards listing pages.
+ *
+ * Each reserved slug points to a real `Page` entity (multilingual,
+ * Markdown-rendered, admin-editable) but its canonical URL is the
+ * listing route — not `app_page_show`. Centralised here so the
+ * controllers, the search indexer, the search runtime and the
+ * Doctrine listener all agree on the mapping.
+ */
+final class ListingIntroPage
+{
+    public const string BANNED_CARDS_SLUG = 'banned-cards-intro';
+    public const string STAPLE_CARDS_SLUG = 'staple-cards-intro';
+
+    /** @var list<string> */
+    public const array SLUGS = [
+        self::BANNED_CARDS_SLUG,
+        self::STAPLE_CARDS_SLUG,
+    ];
+
+    /** @var array<string, string> */
+    public const array ROUTE_BY_SLUG = [
+        self::BANNED_CARDS_SLUG => 'app_banned_card_list',
+        self::STAPLE_CARDS_SLUG => 'app_staple_card_list',
+    ];
+
+    public static function isListingSlug(string $slug): bool
+    {
+        return \in_array($slug, self::SLUGS, true);
+    }
+
+    public static function routeForSlug(string $slug): ?string
+    {
+        return self::ROUTE_BY_SLUG[$slug] ?? null;
+    }
+}

--- a/src/Controller/AdminTechnicalController.php
+++ b/src/Controller/AdminTechnicalController.php
@@ -25,6 +25,7 @@ use App\Service\BannedCardsSyncService;
 use App\Service\CardReenrichService;
 use App\Service\EnrichmentFlushService;
 use App\Service\Mosaic\MosaicRedispatchService;
+use App\Service\Search\SearchIndexer;
 use App\Service\Sprite\SpriteMappingSyncService;
 use App\Service\Tcgdex\TcgdexApiThrottle;
 use App\Service\Tcgdex\TcgdexSyncStatusService;
@@ -57,6 +58,7 @@ class AdminTechnicalController extends AbstractAppController
         private readonly TcgdexApiThrottle $tcgdexApiThrottle,
         private readonly \App\Repository\StapleCardRepository $stapleCardRepository,
         private readonly \App\Service\StapleCardEnricher $stapleCardEnricher,
+        private readonly SearchIndexer $searchIndexer,
     ) {
         parent::__construct($translator);
     }
@@ -344,6 +346,35 @@ class AdminTechnicalController extends AbstractAppController
                 '%cards%' => implode(', ', $unresolved),
             ]);
         }
+
+        return $this->redirectToRoute('app_admin_technical_dashboard');
+    }
+
+    /**
+     * @see docs/features.md F18.1 — Full-text search engine (MeiliSearch sidecar)
+     */
+    #[Route('/search-reindex', name: 'app_admin_technical_search_reindex', methods: ['POST'])]
+    public function searchReindex(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('technical-search-reindex', $request->getPayload()->getString('_token'))) {
+            $this->addFlash('danger', 'app.common.invalid_csrf');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        if (!$this->searchIndexer->isHealthy()) {
+            $this->addFlash('warning', 'app.admin.technical.search.unreachable');
+
+            return $this->redirectToRoute('app_admin_technical_dashboard');
+        }
+
+        $counts = $this->searchIndexer->reindexAll();
+        $total = array_sum($counts);
+
+        $this->addFlash('success', 'app.admin.technical.search.success', [
+            '%total%' => $total,
+            '%indexes%' => \count($counts),
+        ]);
 
         return $this->redirectToRoute('app_admin_technical_dashboard');
     }

--- a/src/Controller/BannedCardController.php
+++ b/src/Controller/BannedCardController.php
@@ -13,8 +13,12 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Constants\ListingIntroPage;
 use App\Repository\BannedCardRepository;
+use App\Repository\PageRepository;
+use App\Service\ArchetypeDescriptionRenderer;
 use App\Service\BannedCardImageResolver;
+use App\Service\Channel\ChannelContext;
 use App\Service\MarkdownRenderer;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,9 +38,12 @@ class BannedCardController extends AbstractController
     #[Route('/{_locale}/banned-cards', name: 'app_banned_card_list', methods: ['GET'], requirements: ['_locale' => 'en|fr'], priority: 10)]
     public function list(
         Request $request,
+        ChannelContext $channelContext,
         BannedCardRepository $bannedCardRepository,
         BannedCardImageResolver $imageResolver,
         MarkdownRenderer $markdownRenderer,
+        PageRepository $pageRepository,
+        ArchetypeDescriptionRenderer $contentRenderer,
     ): Response {
         $bannedCards = $bannedCardRepository->findActiveOrderedByEffectiveDate();
         $locale = $request->getLocale();
@@ -57,10 +64,17 @@ class BannedCardController extends AbstractController
             }
         }
 
+        $introPage = $pageRepository->findBySlug(ListingIntroPage::BANNED_CARDS_SLUG, $channelContext->getChannel());
+        $introTranslation = $introPage?->getDisplayTranslation($locale);
+        $introContent = $introTranslation?->getContent() ?? '';
+        $introHtml = '' !== trim($introContent) ? $contentRenderer->render($introContent, $locale) : null;
+
         return $this->render('banned_card/list.html.twig', [
             'bannedCards' => $bannedCards,
             'imageUrls' => $imageUrls,
             'renderedExplanations' => $renderedExplanations,
+            'introHtml' => $introHtml,
+            'introPage' => $introPage,
         ]);
     }
 }

--- a/src/Controller/PageController.php
+++ b/src/Controller/PageController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Constants\ListingIntroPage;
 use App\Entity\Channel;
 use App\Entity\MenuCategory;
 use App\Repository\PageRepository;
@@ -76,6 +77,13 @@ class PageController extends AbstractController
         PageRepository $pageRepository,
         ArchetypeDescriptionRenderer $contentRenderer,
     ): Response {
+        if (ListingIntroPage::isListingSlug($slug)) {
+            $route = ListingIntroPage::routeForSlug($slug);
+            if (null !== $route) {
+                return $this->redirectToRoute($route, ['_locale' => $request->getLocale()], Response::HTTP_MOVED_PERMANENTLY);
+            }
+        }
+
         $channel = $request->attributes->get('_channel');
         $page = $pageRepository->findBySlug($slug, $channel instanceof Channel ? $channel : null);
 

--- a/src/Controller/StapleCardController.php
+++ b/src/Controller/StapleCardController.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Constants\CardHotness;
+use App\Constants\ListingIntroPage;
 use App\Constants\StapleCardBucket;
+use App\Repository\PageRepository;
 use App\Repository\StapleCardRepository;
+use App\Service\ArchetypeDescriptionRenderer;
 use App\Service\Channel\ChannelContext;
 use App\Service\MarkdownRenderer;
 use App\Service\StapleCardImageResolver;
@@ -39,6 +42,8 @@ class StapleCardController extends AbstractController
         StapleCardRepository $stapleCardRepository,
         StapleCardImageResolver $imageResolver,
         MarkdownRenderer $markdownRenderer,
+        PageRepository $pageRepository,
+        ArchetypeDescriptionRenderer $contentRenderer,
     ): Response {
         if (!$channelContext->getChannel()->getEnableStaples()) {
             throw new NotFoundHttpException('Staple cards are not enabled on this channel.');
@@ -73,12 +78,19 @@ class StapleCardController extends AbstractController
             }
         }
 
+        $introPage = $pageRepository->findBySlug(ListingIntroPage::STAPLE_CARDS_SLUG, $channelContext->getChannel());
+        $introTranslation = $introPage?->getDisplayTranslation($locale);
+        $introContent = $introTranslation?->getContent() ?? '';
+        $introHtml = '' !== trim($introContent) ? $contentRenderer->render($introContent, $locale) : null;
+
         return $this->render('staple_card/list.html.twig', [
             'cardsByBucket' => $cardsByBucket,
             'buckets' => StapleCardBucket::ORDER,
             'imageUrls' => $imageUrls,
             'renderedNotes' => $renderedNotes,
             'minHotness' => $minHotness,
+            'introHtml' => $introHtml,
+            'introPage' => $introPage,
         ]);
     }
 }

--- a/src/EventListener/SearchIndexListener.php
+++ b/src/EventListener/SearchIndexListener.php
@@ -13,12 +13,18 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
+use App\Constants\ListingIntroPage;
 use App\Entity\Archetype;
 use App\Entity\ArchetypeTranslation;
+use App\Entity\BannedCard;
+use App\Entity\BannedCardPrinting;
 use App\Entity\Deck;
 use App\Entity\Event;
 use App\Entity\Page;
 use App\Entity\PageTranslation;
+use App\Entity\StapleCard;
+use App\Entity\StapleCardPrinting;
+use App\Repository\PageRepository;
 use App\Service\Search\SearchIndexer;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\PostPersistEventArgs;
@@ -43,6 +49,7 @@ class SearchIndexListener
 {
     public function __construct(
         private readonly SearchIndexer $searchIndexer,
+        private readonly PageRepository $pageRepository,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -73,6 +80,10 @@ class SearchIndexListener
             } else {
                 $this->searchIndexer->removeDeck($entity);
             }
+        } elseif ($entity instanceof BannedCard || $entity instanceof BannedCardPrinting) {
+            $this->refreshListingIntroPage(ListingIntroPage::BANNED_CARDS_SLUG);
+        } elseif ($entity instanceof StapleCard || $entity instanceof StapleCardPrinting) {
+            $this->refreshListingIntroPage(ListingIntroPage::STAPLE_CARDS_SLUG);
         }
     }
 
@@ -95,12 +106,37 @@ class SearchIndexListener
                 $this->searchIndexer->indexArchetype($entity->getArchetype());
             } elseif ($entity instanceof PageTranslation) {
                 $this->searchIndexer->indexPage($entity->getPage());
+            } elseif ($entity instanceof BannedCard || $entity instanceof BannedCardPrinting) {
+                $this->refreshListingIntroPage(ListingIntroPage::BANNED_CARDS_SLUG);
+            } elseif ($entity instanceof StapleCard || $entity instanceof StapleCardPrinting) {
+                $this->refreshListingIntroPage(ListingIntroPage::STAPLE_CARDS_SLUG);
             }
         } catch (\Throwable $exception) {
             // Search index sync should never break the main application flow
             $this->logger->warning('Search index sync failed: {error}', [
                 'error' => $exception->getMessage(),
                 'entity' => $entity::class,
+            ]);
+        }
+    }
+
+    /**
+     * Refresh the augmented Meilisearch document for a listing intro page.
+     *
+     * Banned/staple card lifecycle changes don't index a card directly — they
+     * update the parent listing page's indexed content (which carries every
+     * card name on that page). One re-index per affected channel-scoped page.
+     */
+    private function refreshListingIntroPage(string $slug): void
+    {
+        try {
+            foreach ($this->pageRepository->findAllBySlug($slug) as $page) {
+                $this->searchIndexer->indexPage($page);
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->warning('Failed to refresh listing intro page {slug}: {error}', [
+                'slug' => $slug,
+                'error' => $exception->getMessage(),
             ]);
         }
     }

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Constants\ListingIntroPage;
 use App\Entity\Channel;
 use App\Entity\MenuCategory;
 use App\Entity\Page;
@@ -31,6 +32,26 @@ class PageRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Page::class);
+    }
+
+    /**
+     * Find every page sharing a slug across all channels.
+     *
+     * @return list<Page>
+     */
+    public function findAllBySlug(string $slug): array
+    {
+        /** @var list<Page> $pages */
+        $pages = $this->createQueryBuilder('p')
+            ->leftJoin('p.translations', 't')
+            ->addSelect('t')
+            ->where('p.slug = :slug')
+            ->andWhere('p.deletedAt IS NULL')
+            ->setParameter('slug', $slug)
+            ->getQuery()
+            ->getResult();
+
+        return $pages;
     }
 
     /**
@@ -179,7 +200,9 @@ class PageRepository extends ServiceEntityRepository
             ->leftJoin('p.translations', 't')
             ->addSelect('t')
             ->leftJoin('p.menuCategory', 'c')
-            ->addSelect('c');
+            ->addSelect('c')
+            ->andWhere('p.slug NOT IN (:reservedSlugs)')
+            ->setParameter('reservedSlugs', ListingIntroPage::SLUGS);
 
         if (null !== $category) {
             $queryBuilder

--- a/src/Service/Search/SearchIndexer.php
+++ b/src/Service/Search/SearchIndexer.php
@@ -13,15 +13,18 @@ declare(strict_types=1);
 
 namespace App\Service\Search;
 
+use App\Constants\ListingIntroPage;
 use App\Entity\Archetype;
 use App\Entity\Deck;
 use App\Entity\Event;
 use App\Entity\Page;
 use App\Enum\EventVisibility;
 use App\Repository\ArchetypeRepository;
+use App\Repository\BannedCardRepository;
 use App\Repository\DeckRepository;
 use App\Repository\EventRepository;
 use App\Repository\PageRepository;
+use App\Repository\StapleCardRepository;
 use Meilisearch\Client;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -56,6 +59,8 @@ class SearchIndexer
         private readonly PageRepository $pageRepository,
         private readonly EventRepository $eventRepository,
         private readonly DeckRepository $deckRepository,
+        private readonly BannedCardRepository $bannedCardRepository,
+        private readonly StapleCardRepository $stapleCardRepository,
         private readonly LoggerInterface $logger,
     ) {
         $this->client = new Client($meilisearchUrl, $meiliMasterKey);
@@ -395,16 +400,26 @@ class SearchIndexer
     /**
      * Map a page to MeiliSearch documents (one per locale).
      *
+     * Pages whose slug is reserved as a listing intro (banned/staple cards) get
+     * their indexed `content` enriched with the matching listing's card names and
+     * notes, so a search for any card on those pages surfaces the page itself.
+     *
      * @return list<array<string, mixed>>
      */
     private function mapPage(Page $page): array
     {
         $documents = [];
+        $listingExtras = $this->collectListingExtras($page->getSlug());
 
         foreach (self::SUPPORTED_LOCALES as $locale) {
             $translation = $page->getTranslation($locale);
             if (null === $translation) {
                 continue;
+            }
+
+            $content = $this->stripMarkdown($translation->getContent());
+            if ('' !== $listingExtras) {
+                $content = '' === $content ? $listingExtras : $content.' '.$listingExtras;
             }
 
             $documents[] = [
@@ -414,12 +429,45 @@ class SearchIndexer
                 'type' => 'page',
                 'title' => $translation->getTitle(),
                 'slug' => $page->getSlug(),
-                'content' => $this->stripMarkdown($translation->getContent()),
+                'content' => $content,
                 'channelCode' => $page->getChannel()?->getCode(),
             ];
         }
 
         return $documents;
+    }
+
+    /**
+     * Concatenate every active banned/staple card name and note into a single
+     * plain-text blob, so the listing page becomes findable through its contents.
+     */
+    private function collectListingExtras(string $slug): string
+    {
+        if (!ListingIntroPage::isListingSlug($slug)) {
+            return '';
+        }
+
+        $tokens = [];
+
+        if (ListingIntroPage::BANNED_CARDS_SLUG === $slug) {
+            foreach ($this->bannedCardRepository->findActiveOrderedByEffectiveDate() as $card) {
+                $tokens[] = $card->getCardName();
+                $explanation = $card->getExplanation();
+                if (null !== $explanation && '' !== trim($explanation)) {
+                    $tokens[] = $this->stripMarkdown($explanation);
+                }
+            }
+        } elseif (ListingIntroPage::STAPLE_CARDS_SLUG === $slug) {
+            foreach ($this->stapleCardRepository->findAllActive() as $card) {
+                $tokens[] = $card->getCardName();
+                $note = $card->getNote();
+                if (null !== $note && '' !== trim($note)) {
+                    $tokens[] = $this->stripMarkdown($note);
+                }
+            }
+        }
+
+        return trim(implode(' ', $tokens));
     }
 
     /**

--- a/src/Twig/Runtime/SearchRuntime.php
+++ b/src/Twig/Runtime/SearchRuntime.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Twig\Runtime;
 
+use App\Constants\ListingIntroPage;
 use App\Service\Search\SearchResult;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -32,6 +33,13 @@ class SearchRuntime implements RuntimeExtensionInterface
     public function searchResultUrl(SearchResult $result): string
     {
         $locale = $this->requestStack->getCurrentRequest()?->getLocale() ?? 'en';
+
+        if ('page' === $result->type && ListingIntroPage::isListingSlug($result->slug)) {
+            $route = ListingIntroPage::routeForSlug($result->slug);
+            if (null !== $route) {
+                return $this->urlGenerator->generate($route, ['_locale' => $locale]);
+            }
+        }
 
         return match ($result->type) {
             'archetype' => $this->urlGenerator->generate('app_archetype_show', ['slug' => $result->slug, '_locale' => $locale]),

--- a/templates/admin/technical/dashboard.html.twig
+++ b/templates/admin/technical/dashboard.html.twig
@@ -282,6 +282,23 @@
         </div>
     </div>
 
+    {# Search reindex card #}
+    <div class="card shadow-sm mb-3">
+        <div class="card-header card-header-themed">
+            <h5 class="mb-0">{{ 'app.admin.technical.search.title'|trans }}</h5>
+        </div>
+        <div class="card-body">
+            <p>{{ 'app.admin.technical.search.description'|trans }}</p>
+            <form method="post" action="{{ path('app_admin_technical_search_reindex') }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('technical-search-reindex') }}">
+                <button type="submit" class="btn btn-gold"
+                        onclick="return confirm('{{ 'app.admin.technical.search.confirm_reindex'|trans|e('js') }}')">
+                    {{ 'app.admin.technical.search.reindex_button'|trans }}
+                </button>
+            </form>
+        </div>
+    </div>
+
     {# Flush & Re-enrich card — danger zone #}
     <div class="card shadow-sm mb-3 border-danger">
         <div class="card-header bg-danger text-white">

--- a/templates/banned_card/list.html.twig
+++ b/templates/banned_card/list.html.twig
@@ -36,44 +36,60 @@
 {% endblock %}
 
 {% block body %}
-    <h1 class="mb-2">{{ 'app.banned_card.public.title'|trans }}</h1>
-    <p class="text-muted mb-4">{{ 'app.banned_card.public.subtitle'|trans }}</p>
+    <article class="card shadow-sm mb-4">
+        <div class="card-header card-header-themed d-flex justify-content-between align-items-center">
+            <h1 class="mb-0 h3">{{ 'app.banned_card.public.title'|trans }}</h1>
+            {% if introPage and is_granted('ROLE_CMS_EDITOR') %}
+                <a href="{{ path('app_admin_page_edit', {id: introPage.id}) }}" class="btn btn-sm btn-outline-light-gold">
+                    <i class="bi bi-pencil me-1"></i>{{ 'app.common.edit'|trans }}
+                </a>
+            {% endif %}
+        </div>
+        {% if introHtml %}
+            <div class="card-body cms-content">{{ introHtml|raw }}</div>
+        {% endif %}
+        <div class="card-body{% if introHtml %} pt-0{% endif %}">
+            {% if bannedCards|length > 0 %}
+                <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 row-cols-lg-9 g-3">
+                    {% for card in bannedCards %}
+                        {% set highResImageUrl = imageUrls[card.id] ?? null %}
+                        {% set imageUrl = highResImageUrl ? highResImageUrl|replace({'/high.webp': '/low.webp'}) : null %}
+                        {% set printingsJson = card.printings|map(p => {setCode: p.setCode, cardNumber: p.cardNumber})|json_encode %}
+                        {% set printingsCount = card.printings|length %}
+                        <div class="col" id="card-{{ card.id }}">
+                            <button type="button"
+                                class="banned-card-trigger btn p-0 border-0 bg-transparent w-100 position-relative"
+                                data-bs-toggle="modal"
+                                data-bs-target="#bannedCardModal"
+                                data-card-name="{{ card.cardName }}"
+                                data-card-image="{{ highResImageUrl ?? '' }}"
+                                data-card-effective-date="{{ card.effectiveDate ? card.effectiveDate|user_date : '' }}"
+                                data-card-source-url="{{ card.sourceUrl ?? '' }}"
+                                data-card-explanation="{{ card.id in renderedExplanations|keys ? renderedExplanations[card.id] : '' }}"
+                                data-card-printings="{{ printingsJson }}"
+                                aria-label="{{ 'app.banned_card.public.view_details'|trans({'%name%': card.cardName}) }}">
+                                {% if imageUrl %}
+                                    <img src="{{ imageUrl }}" alt="{{ card.cardName }}" class="img-fluid rounded shadow-sm" loading="lazy">
+                                {% else %}
+                                    <div class="banned-card-placeholder rounded shadow-sm d-flex align-items-center justify-content-center text-center p-3">
+                                        {% set firstPrinting = card.printings|first %}
+                                        <span class="small fw-semibold">{{ card.cardName }}{% if firstPrinting %}<br><span class="text-muted">{{ firstPrinting.setCode }} {{ firstPrinting.cardNumber }}</span>{% endif %}</span>
+                                    </div>
+                                {% endif %}
+                                {% if printingsCount > 1 %}
+                                    <span class="badge bg-secondary position-absolute top-0 end-0 m-1">{{ 'app.banned_card.public.printings_count'|trans({'%count%': printingsCount}) }}</span>
+                                {% endif %}
+                            </button>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <div class="alert alert-info mb-0">{{ 'app.banned_card.public.empty'|trans }}</div>
+            {% endif %}
+        </div>
+    </article>
 
     {% if bannedCards|length > 0 %}
-        <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 row-cols-lg-9 g-3">
-            {% for card in bannedCards %}
-                {% set highResImageUrl = imageUrls[card.id] ?? null %}
-                {% set imageUrl = highResImageUrl ? highResImageUrl|replace({'/high.webp': '/low.webp'}) : null %}
-                {% set printingsJson = card.printings|map(p => {setCode: p.setCode, cardNumber: p.cardNumber})|json_encode %}
-                {% set printingsCount = card.printings|length %}
-                <div class="col" id="card-{{ card.id }}">
-                    <button type="button"
-                        class="banned-card-trigger btn p-0 border-0 bg-transparent w-100 position-relative"
-                        data-bs-toggle="modal"
-                        data-bs-target="#bannedCardModal"
-                        data-card-name="{{ card.cardName }}"
-                        data-card-image="{{ highResImageUrl ?? '' }}"
-                        data-card-effective-date="{{ card.effectiveDate ? card.effectiveDate|user_date : '' }}"
-                        data-card-source-url="{{ card.sourceUrl ?? '' }}"
-                        data-card-explanation="{{ card.id in renderedExplanations|keys ? renderedExplanations[card.id] : '' }}"
-                        data-card-printings="{{ printingsJson }}"
-                        aria-label="{{ 'app.banned_card.public.view_details'|trans({'%name%': card.cardName}) }}">
-                        {% if imageUrl %}
-                            <img src="{{ imageUrl }}" alt="{{ card.cardName }}" class="img-fluid rounded shadow-sm" loading="lazy">
-                        {% else %}
-                            <div class="banned-card-placeholder rounded shadow-sm d-flex align-items-center justify-content-center text-center p-3">
-                                {% set firstPrinting = card.printings|first %}
-                                <span class="small fw-semibold">{{ card.cardName }}{% if firstPrinting %}<br><span class="text-muted">{{ firstPrinting.setCode }} {{ firstPrinting.cardNumber }}</span>{% endif %}</span>
-                            </div>
-                        {% endif %}
-                        {% if printingsCount > 1 %}
-                            <span class="badge bg-secondary position-absolute top-0 end-0 m-1">{{ 'app.banned_card.public.printings_count'|trans({'%count%': printingsCount}) }}</span>
-                        {% endif %}
-                    </button>
-                </div>
-            {% endfor %}
-        </div>
-
         {# Modal — populated from the clicked card's data attributes #}
         <div class="modal fade" id="bannedCardModal" tabindex="-1" aria-labelledby="bannedCardModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-dialog-centered modal-lg">
@@ -109,8 +125,6 @@
                 </div>
             </div>
         </div>
-    {% else %}
-        <div class="alert alert-info">{{ 'app.banned_card.public.empty'|trans }}</div>
     {% endif %}
 {% endblock %}
 

--- a/templates/staple_card/list.html.twig
+++ b/templates/staple_card/list.html.twig
@@ -27,8 +27,19 @@
 {% endblock %}
 
 {% block body %}
-    <h1 class="mb-2">{{ 'app.staple_card.public.title'|trans }}</h1>
-    <p class="text-muted mb-4">{{ 'app.staple_card.public.subtitle'|trans }}</p>
+    <article class="card shadow-sm mb-4">
+        <div class="card-header card-header-themed d-flex justify-content-between align-items-center">
+            <h1 class="mb-0 h3">{{ 'app.staple_card.public.title'|trans }}</h1>
+            {% if introPage and is_granted('ROLE_CMS_EDITOR') %}
+                <a href="{{ path('app_admin_page_edit', {id: introPage.id}) }}" class="btn btn-sm btn-outline-light-gold">
+                    <i class="bi bi-pencil me-1"></i>{{ 'app.common.edit'|trans }}
+                </a>
+            {% endif %}
+        </div>
+        {% if introHtml %}
+            <div class="card-body cms-content">{{ introHtml|raw }}</div>
+        {% endif %}
+    </article>
 
     {% set hasAnyCard = cardsByBucket|filter(cards => cards is not empty)|length > 0 %}
 
@@ -38,36 +49,40 @@
         {% for bucket in buckets %}
             {% set cards = cardsByBucket[bucket] %}
             {% if cards is not empty %}
-                <section class="mb-5">
-                    <h2 class="h4 mb-3">{{ ('app.staple_card.bucket.' ~ bucket)|trans }}</h2>
-                    <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 row-cols-lg-9 g-3">
-                        {% for card in cards %}
-                            {% set highResImageUrl = imageUrls[card.id] ?? null %}
-                            {% set imageUrl = highResImageUrl ? highResImageUrl|replace({'/high.webp': '/low.webp'}) : null %}
-                            {% set printingsJson = card.printings|map(p => {setCode: p.setCode, cardNumber: p.cardNumber})|json_encode %}
-                            <div class="col" id="staple-{{ card.id }}">
-                                <button type="button"
-                                    class="staple-card-trigger btn p-0 border-0 bg-transparent w-100 position-relative"
-                                    data-bs-toggle="modal"
-                                    data-bs-target="#stapleCardModal"
-                                    data-card-name="{{ card.cardName }}"
-                                    data-card-image="{{ highResImageUrl ?? '' }}"
-                                    data-card-note="{{ card.id in renderedNotes|keys ? renderedNotes[card.id] : '' }}"
-                                    data-card-printings="{{ printingsJson }}"
-                                    aria-label="{{ 'app.staple_card.public.view_details'|trans({'%name%': card.cardName}) }}">
-                                    {% if imageUrl %}
-                                        <img src="{{ imageUrl }}" alt="{{ card.cardName }}" class="img-fluid rounded shadow-sm" loading="lazy">
-                                    {% else %}
-                                        <div class="banned-card-placeholder rounded shadow-sm d-flex align-items-center justify-content-center text-center p-3">
-                                            {% set firstPrinting = card.printings|first %}
-                                            <span class="small fw-semibold">{{ card.cardName }}{% if firstPrinting %}<br><span class="text-muted">{{ firstPrinting.setCode }} {{ firstPrinting.cardNumber }}</span>{% endif %}</span>
-                                        </div>
-                                    {% endif %}
-                                </button>
-                            </div>
-                        {% endfor %}
+                <article class="card shadow-sm mb-4">
+                    <div class="card-header card-header-themed">
+                        <h2 class="mb-0 h5">{{ ('app.staple_card.bucket.' ~ bucket)|trans }}</h2>
                     </div>
-                </section>
+                    <div class="card-body">
+                        <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 row-cols-lg-9 g-3">
+                            {% for card in cards %}
+                                {% set highResImageUrl = imageUrls[card.id] ?? null %}
+                                {% set imageUrl = highResImageUrl ? highResImageUrl|replace({'/high.webp': '/low.webp'}) : null %}
+                                {% set printingsJson = card.printings|map(p => {setCode: p.setCode, cardNumber: p.cardNumber})|json_encode %}
+                                <div class="col" id="staple-{{ card.id }}">
+                                    <button type="button"
+                                        class="staple-card-trigger btn p-0 border-0 bg-transparent w-100 position-relative"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#stapleCardModal"
+                                        data-card-name="{{ card.cardName }}"
+                                        data-card-image="{{ highResImageUrl ?? '' }}"
+                                        data-card-note="{{ card.id in renderedNotes|keys ? renderedNotes[card.id] : '' }}"
+                                        data-card-printings="{{ printingsJson }}"
+                                        aria-label="{{ 'app.staple_card.public.view_details'|trans({'%name%': card.cardName}) }}">
+                                        {% if imageUrl %}
+                                            <img src="{{ imageUrl }}" alt="{{ card.cardName }}" class="img-fluid rounded shadow-sm" loading="lazy">
+                                        {% else %}
+                                            <div class="banned-card-placeholder rounded shadow-sm d-flex align-items-center justify-content-center text-center p-3">
+                                                {% set firstPrinting = card.printings|first %}
+                                                <span class="small fw-semibold">{{ card.cardName }}{% if firstPrinting %}<br><span class="text-muted">{{ firstPrinting.setCode }} {{ firstPrinting.cardNumber }}</span>{% endif %}</span>
+                                            </div>
+                                        {% endif %}
+                                    </button>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </article>
             {% endif %}
         {% endfor %}
 

--- a/tests/EventListener/SearchIndexListenerTest.php
+++ b/tests/EventListener/SearchIndexListenerTest.php
@@ -21,6 +21,7 @@ use App\Entity\Page;
 use App\Entity\PageTranslation;
 use App\Entity\User;
 use App\EventListener\SearchIndexListener;
+use App\Repository\PageRepository;
 use App\Service\Search\SearchIndexer;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PostPersistEventArgs;
@@ -41,7 +42,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('indexArchetype')->with($archetype);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postPersist($this->createPostPersistArgs($archetype));
     }
 
@@ -52,7 +53,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('indexPage')->with($page);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postUpdate($this->createPostUpdateArgs($page));
     }
 
@@ -63,7 +64,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('indexEvent')->with($event);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postPersist($this->createPostPersistArgs($event));
     }
 
@@ -75,7 +76,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('indexDeck')->with($deck);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postPersist($this->createPostPersistArgs($deck));
     }
 
@@ -87,7 +88,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('indexVariant')->with($deck);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postPersist($this->createPostPersistArgs($deck));
     }
 
@@ -100,7 +101,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('indexArchetype')->with($archetype);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postPersist($this->createPostPersistArgs($translation));
     }
 
@@ -113,7 +114,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('indexPage')->with($page);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postPersist($this->createPostPersistArgs($translation));
     }
 
@@ -124,7 +125,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('removeArchetype')->with($archetype);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postRemove($this->createPostRemoveArgs($archetype));
     }
 
@@ -135,7 +136,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('removeVariant')->with($deck);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postRemove($this->createPostRemoveArgs($deck));
     }
 
@@ -147,7 +148,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::once())->method('removeDeck')->with($deck);
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postRemove($this->createPostRemoveArgs($deck));
     }
 
@@ -158,7 +159,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createStub(SearchIndexer::class);
         $indexer->method('indexArchetype')->willThrowException(new \RuntimeException('Connection refused'));
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
 
         // Should not throw
         $listener->postPersist($this->createPostPersistArgs($archetype));
@@ -170,7 +171,7 @@ class SearchIndexListenerTest extends TestCase
         $indexer = $this->createMock(SearchIndexer::class);
         $indexer->expects(self::never())->method(self::anything());
 
-        $listener = new SearchIndexListener($indexer, new NullLogger());
+        $listener = new SearchIndexListener($indexer, $this->createStub(PageRepository::class), new NullLogger());
         $listener->postPersist($this->createPostPersistArgs(new \stdClass()));
     }
 

--- a/tests/Functional/AdminPageControllerTest.php
+++ b/tests/Functional/AdminPageControllerTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Functional;
 
+use App\Constants\ListingIntroPage;
 use App\Entity\Page;
+use App\Entity\PageTranslation;
+use App\Repository\ChannelRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
 class AdminPageControllerTest extends AbstractFunctionalTest
@@ -113,6 +116,71 @@ class AdminPageControllerTest extends AbstractFunctionalTest
         self::assertResponseRedirects();
         $this->client->followRedirect();
         self::assertSelectorExists('.alert-success');
+    }
+
+    public function testListingIntroSlugsAreHiddenFromAdminList(): void
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+
+        /** @var ChannelRepository $channelRepository */
+        $channelRepository = self::getContainer()->get(ChannelRepository::class);
+        $channel = $channelRepository->findOneBy([]);
+        self::assertNotNull($channel);
+
+        $reserved = new Page();
+        $reserved->setSlug(ListingIntroPage::BANNED_CARDS_SLUG);
+        $reserved->setChannel($channel);
+        $reserved->setIsPublished(true);
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Banned cards intro');
+        $translation->setContent('Hidden from admin list.');
+        $reserved->addTranslation($translation);
+
+        $entityManager->persist($reserved);
+        $entityManager->flush();
+
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', '/admin/pages');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString(
+            ListingIntroPage::BANNED_CARDS_SLUG,
+            $crawler->filter('body')->html(),
+            'Reserved listing intro slugs must not appear in the admin pages list.',
+        );
+    }
+
+    public function testListingIntroEditFormIsStillReachableViaDirectUrl(): void
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+
+        /** @var ChannelRepository $channelRepository */
+        $channelRepository = self::getContainer()->get(ChannelRepository::class);
+        $channel = $channelRepository->findOneBy([]);
+        self::assertNotNull($channel);
+
+        $reserved = new Page();
+        $reserved->setSlug(ListingIntroPage::STAPLE_CARDS_SLUG);
+        $reserved->setChannel($channel);
+        $reserved->setIsPublished(true);
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Staple cards intro');
+        $translation->setContent('Reachable via the in-page edit button.');
+        $reserved->addTranslation($translation);
+
+        $entityManager->persist($reserved);
+        $entityManager->flush();
+
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', '/admin/pages/'.$reserved->getId());
+
+        self::assertResponseIsSuccessful();
     }
 
     private function getPageBySlug(string $slug): Page

--- a/tests/Functional/BannedCardControllerTest.php
+++ b/tests/Functional/BannedCardControllerTest.php
@@ -17,6 +17,9 @@ use App\Entity\BannedCard;
 use App\Entity\BannedCardPrinting;
 use App\Entity\CardIdentity;
 use App\Entity\CardPrinting;
+use App\Entity\Page;
+use App\Entity\PageTranslation;
+use App\Repository\ChannelRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -223,6 +226,71 @@ class BannedCardControllerTest extends AbstractFunctionalTest
             }
         }
         self::assertTrue($found);
+    }
+
+    public function testListRendersEditableIntroBlockWhenPagePresent(): void
+    {
+        $this->seedBannedCardsIntroPage();
+
+        $crawler = $this->client->request('GET', '/en/banned-cards');
+
+        self::assertResponseIsSuccessful();
+        $intro = $crawler->filter('.card-body.cms-content');
+        self::assertSame(1, $intro->count(), 'The editable intro block must render once when the Page exists.');
+        self::assertStringContainsString('<strong>friendly</strong>', $intro->html());
+    }
+
+    public function testEditButtonHiddenForAnonymousVisitors(): void
+    {
+        $this->seedBannedCardsIntroPage();
+
+        $crawler = $this->client->request('GET', '/en/banned-cards');
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(
+            0,
+            $crawler->filter('a[href*="/admin/pages/"]')->count(),
+            'Anonymous visitors must not see the intro edit button.',
+        );
+    }
+
+    public function testEditButtonVisibleForCmsEditor(): void
+    {
+        $page = $this->seedBannedCardsIntroPage();
+
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', '/en/banned-cards');
+
+        self::assertResponseIsSuccessful();
+        $editLink = $crawler->filter('a[href="/admin/pages/'.$page->getId().'"]');
+        self::assertSame(1, $editLink->count(), 'CMS editors must see an edit link pointing to the intro page.');
+    }
+
+    private function seedBannedCardsIntroPage(): Page
+    {
+        $em = $this->getEntityManager();
+
+        /** @var ChannelRepository $channelRepository */
+        $channelRepository = static::getContainer()->get(ChannelRepository::class);
+        $channel = $channelRepository->findOneBy([]);
+        self::assertNotNull($channel, 'A channel fixture must exist for this test.');
+
+        $page = new Page();
+        $page->setSlug('banned-cards-intro');
+        $page->setChannel($channel);
+        $page->setIsPublished(true);
+        $page->setNoIndex(false);
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Banned cards');
+        $translation->setContent('A **friendly** intro to the ban list.');
+        $page->addTranslation($translation);
+
+        $em->persist($page);
+        $em->flush();
+
+        return $page;
     }
 
     public function testListIncludesCanonicalAndHreflang(): void

--- a/tests/Service/Search/SearchIndexerTest.php
+++ b/tests/Service/Search/SearchIndexerTest.php
@@ -15,13 +15,17 @@ namespace App\Tests\Service\Search;
 
 use App\Entity\Archetype;
 use App\Entity\ArchetypeTranslation;
+use App\Entity\BannedCard;
 use App\Entity\Deck;
 use App\Entity\DeckCard;
 use App\Entity\DeckVersion;
 use App\Entity\Event;
 use App\Entity\Page;
 use App\Entity\PageTranslation;
+use App\Entity\StapleCard;
 use App\Entity\User;
+use App\Repository\BannedCardRepository;
+use App\Repository\StapleCardRepository;
 use App\Service\Search\SearchIndexer;
 use PHPUnit\Framework\TestCase;
 
@@ -247,6 +251,104 @@ class SearchIndexerTest extends TestCase
         self::assertSame('', $document['cardNames']);
     }
 
+    public function testMapPageForBannedCardsListingAppendsCardNamesAndExplanations(): void
+    {
+        $page = new Page();
+        $page->setSlug('banned-cards-intro');
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Banned cards');
+        $translation->setContent('The current Expanded ban list.');
+        $translation->setPage($page);
+        $page->addTranslation($translation);
+
+        $banned = new BannedCard();
+        $banned->setCardName('Forest of Giant Plants');
+        $banned->setExplanation('Enabled **infinite** Stage 1 evolutions.');
+
+        $bannedRepo = $this->createStub(BannedCardRepository::class);
+        $bannedRepo->method('findActiveOrderedByEffectiveDate')->willReturn([$banned]);
+
+        $stapleRepo = $this->createStub(StapleCardRepository::class);
+
+        $indexer = $this->newIndexerWithRepositories($bannedRepo, $stapleRepo);
+
+        /** @var list<array<string, mixed>> $documents */
+        $documents = $this->invokeMapperOn($indexer, 'mapPage', $page);
+
+        self::assertNotEmpty($documents);
+        $content = $documents[0]['content'];
+        self::assertIsString($content);
+        self::assertStringContainsString('The current Expanded ban list.', $content);
+        self::assertStringContainsString('Forest of Giant Plants', $content);
+        self::assertStringContainsString('infinite', $content);
+        // Markdown bold markers must be stripped from the appended explanation
+        self::assertStringNotContainsString('**', $content);
+    }
+
+    public function testMapPageForStapleCardsListingAppendsCardNamesAndNotes(): void
+    {
+        $page = new Page();
+        $page->setSlug('staple-cards-intro');
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Staple Cards');
+        $translation->setContent('Editor picks.');
+        $translation->setPage($page);
+        $page->addTranslation($translation);
+
+        $staple = new StapleCard();
+        $staple->setCardName('Iono');
+        $staple->setBucket('supporter');
+        $staple->setNote('Hand control + draw on demand.');
+
+        $bannedRepo = $this->createStub(BannedCardRepository::class);
+        $stapleRepo = $this->createStub(StapleCardRepository::class);
+        $stapleRepo->method('findAllActive')->willReturn([$staple]);
+
+        $indexer = $this->newIndexerWithRepositories($bannedRepo, $stapleRepo);
+
+        /** @var list<array<string, mixed>> $documents */
+        $documents = $this->invokeMapperOn($indexer, 'mapPage', $page);
+
+        self::assertNotEmpty($documents);
+        $content = $documents[0]['content'];
+        self::assertIsString($content);
+        self::assertStringContainsString('Editor picks.', $content);
+        self::assertStringContainsString('Iono', $content);
+        self::assertStringContainsString('Hand control', $content);
+    }
+
+    public function testMapPageForUnreservedSlugIsNotAugmented(): void
+    {
+        $page = new Page();
+        $page->setSlug('about');
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('About');
+        $translation->setContent('Plain page body.');
+        $translation->setPage($page);
+        $page->addTranslation($translation);
+
+        // The repos must not be touched for unreserved slugs — wire them to throw.
+        $bannedRepo = $this->createStub(BannedCardRepository::class);
+        $bannedRepo->method('findActiveOrderedByEffectiveDate')
+            ->willReturnCallback(static fn (): never => throw new \RuntimeException('should not be called'));
+        $stapleRepo = $this->createStub(StapleCardRepository::class);
+        $stapleRepo->method('findAllActive')
+            ->willReturnCallback(static fn (): never => throw new \RuntimeException('should not be called'));
+
+        $indexer = $this->newIndexerWithRepositories($bannedRepo, $stapleRepo);
+
+        /** @var list<array<string, mixed>> $documents */
+        $documents = $this->invokeMapperOn($indexer, 'mapPage', $page);
+
+        self::assertSame('Plain page body.', $documents[0]['content']);
+    }
+
     private function invokeStripMarkdown(string $markdown): string
     {
         $reflectionMethod = new \ReflectionMethod(SearchIndexer::class, 'stripMarkdown');
@@ -262,10 +364,27 @@ class SearchIndexerTest extends TestCase
 
     private function invokeMapper(string $methodName, object $entity): mixed
     {
-        $method = new \ReflectionMethod(SearchIndexer::class, $methodName);
         $indexer = (new \ReflectionClass(SearchIndexer::class))->newInstanceWithoutConstructor();
 
+        return $this->invokeMapperOn($indexer, $methodName, $entity);
+    }
+
+    private function invokeMapperOn(SearchIndexer $indexer, string $methodName, object $entity): mixed
+    {
+        $method = new \ReflectionMethod(SearchIndexer::class, $methodName);
+
         return $method->invoke($indexer, $entity);
+    }
+
+    private function newIndexerWithRepositories(
+        BannedCardRepository $bannedCardRepository,
+        StapleCardRepository $stapleCardRepository,
+    ): SearchIndexer {
+        $indexer = (new \ReflectionClass(SearchIndexer::class))->newInstanceWithoutConstructor();
+        $this->setProperty($indexer, 'bannedCardRepository', $bannedCardRepository);
+        $this->setProperty($indexer, 'stapleCardRepository', $stapleCardRepository);
+
+        return $indexer;
     }
 
     private function setProperty(object $entity, string $property, mixed $value): void

--- a/tests/Twig/Runtime/SearchRuntimeTest.php
+++ b/tests/Twig/Runtime/SearchRuntimeTest.php
@@ -85,6 +85,26 @@ class SearchRuntimeTest extends TestCase
         self::assertSame('/', $url);
     }
 
+    public function testSearchResultUrlForBannedCardsListingPageGoesToListing(): void
+    {
+        $runtime = $this->createRuntimeWithExpectedRoute('app_banned_card_list', '/en/banned-cards');
+
+        $result = new SearchResult('page', 'Banned cards', '', 'banned-cards-intro');
+        $url = $runtime->searchResultUrl($result);
+
+        self::assertSame('/en/banned-cards', $url);
+    }
+
+    public function testSearchResultUrlForStapleCardsListingPageGoesToListing(): void
+    {
+        $runtime = $this->createRuntimeWithExpectedRoute('app_staple_card_list', '/en/staple-cards');
+
+        $result = new SearchResult('page', 'Staple Cards', '', 'staple-cards-intro');
+        $url = $runtime->searchResultUrl($result);
+
+        self::assertSame('/en/staple-cards', $url);
+    }
+
     private function createRuntime(string $expectedUrl): SearchRuntime
     {
         $request = Request::create('/');
@@ -95,6 +115,28 @@ class SearchRuntimeTest extends TestCase
 
         $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
         $urlGenerator->method('generate')->willReturn($expectedUrl);
+
+        return new SearchRuntime($urlGenerator, $requestStack);
+    }
+
+    /**
+     * Build a runtime whose URL generator only returns the expected URL when the
+     * matching route is requested — so a regression that calls the wrong route
+     * (e.g. `app_page_show` instead of `app_banned_card_list`) returns an empty
+     * string and fails the assertion.
+     */
+    private function createRuntimeWithExpectedRoute(string $expectedRoute, string $expectedUrl): SearchRuntime
+    {
+        $request = Request::create('/');
+        $request->setLocale('en');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturnCallback(
+            static fn (string $route): string => $route === $expectedRoute ? $expectedUrl : '',
+        );
 
         return new SearchRuntime($urlGenerator, $requestStack);
     }

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5732,11 +5732,6 @@
                 <target>Banned cards</target>
                 <note>F6.14 — public banned cards page heading</note>
             </trans-unit>
-            <trans-unit id="app.banned_card.public.subtitle">
-                <source>app.banned_card.public.subtitle</source>
-                <target>Cards currently banned in the Expanded format. Click any card for details and the official announcement.</target>
-                <note>F6.14 — public banned cards page subtitle</note>
-            </trans-unit>
             <trans-unit id="app.banned_card.public.empty">
                 <source>app.banned_card.public.empty</source>
                 <target>No cards are currently banned in the Expanded format.</target>
@@ -5986,11 +5981,6 @@
                 <source>app.staple_card.public.title</source>
                 <target>Staple Cards</target>
                 <note>F6.15 — public list page heading</note>
-            </trans-unit>
-            <trans-unit id="app.staple_card.public.subtitle">
-                <source>app.staple_card.public.subtitle</source>
-                <target>Editor-curated cards that anchor most Expanded decks, grouped by card type.</target>
-                <note>F6.15 — public list page subtitle</note>
             </trans-unit>
             <trans-unit id="app.staple_card.public.empty">
                 <source>app.staple_card.public.empty</source>
@@ -6251,6 +6241,36 @@
                 <source>app.admin.technical.staple_cards.enrich_unresolved</source>
                 <target>Could not resolve: %cards%</target>
                 <note>F6.15 — technical re-enrich partial-success warning flash</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.title">
+                <source>app.admin.technical.search.title</source>
+                <target>Search index</target>
+                <note>F18.1 — technical dashboard search reindex card title</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.description">
+                <source>app.admin.technical.search.description</source>
+                <target>Rebuild every Meilisearch index from MySQL. Useful when documents drift from the source data, when the sidecar storage is wiped, or right after a structural change to the indexed fields.</target>
+                <note>F18.1 — technical dashboard search reindex description</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.reindex_button">
+                <source>app.admin.technical.search.reindex_button</source>
+                <target>Rebuild search indexes</target>
+                <note>F18.1 — technical dashboard search reindex button</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.confirm_reindex">
+                <source>app.admin.technical.search.confirm_reindex</source>
+                <target>This drops every Meilisearch index and rebuilds them from the database. Continue?</target>
+                <note>F18.1 — technical dashboard search reindex confirm prompt</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.success">
+                <source>app.admin.technical.search.success</source>
+                <target>Reindexed %total% documents across %indexes% indexes.</target>
+                <note>F18.1 — technical dashboard search reindex success flash</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.unreachable">
+                <source>app.admin.technical.search.unreachable</source>
+                <target>Meilisearch is not reachable — reindex skipped.</target>
+                <note>F18.1 — technical dashboard search reindex unreachable warning</note>
             </trans-unit>
         </body>
     </file>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -5695,11 +5695,6 @@
                 <target>Cartes bannies</target>
                 <note>F6.14 — public banned cards page heading</note>
             </trans-unit>
-            <trans-unit id="app.banned_card.public.subtitle">
-                <source>app.banned_card.public.subtitle</source>
-                <target>Cartes actuellement bannies du format Étendu. Cliquez sur une carte pour voir le détail et l'annonce officielle.</target>
-                <note>F6.14 — public banned cards page subtitle</note>
-            </trans-unit>
             <trans-unit id="app.banned_card.public.empty">
                 <source>app.banned_card.public.empty</source>
                 <target>Aucune carte n'est actuellement bannie du format Étendu.</target>
@@ -5949,11 +5944,6 @@
                 <source>app.staple_card.public.title</source>
                 <target>Staple Cards</target>
                 <note>F6.15 — public list page heading</note>
-            </trans-unit>
-            <trans-unit id="app.staple_card.public.subtitle">
-                <source>app.staple_card.public.subtitle</source>
-                <target>Cartes incontournables choisies par les éditeurs, triées par type.</target>
-                <note>F6.15 — public list page subtitle</note>
             </trans-unit>
             <trans-unit id="app.staple_card.public.empty">
                 <source>app.staple_card.public.empty</source>
@@ -6214,6 +6204,36 @@
                 <source>app.admin.technical.staple_cards.enrich_unresolved</source>
                 <target>Impossible de résoudre : %cards%</target>
                 <note>F6.15 — technical re-enrich partial-success warning flash</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.title">
+                <source>app.admin.technical.search.title</source>
+                <target>Index de recherche</target>
+                <note>F18.1 — technical dashboard search reindex card title</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.description">
+                <source>app.admin.technical.search.description</source>
+                <target>Reconstruit tous les index Meilisearch depuis MySQL. Utile lorsque les documents divergent des données sources, après un effacement du stockage du sidecar ou après une modification structurelle des champs indexés.</target>
+                <note>F18.1 — technical dashboard search reindex description</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.reindex_button">
+                <source>app.admin.technical.search.reindex_button</source>
+                <target>Reconstruire les index de recherche</target>
+                <note>F18.1 — technical dashboard search reindex button</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.confirm_reindex">
+                <source>app.admin.technical.search.confirm_reindex</source>
+                <target>Cette action supprime tous les index Meilisearch et les reconstruit depuis la base de données. Continuer ?</target>
+                <note>F18.1 — technical dashboard search reindex confirm prompt</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.success">
+                <source>app.admin.technical.search.success</source>
+                <target>%total% documents réindexés dans %indexes% index.</target>
+                <note>F18.1 — technical dashboard search reindex success flash</note>
+            </trans-unit>
+            <trans-unit id="app.admin.technical.search.unreachable">
+                <source>app.admin.technical.search.unreachable</source>
+                <target>Meilisearch est inaccessible — réindexation ignorée.</target>
+                <note>F18.1 — technical dashboard search reindex unreachable warning</note>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
## Summary
- Replaces the static subtitle on `/banned-cards` and `/staple-cards` with an admin-editable Markdown block, backed by reserved-slug `Page` entries (`banned-cards-intro`, `staple-cards-intro`) and centralised in `App\Constants\ListingIntroPage`.
- Surfaces both listing pages in Meilisearch site search: `SearchIndexer::mapPage` appends every active card name + note to the reserved-slug documents, and `SearchIndexListener` refreshes those documents on banned/staple card lifecycle events.
- `SearchRuntime` and `PageController::show` route reserved-slug links back to the canonical listing routes (`/banned-cards`, `/staple-cards`) instead of `app_page_show`.
- Admin-only "Edit" button on each listing's card header; reserved slugs filtered out of `/admin/pages` (still reachable via direct URL through the in-page edit button).
- New "Search index" card on `/admin/technical` exposes `SearchIndexer::reindexAll()` as a CSRF-protected button with a Meilisearch health pre-check, gated by `ROLE_TECHNICAL_ADMIN`.
- Idempotent `app:listings:seed-intros` console command runs at cold start (wired into `docker-entrypoint.sh` next to the existing search reindex) so a fresh deployment always renders content under the H1; gated per channel by `enableBannedCards` / `enableStaples`.
- Both listing pages restructured into Bootstrap card blocks (`card-header-themed` + `card-body cms-content`) so the editable region — and the actual card mosaics — inherit properly-themed surfaces in dark mode and shrink the FOUC blast radius.
- Old `app.banned_card.public.subtitle` / `app.staple_card.public.subtitle` keys removed; their copy moved into the seed-command defaults (no UX regression).

## Test plan
- [ ] Visit `/en/banned-cards` and `/en/staple-cards` — confirm the seeded intro renders inside the card-header card-block under the H1, in both light and dark mode.
- [ ] As a CMS editor, click the "Edit" button on either listing → lands on the page edit form; save a Markdown change and verify it appears after `c:c`.
- [ ] As a non-editor (or anonymous) — confirm the "Edit" button is not rendered.
- [ ] Confirm `banned-cards-intro` and `staple-cards-intro` are NOT listed at `/admin/pages`, but `/admin/pages/<id>` for either still loads the edit form.
- [ ] Search a banned-card name in the navbar — expect "Banned cards" page in results with the matched name highlighted; click should route to `/en/banned-cards` (not `/en/pages/...`).
- [ ] Same flow for a staple-card name.
- [ ] On `/admin/technical`, click "Rebuild search indexes" → success flash showing document counts. Stop the Meilisearch sidecar and re-trigger → expect the orange unreachable warning instead of a 500.
- [ ] Toggle the theme switcher in the footer — listing pages and admin technical card should remain legible in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)