### PR TITLE
:bug: Fix: scroll banned & staple card modals on mobile

### DIFF
--- a/assets/banned-card-list.ts
+++ b/assets/banned-card-list.ts
@@ -74,20 +74,11 @@ function initBannedCardModal(modalElement: HTMLElement, triggers: HTMLButtonElem
             touchStartY = touch.clientY;
         }, { passive: true });
 
-        modalBody.addEventListener('touchmove', (event) => {
-            const touch = (event as TouchEvent).touches[0];
-            const deltaX = Math.abs(touch.clientX - touchStartX);
-            const deltaY = Math.abs(touch.clientY - touchStartY);
-            // Block vertical scroll; allow horizontal swipe to drive navigation
-            if (deltaY > deltaX) {
-                event.preventDefault();
-            }
-        }, { passive: false });
-
         modalBody.addEventListener('touchend', (event) => {
-            const touchEndX = (event as TouchEvent).changedTouches[0].clientX;
-            const deltaX = touchEndX - touchStartX;
-            if (Math.abs(deltaX) > SWIPE_THRESHOLD) {
+            const touch = (event as TouchEvent).changedTouches[0];
+            const deltaX = touch.clientX - touchStartX;
+            const deltaY = touch.clientY - touchStartY;
+            if (Math.abs(deltaX) > SWIPE_THRESHOLD && Math.abs(deltaX) > Math.abs(deltaY)) {
                 navigate(deltaX < 0 ? 1 : -1);
             }
         }, { passive: true });

--- a/assets/staple-card-list.ts
+++ b/assets/staple-card-list.ts
@@ -76,20 +76,11 @@ function initStapleCardModal(modalElement: HTMLElement, triggers: HTMLButtonElem
             touchStartY = touch.clientY;
         }, { passive: true });
 
-        modalBody.addEventListener('touchmove', (event) => {
-            const touch = (event as TouchEvent).touches[0];
-            const deltaX = Math.abs(touch.clientX - touchStartX);
-            const deltaY = Math.abs(touch.clientY - touchStartY);
-            // Block vertical scroll; allow horizontal swipe to drive navigation
-            if (deltaY > deltaX) {
-                event.preventDefault();
-            }
-        }, { passive: false });
-
         modalBody.addEventListener('touchend', (event) => {
-            const touchEndX = (event as TouchEvent).changedTouches[0].clientX;
-            const deltaX = touchEndX - touchStartX;
-            if (Math.abs(deltaX) > SWIPE_THRESHOLD) {
+            const touch = (event as TouchEvent).changedTouches[0];
+            const deltaX = touch.clientX - touchStartX;
+            const deltaY = touch.clientY - touchStartY;
+            if (Math.abs(deltaX) > SWIPE_THRESHOLD && Math.abs(deltaX) > Math.abs(deltaY)) {
                 navigate(deltaX < 0 ? 1 : -1);
             }
         }, { passive: true });

--- a/templates/banned_card/list.html.twig
+++ b/templates/banned_card/list.html.twig
@@ -92,7 +92,7 @@
     {% if bannedCards|length > 0 %}
         {# Modal — populated from the clicked card's data attributes #}
         <div class="modal fade" id="bannedCardModal" tabindex="-1" aria-labelledby="bannedCardModalLabel" aria-hidden="true">
-            <div class="modal-dialog modal-dialog-centered modal-lg">
+            <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="bannedCardModalLabel"></h5>

--- a/templates/staple_card/list.html.twig
+++ b/templates/staple_card/list.html.twig
@@ -87,7 +87,7 @@
         {% endfor %}
 
         <div class="modal fade" id="stapleCardModal" tabindex="-1" aria-labelledby="stapleCardModalLabel" aria-hidden="true">
-            <div class="modal-dialog modal-dialog-centered modal-lg">
+            <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="stapleCardModalLabel"></h5>


### PR DESCRIPTION
## Summary

- The card modals on `/banned-cards` and `/staple-cards` could not be scrolled on mobile: the `touchmove` handler on `.modal-body` called `event.preventDefault()` whenever vertical drag dominated horizontal drag, which cancels the browser's native scroll. Users only ever saw the card image — the explanation, source link, and printings list below the fold were unreachable.
- Removed the `touchmove` listener entirely so the browser scrolls natively, and tightened the existing `touchend` swipe-detection to require horizontal dominance (`|deltaX| > |deltaY|` AND `|deltaX| > SWIPE_THRESHOLD`). Horizontal-swipe navigation still works; near-vertical swipes no longer mis-trigger it.
- Added Bootstrap's `modal-dialog-scrollable` to both modals so `.modal-body` is the scroll container — the header (with the `×` close button) stays pinned on mobile while content scrolls.

Net change: **−18 lines**, no new SCSS, no new dependencies.

Affected files:
- `assets/banned-card-list.ts`
- `assets/staple-card-list.ts`
- `templates/banned_card/list.html.twig`
- `templates/staple_card/list.html.twig`

## Test plan

- [ ] On a real phone (or DevTools mobile emulation), open `/banned-cards`, tap a card with a long explanation, confirm vertical drag scrolls the body
- [ ] Same on `/staple-cards`
- [ ] Modal header + close `×` stay pinned while body scrolls
- [ ] Horizontal swipe still navigates between cards
- [ ] Near-vertical swipe does **not** spuriously trigger navigation
- [ ] Desktop: chevron buttons, arrow keys, and click-to-close all still work
- [ ] Modal still appears centered when content fits the viewport