### PR TITLE
:sparkles: feat(cms): listing-intro pages follow their menu category

### DIFF
--- a/assets/components/AppMantineProvider.tsx
+++ b/assets/components/AppMantineProvider.tsx
@@ -19,6 +19,7 @@ import { MantineProvider, MantineColorSchemeManager, MantineColorScheme } from '
  */
 function dataBsThemeColorSchemeManager(): MantineColorSchemeManager {
     let observer: MutationObserver | null = null;
+    let lastNotified: MantineColorScheme | null = null;
 
     const readScheme = (): MantineColorScheme => {
         if (typeof document === 'undefined') {
@@ -29,18 +30,29 @@ function dataBsThemeColorSchemeManager(): MantineColorSchemeManager {
     };
 
     return {
-        get: () => readScheme(),
-        set: (scheme) => {
-            const edTheme = (window as unknown as { __edTheme?: { apply: (mode: string) => void } }).__edTheme;
-            if (edTheme && (scheme === 'light' || scheme === 'dark' || scheme === 'auto')) {
-                edTheme.apply(scheme);
-            }
+        get: () => {
+            const scheme = readScheme();
+            lastNotified = scheme;
+            return scheme;
+        },
+        set: () => {
+            // Intentional no-op. Persistence is owned by `window.__edTheme` (called by
+            // the in-page theme switcher); writing back here would loop because
+            // MutationObserver fires on every `setAttribute` even when the value
+            // is unchanged, and Mantine calls `set` from its post-update effect.
         },
         subscribe: (onUpdate) => {
             if (typeof window === 'undefined') {
                 return;
             }
-            observer = new MutationObserver(() => onUpdate(readScheme()));
+            observer = new MutationObserver(() => {
+                const next = readScheme();
+                if (next === lastNotified) {
+                    return;
+                }
+                lastNotified = next;
+                onUpdate(next);
+            });
             observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-bs-theme'] });
         },
         unsubscribe: () => {

--- a/assets/components/AppMantineProvider.tsx
+++ b/assets/components/AppMantineProvider.tsx
@@ -8,19 +8,61 @@
  */
 
 import React from 'react';
-import { MantineProvider } from '@mantine/core';
+import { MantineProvider, MantineColorSchemeManager, MantineColorScheme } from '@mantine/core';
 
 /**
- * Shared Mantine provider for all React islands in the app. Configures
- * Mantine to follow the operating-system color scheme (`auto`) so it stays
- * in sync with the `data-bs-theme` attribute set on `<html>` by the inline
- * bridge script in base.html.twig.
+ * Bridge Mantine's color scheme to the resolved `data-bs-theme` attribute set
+ * on `<html>` by the inline script in base.html.twig. Without this, Mantine's
+ * "auto" mode follows the OS preference and overrides the user's app-level
+ * toggle — surfaces like the RichTextEditor toolbar render light over a dark
+ * page when the OS is light but the app is forced dark.
+ */
+function dataBsThemeColorSchemeManager(): MantineColorSchemeManager {
+    let observer: MutationObserver | null = null;
+
+    const readScheme = (): MantineColorScheme => {
+        if (typeof document === 'undefined') {
+            return 'auto';
+        }
+        const value = document.documentElement.getAttribute('data-bs-theme');
+        return value === 'dark' ? 'dark' : 'light';
+    };
+
+    return {
+        get: () => readScheme(),
+        set: (scheme) => {
+            const edTheme = (window as unknown as { __edTheme?: { apply: (mode: string) => void } }).__edTheme;
+            if (edTheme && (scheme === 'light' || scheme === 'dark' || scheme === 'auto')) {
+                edTheme.apply(scheme);
+            }
+        },
+        subscribe: (onUpdate) => {
+            if (typeof window === 'undefined') {
+                return;
+            }
+            observer = new MutationObserver(() => onUpdate(readScheme()));
+            observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-bs-theme'] });
+        },
+        unsubscribe: () => {
+            observer?.disconnect();
+            observer = null;
+        },
+        clear: () => {
+            // Persistence lives in localStorage via window.__edTheme; nothing to clear here.
+        },
+    };
+}
+
+const colorSchemeManager = dataBsThemeColorSchemeManager();
+
+/**
+ * Shared Mantine provider for all React islands in the app.
  *
  * @see docs/features.md F20.1 — Dark theme following OS preference
  */
 export default function AppMantineProvider({ children }: { children: React.ReactNode }) {
     return (
-        <MantineProvider defaultColorScheme="auto">
+        <MantineProvider defaultColorScheme="auto" colorSchemeManager={colorSchemeManager}>
             {children}
         </MantineProvider>
     );

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -875,4 +875,49 @@ footer {
     .mantine-RichTextEditor-content .selectedCell {
         background-color: var(--ed-border-faint);
     }
+
+    // Mantine RichTextEditor doesn't read Bootstrap's data-bs-theme attribute,
+    // so its surfaces stay white over the dark page. Pin the editor chrome and
+    // the contenteditable area to our theme tokens.
+    /* stylelint-disable selector-class-pattern */
+    .mantine-RichTextEditor-root {
+        background-color: var(--ed-surface-elevated);
+        border-color: var(--ed-border-faint);
+        color: var(--bs-body-color);
+    }
+
+    .mantine-RichTextEditor-toolbar {
+        background-color: var(--ed-overlay-soft);
+        border-color: var(--ed-border-faint);
+        color: var(--bs-body-color);
+    }
+
+    .mantine-RichTextEditor-control {
+        background-color: transparent;
+        border-color: var(--ed-border-faint);
+        color: var(--bs-body-color);
+
+        &:hover {
+            background-color: var(--ed-overlay-medium);
+        }
+
+        &[data-active="true"] {
+            background-color: var(--ed-overlay-medium);
+            color: var(--bs-body-color);
+        }
+    }
+
+    .mantine-RichTextEditor-content {
+        background-color: var(--ed-surface-elevated);
+        color: var(--bs-body-color);
+
+        .ProseMirror {
+            color: var(--bs-body-color);
+        }
+
+        a {
+            color: var(--ed-gold);
+        }
+    }
+    /* stylelint-enable selector-class-pattern */
 }

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -875,49 +875,4 @@ footer {
     .mantine-RichTextEditor-content .selectedCell {
         background-color: var(--ed-border-faint);
     }
-
-    // Mantine RichTextEditor doesn't read Bootstrap's data-bs-theme attribute,
-    // so its surfaces stay white over the dark page. Pin the editor chrome and
-    // the contenteditable area to our theme tokens.
-    /* stylelint-disable selector-class-pattern */
-    .mantine-RichTextEditor-root {
-        background-color: var(--ed-surface-elevated);
-        border-color: var(--ed-border-faint);
-        color: var(--bs-body-color);
-    }
-
-    .mantine-RichTextEditor-toolbar {
-        background-color: var(--ed-overlay-soft);
-        border-color: var(--ed-border-faint);
-        color: var(--bs-body-color);
-    }
-
-    .mantine-RichTextEditor-control {
-        background-color: transparent;
-        border-color: var(--ed-border-faint);
-        color: var(--bs-body-color);
-
-        &:hover {
-            background-color: var(--ed-overlay-medium);
-        }
-
-        &[data-active="true"] {
-            background-color: var(--ed-overlay-medium);
-            color: var(--bs-body-color);
-        }
-    }
-
-    .mantine-RichTextEditor-content {
-        background-color: var(--ed-surface-elevated);
-        color: var(--bs-body-color);
-
-        .ProseMirror {
-            color: var(--bs-body-color);
-        }
-
-        a {
-            color: var(--ed-gold);
-        }
-    }
-    /* stylelint-enable selector-class-pattern */
 }

--- a/docs/models/cms.md
+++ b/docs/models/cms.md
@@ -129,3 +129,16 @@ Pages are served at:
 ```
 
 Where `{slug}` is the `Page.slug` field. Example: `/en/pages/how-to-borrow`, `/fr/pages/how-to-borrow`.
+
+### Reserved listing-intro slugs
+
+Two slugs are reserved (centralised in `App\Constants\ListingIntroPage`) and back the editable intro block on the banned-cards / staple-cards listing pages:
+
+| Slug                  | Canonical route          |
+|-----------------------|--------------------------|
+| `banned-cards-intro`  | `app_banned_card_list`   |
+| `staple-cards-intro`  | `app_staple_card_list`   |
+
+Direct hits to `/{locale}/pages/{reserved-slug}` redirect (HTTP 301) to the canonical listing route, and the navigation Twig helper `cms_page_url(page)` links straight to the listing route to skip the redirect.
+
+**Menu placement.** A reserved-slug page with `menuCategory = null` keeps the listing link in its hardcoded position in `base.html.twig` (between Archetypes and Decks). Assigning a `MenuCategory` makes the link appear inside that category's dropdown — sorted by `position` like any sibling page — and suppresses the hardcoded fallback (controlled by the `listing_intro_in_menu(slug)` helper). The dropdown label is the page's translated title.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7649,9 +7649,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {

--- a/src/Controller/AdminPageController.php
+++ b/src/Controller/AdminPageController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Constants\ListingIntroPage;
 use App\Entity\Channel;
 use App\Entity\Page;
 use App\Entity\PageTranslation;
@@ -291,6 +292,12 @@ class AdminPageController extends AbstractAppController
     #[Route('/{id}/delete', name: 'app_admin_page_delete', methods: ['POST'], requirements: ['id' => '\d+'])]
     public function delete(Request $request, Page $page, MenuRuntime $menuRuntime): Response
     {
+        if (ListingIntroPage::isListingSlug($page->getSlug())) {
+            $this->addFlash('danger', 'app.flash.page.cannot_delete_listing_intro');
+
+            return $this->redirectToRoute('app_admin_page_edit', ['id' => $page->getId()]);
+        }
+
         if (!$this->isCsrfTokenValid('page-delete-'.$page->getId(), $request->getPayload()->getString('_token'))) {
             $this->addFlash('danger', 'app.common.invalid_csrf');
 

--- a/src/Controller/AdminPageController.php
+++ b/src/Controller/AdminPageController.php
@@ -219,8 +219,11 @@ class AdminPageController extends AbstractAppController
     #[Route('/{id}', name: 'app_admin_page_edit', methods: ['GET', 'POST'], requirements: ['id' => '\d+'])]
     public function edit(Request $request, Page $page, MenuRuntime $menuRuntime, ChannelContext $channelContext): Response
     {
+        $isListingIntro = ListingIntroPage::isListingSlug($page->getSlug());
+
         $form = $this->createForm(PageFormType::class, $page, [
             'locale' => $request->getLocale(),
+            'is_listing_intro' => $isListingIntro,
         ]);
         $form->handleRequest($request);
 
@@ -243,6 +246,7 @@ class AdminPageController extends AbstractAppController
             'form' => $form,
             'translationForms' => $translationForms,
             'supportedLocales' => $supportedLocales,
+            'isListingIntro' => $isListingIntro,
         ]);
     }
 
@@ -268,6 +272,9 @@ class AdminPageController extends AbstractAppController
             'page_translation_form_'.$locale,
             PageTranslationFormType::class,
             $translation,
+            [
+                'is_listing_intro' => ListingIntroPage::isListingSlug($page->getSlug()),
+            ],
         );
         $form->handleRequest($request);
 
@@ -355,6 +362,7 @@ class AdminPageController extends AbstractAppController
     private function buildTranslationForms(Page $page, Request $request, array $locales): array
     {
         $forms = [];
+        $isListingIntro = ListingIntroPage::isListingSlug($page->getSlug());
 
         foreach ($locales as $locale) {
             $translation = $page->getTranslation($locale);
@@ -373,6 +381,7 @@ class AdminPageController extends AbstractAppController
                         'id' => $page->getId(),
                         'locale' => $locale,
                     ]),
+                    'is_listing_intro' => $isListingIntro,
                 ],
             );
 

--- a/src/Form/PageFormType.php
+++ b/src/Form/PageFormType.php
@@ -54,45 +54,47 @@ class PageFormType extends AbstractType
             ]);
         }
 
-        $builder
-            ->add('slug', TextType::class, [
-                'label' => 'app.common.slug',
-                'attr' => ['placeholder' => 'app.cms.form.slug_placeholder'],
-                'disabled' => $isListingIntro,
-            ])
-            ->add('channel', EntityType::class, [
-                'class' => Channel::class,
-                'choice_label' => 'domain',
-                'label' => 'app.cms.form.channel',
-                'placeholder' => '',
-                'required' => false,
-                'disabled' => $isListingIntro,
-            ])
-            ->add('menuCategory', EntityType::class, [
-                'class' => MenuCategory::class,
-                'label' => 'app.cms.form.menu_category',
-                'required' => false,
-                'placeholder' => 'app.cms.form.no_category',
-                'choice_label' => static fn (MenuCategory $category): string => $category->getName($locale),
-                'query_builder' => static fn (EntityRepository $repository): QueryBuilder => $repository->createQueryBuilder('c')
-                    ->orderBy('c.position', 'ASC'),
-            ])
-            ->add('isPublished', CheckboxType::class, [
-                'label' => 'app.common.published',
-                'required' => false,
-                'disabled' => $isListingIntro,
-            ])
-            ->add('noIndex', CheckboxType::class, [
-                'label' => 'app.cms.form.no_index',
-                'required' => false,
-                'disabled' => $isListingIntro,
-            ])
-            ->add('ogImage', TextType::class, [
-                'label' => 'app.cms.form.og_image',
-                'required' => false,
-                'empty_data' => null,
-                'disabled' => $isListingIntro,
-            ]);
+        if (!$isListingIntro) {
+            $builder
+                ->add('slug', TextType::class, [
+                    'label' => 'app.common.slug',
+                    'attr' => ['placeholder' => 'app.cms.form.slug_placeholder'],
+                ])
+                ->add('channel', EntityType::class, [
+                    'class' => Channel::class,
+                    'choice_label' => 'domain',
+                    'label' => 'app.cms.form.channel',
+                    'placeholder' => '',
+                    'required' => false,
+                ]);
+        }
+
+        $builder->add('menuCategory', EntityType::class, [
+            'class' => MenuCategory::class,
+            'label' => 'app.cms.form.menu_category',
+            'required' => false,
+            'placeholder' => 'app.cms.form.no_category',
+            'choice_label' => static fn (MenuCategory $category): string => $category->getName($locale),
+            'query_builder' => static fn (EntityRepository $repository): QueryBuilder => $repository->createQueryBuilder('c')
+                ->orderBy('c.position', 'ASC'),
+        ]);
+
+        if (!$isListingIntro) {
+            $builder
+                ->add('isPublished', CheckboxType::class, [
+                    'label' => 'app.common.published',
+                    'required' => false,
+                ])
+                ->add('noIndex', CheckboxType::class, [
+                    'label' => 'app.cms.form.no_index',
+                    'required' => false,
+                ])
+                ->add('ogImage', TextType::class, [
+                    'label' => 'app.cms.form.og_image',
+                    'required' => false,
+                    'empty_data' => null,
+                ]);
+        }
 
         // Filter categories by the selected channel
         $builder->addEventListener(FormEvents::PRE_SET_DATA, static function (FormEvent $event) use ($locale): void {

--- a/src/Form/PageFormType.php
+++ b/src/Form/PageFormType.php
@@ -43,6 +43,9 @@ class PageFormType extends AbstractType
         /** @var bool $isCreation */
         $isCreation = $options['is_creation'];
 
+        /** @var bool $isListingIntro */
+        $isListingIntro = $options['is_listing_intro'];
+
         if ($isCreation) {
             $builder->add('title', TextType::class, [
                 'label' => 'app.cms.form.title',
@@ -55,6 +58,7 @@ class PageFormType extends AbstractType
             ->add('slug', TextType::class, [
                 'label' => 'app.common.slug',
                 'attr' => ['placeholder' => 'app.cms.form.slug_placeholder'],
+                'disabled' => $isListingIntro,
             ])
             ->add('channel', EntityType::class, [
                 'class' => Channel::class,
@@ -62,6 +66,7 @@ class PageFormType extends AbstractType
                 'label' => 'app.cms.form.channel',
                 'placeholder' => '',
                 'required' => false,
+                'disabled' => $isListingIntro,
             ])
             ->add('menuCategory', EntityType::class, [
                 'class' => MenuCategory::class,
@@ -75,15 +80,18 @@ class PageFormType extends AbstractType
             ->add('isPublished', CheckboxType::class, [
                 'label' => 'app.common.published',
                 'required' => false,
+                'disabled' => $isListingIntro,
             ])
             ->add('noIndex', CheckboxType::class, [
                 'label' => 'app.cms.form.no_index',
                 'required' => false,
+                'disabled' => $isListingIntro,
             ])
             ->add('ogImage', TextType::class, [
                 'label' => 'app.cms.form.og_image',
                 'required' => false,
                 'empty_data' => null,
+                'disabled' => $isListingIntro,
             ]);
 
         // Filter categories by the selected channel
@@ -116,9 +124,11 @@ class PageFormType extends AbstractType
             'data_class' => Page::class,
             'locale' => 'en',
             'is_creation' => false,
+            'is_listing_intro' => false,
         ]);
 
         $resolver->setAllowedTypes('locale', 'string');
         $resolver->setAllowedTypes('is_creation', 'bool');
+        $resolver->setAllowedTypes('is_listing_intro', 'bool');
     }
 }

--- a/src/Form/PageTranslationFormType.php
+++ b/src/Form/PageTranslationFormType.php
@@ -32,19 +32,20 @@ class PageTranslationFormType extends AbstractType
         /** @var bool $isListingIntro */
         $isListingIntro = $options['is_listing_intro'];
 
-        $builder
-            ->add('title', TextType::class, [
+        if (!$isListingIntro) {
+            $builder->add('title', TextType::class, [
                 'label' => 'app.cms.form.title',
-                'disabled' => $isListingIntro,
-            ])
-            ->add('content', TextareaType::class, [
-                'label' => 'app.cms.form.content',
-                'required' => false,
-                'attr' => [
-                    'rows' => 15,
-                    'placeholder' => 'app.cms.form.content_placeholder',
-                ],
             ]);
+        }
+
+        $builder->add('content', TextareaType::class, [
+            'label' => 'app.cms.form.content',
+            'required' => false,
+            'attr' => [
+                'rows' => 15,
+                'placeholder' => 'app.cms.form.content_placeholder',
+            ],
+        ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/PageTranslationFormType.php
+++ b/src/Form/PageTranslationFormType.php
@@ -29,9 +29,13 @@ class PageTranslationFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        /** @var bool $isListingIntro */
+        $isListingIntro = $options['is_listing_intro'];
+
         $builder
             ->add('title', TextType::class, [
                 'label' => 'app.cms.form.title',
+                'disabled' => $isListingIntro,
             ])
             ->add('content', TextareaType::class, [
                 'label' => 'app.cms.form.content',
@@ -47,6 +51,9 @@ class PageTranslationFormType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => PageTranslation::class,
+            'is_listing_intro' => false,
         ]);
+
+        $resolver->setAllowedTypes('is_listing_intro', 'bool');
     }
 }

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -200,9 +200,7 @@ class PageRepository extends ServiceEntityRepository
             ->leftJoin('p.translations', 't')
             ->addSelect('t')
             ->leftJoin('p.menuCategory', 'c')
-            ->addSelect('c')
-            ->andWhere('p.slug NOT IN (:reservedSlugs)')
-            ->setParameter('reservedSlugs', ListingIntroPage::SLUGS);
+            ->addSelect('c');
 
         if (null !== $category) {
             $queryBuilder
@@ -211,7 +209,10 @@ class PageRepository extends ServiceEntityRepository
                 ->orderBy('p.position', 'ASC')
                 ->addOrderBy('p.createdAt', 'DESC');
         } else {
-            $queryBuilder->orderBy('p.createdAt', 'DESC');
+            $queryBuilder
+                ->andWhere('p.slug NOT IN (:reservedSlugs)')
+                ->setParameter('reservedSlugs', ListingIntroPage::SLUGS)
+                ->orderBy('p.createdAt', 'DESC');
         }
 
         if (null !== $search && '' !== $search) {

--- a/src/Twig/Extension/MenuExtension.php
+++ b/src/Twig/Extension/MenuExtension.php
@@ -30,6 +30,8 @@ class MenuExtension extends AbstractExtension
         return [
             new TwigFunction('menu_categories', [MenuRuntime::class, 'getCategories']),
             new TwigFunction('footer_categories', [MenuRuntime::class, 'getFooterCategories']),
+            new TwigFunction('cms_page_url', [MenuRuntime::class, 'getPageUrl']),
+            new TwigFunction('listing_intro_in_menu', [MenuRuntime::class, 'isListingIntroInMenu']),
         ];
     }
 }

--- a/src/Twig/Extension/MenuExtension.php
+++ b/src/Twig/Extension/MenuExtension.php
@@ -32,6 +32,7 @@ class MenuExtension extends AbstractExtension
             new TwigFunction('footer_categories', [MenuRuntime::class, 'getFooterCategories']),
             new TwigFunction('cms_page_url', [MenuRuntime::class, 'getPageUrl']),
             new TwigFunction('listing_intro_in_menu', [MenuRuntime::class, 'isListingIntroInMenu']),
+            new TwigFunction('is_listing_intro_slug', [MenuRuntime::class, 'isListingIntroSlug']),
         ];
     }
 }

--- a/src/Twig/Runtime/MenuRuntime.php
+++ b/src/Twig/Runtime/MenuRuntime.php
@@ -113,6 +113,16 @@ class MenuRuntime implements RuntimeExtensionInterface
     }
 
     /**
+     * Whether a slug belongs to one of the reserved listing-intro pages
+     * (banned-cards-intro / staple-cards-intro). Exposed for templates that
+     * need to gate destructive UI (delete, slug rename) on these pages.
+     */
+    public function isListingIntroSlug(string $slug): bool
+    {
+        return ListingIntroPage::isListingSlug($slug);
+    }
+
+    /**
      * Whether a reserved listing-intro slug is currently published AND assigned
      * to a menu category for the active channel — used to suppress the
      * hardcoded fallback nav link when the page has been moved into the menu.

--- a/src/Twig/Runtime/MenuRuntime.php
+++ b/src/Twig/Runtime/MenuRuntime.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace App\Twig\Runtime;
 
+use App\Constants\ListingIntroPage;
 use App\Entity\MenuCategory;
+use App\Entity\Page;
 use App\Repository\MenuCategoryRepository;
 use App\Service\Channel\ChannelContext;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Twig\Extension\RuntimeExtensionInterface;
@@ -32,6 +36,8 @@ class MenuRuntime implements RuntimeExtensionInterface
         private readonly MenuCategoryRepository $menuCategoryRepository,
         private readonly ChannelContext $channelContext,
         private readonly CacheInterface $menuCategoriesCache,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly RequestStack $requestStack,
     ) {
     }
 
@@ -78,5 +84,53 @@ class MenuRuntime implements RuntimeExtensionInterface
         $this->menuCategoriesCache->delete('menu_categories_content');
         $this->menuCategoriesCache->delete('footer_categories_app');
         $this->menuCategoriesCache->delete('footer_categories_content');
+    }
+
+    /**
+     * Build the public URL for a CMS page.
+     *
+     * Reserved listing-intro slugs (banned/staple) resolve to their canonical
+     * listing route so navigation links don't bounce through a 301 redirect.
+     */
+    public function getPageUrl(Page $page): string
+    {
+        $slug = $page->getSlug();
+        $listingRoute = ListingIntroPage::routeForSlug($slug);
+
+        $parameters = [];
+        $locale = $this->requestStack->getCurrentRequest()?->getLocale();
+        if (null !== $locale) {
+            $parameters['_locale'] = $locale;
+        }
+
+        if (null !== $listingRoute) {
+            return $this->urlGenerator->generate($listingRoute, $parameters);
+        }
+
+        $parameters['slug'] = $slug;
+
+        return $this->urlGenerator->generate('app_page_show', $parameters);
+    }
+
+    /**
+     * Whether a reserved listing-intro slug is currently published AND assigned
+     * to a menu category for the active channel — used to suppress the
+     * hardcoded fallback nav link when the page has been moved into the menu.
+     */
+    public function isListingIntroInMenu(string $slug): bool
+    {
+        if (!ListingIntroPage::isListingSlug($slug)) {
+            return false;
+        }
+
+        foreach ($this->getCategories() as $category) {
+            foreach ($category->getPages() as $page) {
+                if ($page->getSlug() === $slug) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/templates/admin/page/edit.html.twig
+++ b/templates/admin/page/edit.html.twig
@@ -29,6 +29,13 @@
         </div>
     </div>
 
+    {% if isListingIntro ?? false %}
+        <div class="alert alert-info d-flex align-items-start mb-4" role="alert">
+            <i class="bi bi-info-circle-fill me-2 mt-1"></i>
+            <div>{{ 'app.cms.admin.listing_intro_locked_fields'|trans }}</div>
+        </div>
+    {% endif %}
+
     {# Page settings #}
     <div class="card shadow-sm mb-4">
         <div class="card-header card-header-themed">

--- a/templates/admin/page/edit.html.twig
+++ b/templates/admin/page/edit.html.twig
@@ -29,7 +29,8 @@
         </div>
     </div>
 
-    {% if isListingIntro ?? false %}
+    {% set isListingIntro = isListingIntro ?? false %}
+    {% if isListingIntro %}
         <div class="alert alert-info d-flex align-items-start mb-4" role="alert">
             <i class="bi bi-info-circle-fill me-2 mt-1"></i>
             <div>{{ 'app.cms.admin.listing_intro_locked_fields'|trans }}</div>
@@ -44,11 +45,15 @@
         <div class="card-body">
             {% from 'admin/_image_url_field.html.twig' import image_url_field %}
             {{ form_start(form) }}
-                {{ form_row(form.slug) }}
+                {% if not isListingIntro %}
+                    {{ form_row(form.slug) }}
+                {% endif %}
                 {{ form_row(form.menuCategory) }}
-                {{ form_row(form.isPublished) }}
-                {{ form_row(form.noIndex) }}
-                {{ image_url_field(form.ogImage) }}
+                {% if not isListingIntro %}
+                    {{ form_row(form.isPublished) }}
+                    {{ form_row(form.noIndex) }}
+                    {{ image_url_field(form.ogImage) }}
+                {% endif %}
                 <button type="submit" class="btn btn-gold mt-3">{{ 'app.common.save'|trans }}</button>
             {{ form_end(form) }}
         </div>
@@ -80,7 +85,9 @@
                     <div class="tab-pane fade {{ loop.first ? 'show active' : '' }}" id="pane-{{ locale }}" role="tabpanel" aria-labelledby="tab-{{ locale }}">
                         {% from 'admin/_rich_text_editor.html.twig' import rich_text_editor %}
                         {{ form_start(translationForms[locale]) }}
-                            {{ form_row(translationForms[locale].title) }}
+                            {% if not isListingIntro %}
+                                {{ form_row(translationForms[locale].title) }}
+                            {% endif %}
                             {{ rich_text_editor(translationForms[locale].content) }}
                             <button type="submit" class="btn btn-gold mt-3">{{ 'app.cms.admin.save_translation'|trans({'%locale%': locale|upper}) }}</button>
                         {{ form_end(translationForms[locale]) }}

--- a/templates/admin/page/edit.html.twig
+++ b/templates/admin/page/edit.html.twig
@@ -85,15 +85,24 @@
 
     {# Delete #}
     {% if page.deletedAt is null %}
-        <div class="card shadow-sm border-danger">
-            <div class="card-body">
-                <h5 class="text-danger">{{ 'app.common.danger_zone'|trans }}</h5>
-                <form method="post" action="{{ path('app_admin_page_delete', {id: page.id}) }}" onsubmit="return confirm('{{ 'app.cms.admin.delete_confirm'|trans|e('js') }}')">
-                    <input type="hidden" name="_token" value="{{ csrf_token('page-delete-' ~ page.id) }}">
-                    <button type="submit" class="btn btn-outline-danger">{{ 'app.cms.admin.delete_page'|trans }}</button>
-                </form>
+        {% if is_listing_intro_slug(page.slug) %}
+            <div class="card shadow-sm border-secondary">
+                <div class="card-body">
+                    <h5 class="text-secondary"><i class="bi bi-lock-fill me-2"></i>{{ 'app.cms.admin.delete_locked_listing_intro'|trans }}</h5>
+                    <p class="text-muted mb-0 small">{{ 'app.cms.admin.delete_locked_listing_intro_help'|trans }}</p>
+                </div>
             </div>
-        </div>
+        {% else %}
+            <div class="card shadow-sm border-danger">
+                <div class="card-body">
+                    <h5 class="text-danger">{{ 'app.common.danger_zone'|trans }}</h5>
+                    <form method="post" action="{{ path('app_admin_page_delete', {id: page.id}) }}" onsubmit="return confirm('{{ 'app.cms.admin.delete_confirm'|trans|e('js') }}')">
+                        <input type="hidden" name="_token" value="{{ csrf_token('page-delete-' ~ page.id) }}">
+                        <button type="submit" class="btn btn-outline-danger">{{ 'app.cms.admin.delete_page'|trans }}</button>
+                    </form>
+                </div>
+            </div>
+        {% endif %}
     {% else %}
         <div class="card shadow-sm border-warning">
             <div class="card-body">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -97,14 +97,14 @@
                                 {% set pages = category.pages|filter(p => p.published)|sort((a, b) => a.position <=> b.position) %}
                                 {% if pages|length == 1 %}
                                     <li class="nav-item">
-                                        <a class="nav-link" href="{{ path('app_page_show', {slug: pages|first.slug}) }}">{{ category.getName(app.request.locale) }}</a>
+                                        <a class="nav-link" href="{{ cms_page_url(pages|first) }}">{{ category.getName(app.request.locale) }}</a>
                                     </li>
                                 {% elseif pages|length > 1 %}
                                     <li class="nav-item dropdown">
                                         <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">{{ category.getName(app.request.locale) }}</a>
                                         <ul class="dropdown-menu">
                                             {% for page in pages|slice(0, 5) %}
-                                                <li><a class="dropdown-item" href="{{ path('app_page_show', {slug: page.slug}) }}">{{ page.getTitle(app.request.locale) }}</a></li>
+                                                <li><a class="dropdown-item" href="{{ cms_page_url(page) }}">{{ page.getTitle(app.request.locale) }}</a></li>
                                             {% endfor %}
                                             {% if pages|length > 5 %}
                                                 <li><hr class="dropdown-divider"></li>
@@ -119,12 +119,12 @@
                                     <a class="nav-link" href="{{ path('app_archetype_list') }}">{{ 'app.nav.archetypes'|trans }}</a>
                                 </li>
                             {% endif %}
-                            {% if channel.enableBannedCards %}
+                            {% if channel.enableBannedCards and not listing_intro_in_menu('banned-cards-intro') %}
                                 <li class="nav-item">
                                     <a class="nav-link" href="{{ path('app_banned_card_list') }}">{{ 'app.nav.banned_cards'|trans }}</a>
                                 </li>
                             {% endif %}
-                            {% if channel.enableStaples %}
+                            {% if channel.enableStaples and not listing_intro_in_menu('staple-cards-intro') %}
                                 <li class="nav-item">
                                     <a class="nav-link" href="{{ path('app_staple_card_list') }}">{{ 'app.nav.staple_cards'|trans }}</a>
                                 </li>
@@ -207,14 +207,14 @@
                                 {% set pages = category.pages|filter(p => p.published)|sort((a, b) => a.position <=> b.position) %}
                                 {% if pages|length == 1 %}
                                     <li class="nav-item">
-                                        <a class="nav-link" href="{{ path('app_page_show', {slug: pages|first.slug}) }}">{{ category.getName(app.request.locale) }}</a>
+                                        <a class="nav-link" href="{{ cms_page_url(pages|first) }}">{{ category.getName(app.request.locale) }}</a>
                                     </li>
                                 {% elseif pages|length > 1 %}
                                     <li class="nav-item dropdown">
                                         <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">{{ category.getName(app.request.locale) }}</a>
                                         <ul class="dropdown-menu">
                                             {% for page in pages|slice(0, 5) %}
-                                                <li><a class="dropdown-item" href="{{ path('app_page_show', {slug: page.slug}) }}">{{ page.getTitle(app.request.locale) }}</a></li>
+                                                <li><a class="dropdown-item" href="{{ cms_page_url(page) }}">{{ page.getTitle(app.request.locale) }}</a></li>
                                             {% endfor %}
                                             {% if pages|length > 5 %}
                                                 <li><hr class="dropdown-divider"></li>
@@ -229,12 +229,12 @@
                                     <a class="nav-link" href="{{ path('app_archetype_list') }}">{{ 'app.nav.archetypes'|trans }}</a>
                                 </li>
                             {% endif %}
-                            {% if channel.enableBannedCards %}
+                            {% if channel.enableBannedCards and not listing_intro_in_menu('banned-cards-intro') %}
                                 <li class="nav-item">
                                     <a class="nav-link" href="{{ path('app_banned_card_list') }}">{{ 'app.nav.banned_cards'|trans }}</a>
                                 </li>
                             {% endif %}
-                            {% if channel.enableStaples %}
+                            {% if channel.enableStaples and not listing_intro_in_menu('staple-cards-intro') %}
                                 <li class="nav-item">
                                     <a class="nav-link" href="{{ path('app_staple_card_list') }}">{{ 'app.nav.staple_cards'|trans }}</a>
                                 </li>
@@ -303,7 +303,7 @@
                                     <h6 class="text-uppercase mb-2">{{ category.getName(app.request.locale) }}</h6>
                                     <ul class="list-unstyled">
                                         {% for page in pages %}
-                                            <li class="mb-1"><a href="{{ path('app_page_show', {slug: page.slug}) }}">{{ page.getTitle(app.request.locale) }}</a></li>
+                                            <li class="mb-1"><a href="{{ cms_page_url(page) }}">{{ page.getTitle(app.request.locale) }}</a></li>
                                         {% endfor %}
                                     </ul>
                                 </div>

--- a/tests/Functional/AdminPageControllerTest.php
+++ b/tests/Functional/AdminPageControllerTest.php
@@ -183,6 +183,83 @@ class AdminPageControllerTest extends AbstractFunctionalTest
         self::assertResponseIsSuccessful();
     }
 
+    public function testListingIntroEditFormHidesDangerZone(): void
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+
+        /** @var ChannelRepository $channelRepository */
+        $channelRepository = self::getContainer()->get(ChannelRepository::class);
+        $channel = $channelRepository->findOneBy([]);
+        self::assertNotNull($channel);
+
+        $reserved = new Page();
+        $reserved->setSlug(ListingIntroPage::BANNED_CARDS_SLUG);
+        $reserved->setChannel($channel);
+        $reserved->setIsPublished(true);
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Banned cards intro');
+        $translation->setContent('Body.');
+        $reserved->addTranslation($translation);
+
+        $entityManager->persist($reserved);
+        $entityManager->flush();
+
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', '/admin/pages/'.$reserved->getId());
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(
+            0,
+            $crawler->filter('form[action$="/delete"]'),
+            'Reserved listing-intro pages must not render the delete form.',
+        );
+    }
+
+    public function testDeleteOnListingIntroPageIsRefused(): void
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+
+        /** @var ChannelRepository $channelRepository */
+        $channelRepository = self::getContainer()->get(ChannelRepository::class);
+        $channel = $channelRepository->findOneBy([]);
+        self::assertNotNull($channel);
+
+        $reserved = new Page();
+        $reserved->setSlug(ListingIntroPage::BANNED_CARDS_SLUG);
+        $reserved->setChannel($channel);
+        $reserved->setIsPublished(true);
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Banned cards intro');
+        $translation->setContent('Body.');
+        $reserved->addTranslation($translation);
+
+        $entityManager->persist($reserved);
+        $entityManager->flush();
+
+        $reservedId = $reserved->getId();
+        self::assertNotNull($reservedId);
+
+        $this->loginAs('admin@example.com');
+
+        // The reserved-slug guard runs before the CSRF check, so we can probe
+        // it without a session-bound token. This also covers the case where
+        // a CLI/curl request bypasses the rendered form entirely.
+        $this->client->request('POST', '/admin/pages/'.$reservedId.'/delete', ['_token' => 'irrelevant']);
+
+        self::assertResponseRedirects('/admin/pages/'.$reservedId);
+
+        $entityManager->clear();
+        $stillThere = $entityManager->getRepository(Page::class)->find($reservedId);
+        self::assertInstanceOf(Page::class, $stillThere);
+        self::assertNull($stillThere->getDeletedAt(), 'Reserved listing-intro page must not be soft-deleted.');
+    }
+
     private function getPageBySlug(string $slug): Page
     {
         $entityManager = self::getContainer()->get(EntityManagerInterface::class);

--- a/tests/Functional/AdminPageControllerTest.php
+++ b/tests/Functional/AdminPageControllerTest.php
@@ -218,7 +218,7 @@ class AdminPageControllerTest extends AbstractFunctionalTest
         );
     }
 
-    public function testListingIntroEditFormIgnoresLockedFieldSubmissions(): void
+    public function testListingIntroEditFormHidesLockedFields(): void
     {
         $entityManager = self::getContainer()->get(EntityManagerInterface::class);
         \assert($entityManager instanceof EntityManagerInterface);
@@ -249,28 +249,69 @@ class AdminPageControllerTest extends AbstractFunctionalTest
         $this->loginAs('admin@example.com');
         $crawler = $this->client->request('GET', '/admin/pages/'.$reservedId);
         self::assertResponseIsSuccessful();
-        self::assertSelectorTextContains('.alert-info', 'menu category');
 
-        // The settings form button is "Save" — submit it with attacker-controlled
-        // values for every locked field. Symfony's `disabled => true` ignores the
-        // submitted values and the entity's existing values must persist.
-        $form = $crawler->selectButton('Save')->form();
-        $values = $form->getPhpValues()['page_form'] ?? [];
-        $values['slug'] = 'pwned-slug';
-        $values['isPublished'] = '0';
-        $values['noIndex'] = '1';
-        $values['ogImage'] = 'https://attacker.example/x.png';
+        // Only menu category and per-locale content are exposed; everything else
+        // is omitted from the form so the corresponding inputs are absent.
+        self::assertCount(0, $crawler->filter('input[name="page_form[slug]"]'));
+        self::assertCount(0, $crawler->filter('select[name="page_form[channel]"]'));
+        self::assertCount(0, $crawler->filter('input[name="page_form[isPublished]"]'));
+        self::assertCount(0, $crawler->filter('input[name="page_form[noIndex]"]'));
+        self::assertCount(0, $crawler->filter('input[name="page_form[ogImage]"]'));
+        self::assertCount(1, $crawler->filter('select[name="page_form[menuCategory]"]'));
+    }
 
-        $this->client->request('POST', '/admin/pages/'.$reservedId, ['page_form' => $values]);
-        self::assertResponseRedirects();
+    public function testListingIntroEditFormRejectsForgedLockedFieldPosts(): void
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+
+        /** @var ChannelRepository $channelRepository */
+        $channelRepository = self::getContainer()->get(ChannelRepository::class);
+        $channel = $channelRepository->findOneBy([]);
+        self::assertNotNull($channel);
+
+        $reserved = new Page();
+        $reserved->setSlug(ListingIntroPage::BANNED_CARDS_SLUG);
+        $reserved->setChannel($channel);
+        $reserved->setIsPublished(true);
+        $reserved->setNoIndex(false);
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Original title');
+        $translation->setContent('Original content.');
+        $reserved->addTranslation($translation);
+
+        $entityManager->persist($reserved);
+        $entityManager->flush();
+
+        $reservedId = $reserved->getId();
+        self::assertNotNull($reservedId);
+
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', '/admin/pages/'.$reservedId);
+        $token = $crawler->filter('input[name="page_form[_token]"]')->attr('value');
+
+        // POST with attacker-supplied values for every locked field. Symfony's
+        // default `allow_extra_fields = false` rejects the form on extras, so the
+        // controller's `isValid()` short-circuit prevents any flush.
+        $this->client->request('POST', '/admin/pages/'.$reservedId, [
+            'page_form' => [
+                '_token' => $token,
+                'slug' => 'pwned-slug',
+                'isPublished' => '0',
+                'noIndex' => '1',
+                'ogImage' => 'https://attacker.example/x.png',
+            ],
+        ]);
 
         $entityManager->clear();
         $reloaded = $entityManager->getRepository(Page::class)->find($reservedId);
         self::assertInstanceOf(Page::class, $reloaded);
-        self::assertSame(ListingIntroPage::BANNED_CARDS_SLUG, $reloaded->getSlug(), 'Slug must remain locked.');
-        self::assertTrue($reloaded->isPublished(), 'Published flag must remain locked.');
-        self::assertFalse($reloaded->isNoIndex(), 'noIndex must remain locked.');
-        self::assertNull($reloaded->getOgImage(), 'ogImage must remain locked.');
+        self::assertSame(ListingIntroPage::BANNED_CARDS_SLUG, $reloaded->getSlug());
+        self::assertTrue($reloaded->isPublished());
+        self::assertFalse($reloaded->isNoIndex());
+        self::assertNull($reloaded->getOgImage());
     }
 
     public function testDeleteOnListingIntroPageIsRefused(): void

--- a/tests/Functional/AdminPageControllerTest.php
+++ b/tests/Functional/AdminPageControllerTest.php
@@ -218,6 +218,61 @@ class AdminPageControllerTest extends AbstractFunctionalTest
         );
     }
 
+    public function testListingIntroEditFormIgnoresLockedFieldSubmissions(): void
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+
+        /** @var ChannelRepository $channelRepository */
+        $channelRepository = self::getContainer()->get(ChannelRepository::class);
+        $channel = $channelRepository->findOneBy([]);
+        self::assertNotNull($channel);
+
+        $reserved = new Page();
+        $reserved->setSlug(ListingIntroPage::BANNED_CARDS_SLUG);
+        $reserved->setChannel($channel);
+        $reserved->setIsPublished(true);
+        $reserved->setNoIndex(false);
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Original title');
+        $translation->setContent('Original content.');
+        $reserved->addTranslation($translation);
+
+        $entityManager->persist($reserved);
+        $entityManager->flush();
+
+        $reservedId = $reserved->getId();
+        self::assertNotNull($reservedId);
+
+        $this->loginAs('admin@example.com');
+        $crawler = $this->client->request('GET', '/admin/pages/'.$reservedId);
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('.alert-info', 'menu category');
+
+        // The settings form button is "Save" — submit it with attacker-controlled
+        // values for every locked field. Symfony's `disabled => true` ignores the
+        // submitted values and the entity's existing values must persist.
+        $form = $crawler->selectButton('Save')->form();
+        $values = $form->getPhpValues()['page_form'] ?? [];
+        $values['slug'] = 'pwned-slug';
+        $values['isPublished'] = '0';
+        $values['noIndex'] = '1';
+        $values['ogImage'] = 'https://attacker.example/x.png';
+
+        $this->client->request('POST', '/admin/pages/'.$reservedId, ['page_form' => $values]);
+        self::assertResponseRedirects();
+
+        $entityManager->clear();
+        $reloaded = $entityManager->getRepository(Page::class)->find($reservedId);
+        self::assertInstanceOf(Page::class, $reloaded);
+        self::assertSame(ListingIntroPage::BANNED_CARDS_SLUG, $reloaded->getSlug(), 'Slug must remain locked.');
+        self::assertTrue($reloaded->isPublished(), 'Published flag must remain locked.');
+        self::assertFalse($reloaded->isNoIndex(), 'noIndex must remain locked.');
+        self::assertNull($reloaded->getOgImage(), 'ogImage must remain locked.');
+    }
+
     public function testDeleteOnListingIntroPageIsRefused(): void
     {
         $entityManager = self::getContainer()->get(EntityManagerInterface::class);

--- a/tests/Twig/MenuRuntimeTest.php
+++ b/tests/Twig/MenuRuntimeTest.php
@@ -15,12 +15,14 @@ namespace App\Tests\Twig;
 
 use App\Entity\Channel;
 use App\Entity\MenuCategory;
+use App\Entity\Page;
 use App\Repository\MenuCategoryRepository;
 use App\Service\Channel\ChannelContext;
 use App\Twig\Runtime\MenuRuntime;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
@@ -42,7 +44,7 @@ class MenuRuntimeTest extends TestCase
             ->with('menu_categories_app', self::callback(static fn (mixed $value): bool => \is_callable($value)))
             ->willReturn([$category]);
 
-        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache);
+        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache, $this->createStub(UrlGeneratorInterface::class), new RequestStack());
         $result = $runtime->getCategories();
 
         self::assertCount(1, $result);
@@ -69,7 +71,7 @@ class MenuRuntimeTest extends TestCase
                 return $callback($item);
             });
 
-        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache);
+        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache, $this->createStub(UrlGeneratorInterface::class), new RequestStack());
         $result = $runtime->getCategories();
 
         self::assertCount(1, $result);
@@ -84,7 +86,7 @@ class MenuRuntimeTest extends TestCase
             ->method('get')
             ->willReturn([]);
 
-        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache);
+        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache, $this->createStub(UrlGeneratorInterface::class), new RequestStack());
         $result = $runtime->getCategories();
 
         self::assertSame([], $result);
@@ -103,7 +105,7 @@ class MenuRuntimeTest extends TestCase
             ->with('footer_categories_app', self::callback(static fn (mixed $value): bool => \is_callable($value)))
             ->willReturn([$category]);
 
-        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache);
+        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache, $this->createStub(UrlGeneratorInterface::class), new RequestStack());
         $result = $runtime->getFooterCategories();
 
         self::assertCount(1, $result);
@@ -131,7 +133,7 @@ class MenuRuntimeTest extends TestCase
                 return $callback($item);
             });
 
-        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache);
+        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache, $this->createStub(UrlGeneratorInterface::class), new RequestStack());
         $result = $runtime->getFooterCategories();
 
         self::assertCount(1, $result);
@@ -155,8 +157,127 @@ class MenuRuntimeTest extends TestCase
                 return true;
             });
 
-        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache);
+        $runtime = new MenuRuntime($repository, $this->createChannelContext(), $cache, $this->createStub(UrlGeneratorInterface::class), new RequestStack());
         $runtime->invalidateCache();
+    }
+
+    public function testGetPageUrlForRegularPageUsesAppPageShowRoute(): void
+    {
+        $page = (new Page())->setSlug('about-us');
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::once())
+            ->method('generate')
+            ->with('app_page_show', ['_locale' => 'fr', 'slug' => 'about-us'])
+            ->willReturn('/fr/pages/about-us');
+
+        $runtime = new MenuRuntime(
+            $this->createStub(MenuCategoryRepository::class),
+            $this->createChannelContext(),
+            $this->createStub(CacheInterface::class),
+            $urlGenerator,
+            $this->createRequestStackWithLocale('fr'),
+        );
+
+        self::assertSame('/fr/pages/about-us', $runtime->getPageUrl($page));
+    }
+
+    public function testGetPageUrlForBannedIntroSlugUsesListingRoute(): void
+    {
+        $page = (new Page())->setSlug('banned-cards-intro');
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::once())
+            ->method('generate')
+            ->with('app_banned_card_list', ['_locale' => 'en'])
+            ->willReturn('/en/banned-cards');
+
+        $runtime = new MenuRuntime(
+            $this->createStub(MenuCategoryRepository::class),
+            $this->createChannelContext(),
+            $this->createStub(CacheInterface::class),
+            $urlGenerator,
+            $this->createRequestStackWithLocale('en'),
+        );
+
+        self::assertSame('/en/banned-cards', $runtime->getPageUrl($page));
+    }
+
+    public function testGetPageUrlForStapleIntroSlugUsesListingRoute(): void
+    {
+        $page = (new Page())->setSlug('staple-cards-intro');
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::once())
+            ->method('generate')
+            ->with('app_staple_card_list', ['_locale' => 'en'])
+            ->willReturn('/en/staple-cards');
+
+        $runtime = new MenuRuntime(
+            $this->createStub(MenuCategoryRepository::class),
+            $this->createChannelContext(),
+            $this->createStub(CacheInterface::class),
+            $urlGenerator,
+            $this->createRequestStackWithLocale('en'),
+        );
+
+        self::assertSame('/en/staple-cards', $runtime->getPageUrl($page));
+    }
+
+    public function testIsListingIntroInMenuReturnsTrueWhenIntroPageIsCategorised(): void
+    {
+        $introPage = (new Page())->setSlug('banned-cards-intro')->setIsPublished(true);
+        $category = new MenuCategory();
+        $category->getPages()->add($introPage);
+
+        $cache = $this->createStub(CacheInterface::class);
+        $cache->method('get')->willReturn([$category]);
+
+        $runtime = new MenuRuntime(
+            $this->createStub(MenuCategoryRepository::class),
+            $this->createChannelContext(),
+            $cache,
+            $this->createStub(UrlGeneratorInterface::class),
+            new RequestStack(),
+        );
+
+        self::assertTrue($runtime->isListingIntroInMenu('banned-cards-intro'));
+    }
+
+    public function testIsListingIntroInMenuReturnsFalseWhenIntroPageHasNoCategory(): void
+    {
+        $regularPage = (new Page())->setSlug('about-us')->setIsPublished(true);
+        $category = new MenuCategory();
+        $category->getPages()->add($regularPage);
+
+        $cache = $this->createStub(CacheInterface::class);
+        $cache->method('get')->willReturn([$category]);
+
+        $runtime = new MenuRuntime(
+            $this->createStub(MenuCategoryRepository::class),
+            $this->createChannelContext(),
+            $cache,
+            $this->createStub(UrlGeneratorInterface::class),
+            new RequestStack(),
+        );
+
+        self::assertFalse($runtime->isListingIntroInMenu('banned-cards-intro'));
+    }
+
+    public function testIsListingIntroInMenuReturnsFalseForNonReservedSlug(): void
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::never())->method('get');
+
+        $runtime = new MenuRuntime(
+            $this->createStub(MenuCategoryRepository::class),
+            $this->createChannelContext(),
+            $cache,
+            $this->createStub(UrlGeneratorInterface::class),
+            new RequestStack(),
+        );
+
+        self::assertFalse($runtime->isListingIntroInMenu('about-us'));
     }
 
     private function createChannelContext(): ChannelContext
@@ -170,5 +291,16 @@ class MenuRuntimeTest extends TestCase
         $requestStack->push($request);
 
         return new ChannelContext($requestStack);
+    }
+
+    private function createRequestStackWithLocale(string $locale): RequestStack
+    {
+        $request = new Request();
+        $request->setLocale($locale);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return $requestStack;
     }
 }

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -4389,6 +4389,11 @@
                 <target>Deletion locked</target>
                 <note>Heading shown in place of the danger zone for reserved listing-intro pages</note>
             </trans-unit>
+            <trans-unit id="app.cms.admin.listing_intro_locked_fields">
+                <source>app.cms.admin.listing_intro_locked_fields</source>
+                <target>This page backs the editable intro block on a listing page. Only the menu category and the content are editable; slug, channel, title, publish state and SEO fields are locked to keep the listing route working.</target>
+                <note>Banner shown on the edit page for reserved listing-intro pages</note>
+            </trans-unit>
             <trans-unit id="app.cms.admin.delete_locked_listing_intro_help">
                 <source>app.cms.admin.delete_locked_listing_intro_help</source>
                 <target>This page backs the editable intro block on a listing page (banned cards or staple cards) and cannot be deleted. Unpublish it or clear its content instead.</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -4384,6 +4384,16 @@
                 <source>app.cms.admin.delete_confirm</source>
                 <target>Are you sure you want to delete this page?</target>
             </trans-unit>
+            <trans-unit id="app.cms.admin.delete_locked_listing_intro">
+                <source>app.cms.admin.delete_locked_listing_intro</source>
+                <target>Deletion locked</target>
+                <note>Heading shown in place of the danger zone for reserved listing-intro pages</note>
+            </trans-unit>
+            <trans-unit id="app.cms.admin.delete_locked_listing_intro_help">
+                <source>app.cms.admin.delete_locked_listing_intro_help</source>
+                <target>This page backs the editable intro block on a listing page (banned cards or staple cards) and cannot be deleted. Unpublish it or clear its content instead.</target>
+                <note>Help text under the locked-deletion heading</note>
+            </trans-unit>
             <trans-unit id="app.cms.admin.search_placeholder">
                 <source>app.cms.admin.search_placeholder</source>
                 <target>Search by slug or title…</target>
@@ -4593,6 +4603,11 @@
                 <source>app.flash.page.deleted</source>
                 <target>Page deleted.</target>
                 <note>Success flash after soft-deleting a page</note>
+            </trans-unit>
+            <trans-unit id="app.flash.page.cannot_delete_listing_intro">
+                <source>app.flash.page.cannot_delete_listing_intro</source>
+                <target>This page backs the editable intro block on a listing page and cannot be deleted.</target>
+                <note>Error flash when an admin tries to delete a reserved listing-intro page</note>
             </trans-unit>
             <trans-unit id="app.cms.category_created">
                 <source>app.cms.category_created</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -4359,6 +4359,16 @@
                 <source>app.cms.admin.delete_confirm</source>
                 <target>Êtes-vous sûr de vouloir supprimer cette page ?</target>
             </trans-unit>
+            <trans-unit id="app.cms.admin.delete_locked_listing_intro">
+                <source>app.cms.admin.delete_locked_listing_intro</source>
+                <target>Suppression verrouillée</target>
+                <note>Heading shown in place of the danger zone for reserved listing-intro pages</note>
+            </trans-unit>
+            <trans-unit id="app.cms.admin.delete_locked_listing_intro_help">
+                <source>app.cms.admin.delete_locked_listing_intro_help</source>
+                <target>Cette page sert de bloc d'introduction éditable à une liste (banned cards ou staples) et ne peut pas être supprimée. Dépubliez-la ou videz son contenu à la place.</target>
+                <note>Help text under the locked-deletion heading</note>
+            </trans-unit>
             <trans-unit id="app.cms.admin.search_placeholder">
                 <source>app.cms.admin.search_placeholder</source>
                 <target>Rechercher par slug ou titre…</target>
@@ -4568,6 +4578,11 @@
                 <source>app.flash.page.deleted</source>
                 <target>Page supprimée.</target>
                 <note>Success flash after soft-deleting a page</note>
+            </trans-unit>
+            <trans-unit id="app.flash.page.cannot_delete_listing_intro">
+                <source>app.flash.page.cannot_delete_listing_intro</source>
+                <target>Cette page sert de bloc d'introduction éditable à une liste et ne peut pas être supprimée.</target>
+                <note>Error flash when an admin tries to delete a reserved listing-intro page</note>
             </trans-unit>
             <trans-unit id="app.cms.category_created">
                 <source>app.cms.category_created</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -4364,6 +4364,11 @@
                 <target>Suppression verrouillée</target>
                 <note>Heading shown in place of the danger zone for reserved listing-intro pages</note>
             </trans-unit>
+            <trans-unit id="app.cms.admin.listing_intro_locked_fields">
+                <source>app.cms.admin.listing_intro_locked_fields</source>
+                <target>Cette page sert de bloc d'introduction éditable à une liste. Seuls la catégorie de menu et le contenu sont modifiables ; le slug, le channel, le titre, la publication et les champs SEO sont verrouillés pour préserver le routage de la liste.</target>
+                <note>Banner shown on the edit page for reserved listing-intro pages</note>
+            </trans-unit>
             <trans-unit id="app.cms.admin.delete_locked_listing_intro_help">
                 <source>app.cms.admin.delete_locked_listing_intro_help</source>
                 <target>Cette page sert de bloc d'introduction éditable à une liste (banned cards ou staples) et ne peut pas être supprimée. Dépubliez-la ou videz son contenu à la place.</target>


### PR DESCRIPTION
## Summary

Until now the banned-cards / staple-cards listing pages each had a sibling reserved-slug `Page` (`banned-cards-intro`, `staple-cards-intro`) that backed an editable Markdown intro block, but their nav links were hardcoded in `base.html.twig` at a fixed position. Assigning a `menuCategory` to one of these pages had no useful effect and would have produced a duplicate nav entry. This branch makes the menu placement of these pages follow `menuCategory` like any other CMS page, while protecting the invariants the listing controllers and the search indexer rely on.

- **Route listing-intro pages through their menu category when set** (`ea6f4e3`). Two new Twig helpers: `cms_page_url(page)` resolves reserved-slug pages directly to their listing route (skipping the 301 from `app_page_show`), and `listing_intro_in_menu(slug)` returns true when the slug appears in the cached `menu_categories()` collection. `base.html.twig` uses both: the menu loop renders intro pages via `cms_page_url`, and the hardcoded fallback links are gated on `not listing_intro_in_menu(...)` so we never get duplicates. `PageRepository::createAdminListQueryBuilder` now scopes the reserved-slug filter to the all-pages view only, so per-category drag-reorder includes intro pages alongside their siblings. Footer rendering also uses `cms_page_url` for consistency. Docs updated in `docs/models/cms.md`.
- **Block deletion of reserved listing-intro pages** (`9d7c750`). Now that they appear in the per-category admin list, an admin could otherwise soft-delete them via the edit page, breaking the listing controllers. `AdminPageController::delete` refuses for `ListingIntroPage::SLUGS` with a flash message; the guard runs before the CSRF check so a CLI/curl probe also gets the clear error. The edit template hides the danger zone for reserved slugs and renders a "deletion locked" notice in its place. New `is_listing_intro_slug(slug)` Twig helper.
- **Lock non-editable fields on listing-intro pages** (`bbcce9d` + `dbd3b94`). Only `menuCategory` (page form) and `content` (translation form) are editable; `slug`, `channel`, `isPublished`, `noIndex`, `ogImage`, and `title` are now omitted from the form entirely on these pages. Removing the field is stricter than `disabled => true`: Symfony's default `allow_extra_fields = false` rejects forged POSTs that include the omitted fields, so `isValid()` short-circuits and no flush happens. New `is_listing_intro` form option drives the conditional `add()` calls.
- **Bridge Mantine color scheme to `data-bs-theme`** (`0308f21` + `718b730` + `a0e418c`). On the same edit page, the Mantine `RichTextEditor` rendered light surfaces over the dark background because `MantineProvider` was using `defaultColorScheme="auto"` (OS preference) instead of tracking the resolved `data-bs-theme` attribute set by the inline bridge script in `base.html.twig`. New `MantineColorSchemeManager` in `AppMantineProvider.tsx` reads from `data-bs-theme` and watches it via `MutationObserver`, so Mantine's native dark palette themes the entire RichTextEditor (root, toolbar, control buttons, hover/active states) plus any other Mantine component on admin pages. The follow-up commit (`a0e418c`) breaks a feedback loop in the manager: `set` is now a no-op (persistence is owned by `window.__edTheme`, which the in-page theme switcher calls directly) and the observer dedupes on the resolved scheme, so a `setAttribute` round-trip can't re-enter the React update cycle and freeze the tab.

## Test plan

- [ ] **Default (no category):** Both anon and logged-in users see banned/staple links between Archetypes and Decks (existing position).
- [ ] **Assign a category:** Edit `/banned-cards` → "Edit Intro" → set `menuCategory`, save. The link appears in that category's dropdown using `/banned-cards` directly (DevTools network: no 301), and the hardcoded fallback is gone.
- [ ] **Reorder:** In Admin → Pages, filter by the assigned category, drag the intro page among siblings. Reload the nav and confirm the new order respects `position`.
- [ ] **Unassign:** Clear `menuCategory` → reload nav → link returns to its hardcoded position.
- [ ] **Channel disabled:** Disable `channel.enableBannedCards` → link is absent regardless of `menuCategory`.
- [ ] **Per-locale label:** Set distinct titles in `PageTranslation` for `en`/`fr` → confirm the dropdown label switches with the active locale.
- [ ] **Delete blocked:** On the edit page for a reserved-slug page, the danger zone is replaced by a "deletion locked" notice. Forge a `POST /admin/pages/{id}/delete` via curl/devtools and confirm the page is not soft-deleted (entity's `deletedAt` stays null).
- [ ] **Locked fields hidden:** On the edit page for a reserved-slug page, only the `menuCategory` selector and the per-locale `content` editor are visible; slug, channel, isPublished, noIndex, ogImage, and title inputs are absent from the DOM.
- [ ] **Forged-field POST rejected:** Submit a `POST /admin/pages/{id}` payload with `page_form[slug]=pwned-slug&page_form[isPublished]=0&...` for a reserved page; confirm the entity's slug, isPublished, etc. are unchanged.
- [ ] **Mantine dark mode:** Open `/admin/pages/{id}` for a reserved page in dark mode. The RichTextEditor toolbar AND its individual control buttons render dark, hover/active states use Mantine's dark accent. Toggle to light mode → editor swaps cleanly.
- [ ] **No tab freeze:** Page loads without CPU pegging or unresponsive UI; theme toggle remains snappy across multiple flips.
- [ ] **OS preference change:** Toggle the OS color preference while the edit page is open with the app set to "auto" → the editor updates in real time (exercises the `MutationObserver` path).
- [ ] **Pre-commit gates:** `make phpstan`, `make twig-cs-fix`, `make cs-fix`, `make stylelint`, `make eslint`, `make lint-i18n`, `make lint-container`, `make test` (2293/2293), `make test.front` (26/26), `make assets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)