### PR TITLE
:sparkles: feat: AND/OR combinator for archetype playstyle tags

### DIFF
--- a/src/Controller/ArchetypeCatalogController.php
+++ b/src/Controller/ArchetypeCatalogController.php
@@ -38,6 +38,7 @@ class ArchetypeCatalogController extends AbstractController
             $allTags = [];
             $tags = [];
             $sort = 'name';
+            $tagsMode = 'and';
         } else {
             /** @var list<string> $tags */
             $tags = $request->query->all('tags');
@@ -48,7 +49,12 @@ class ArchetypeCatalogController extends AbstractController
                 $sort = 'position';
             }
 
-            $results = $archetypeRepository->findPublishedWithDeckCounts($tags, $sort);
+            $tagsMode = $request->query->getString('tagsMode', 'and');
+            if (!\in_array($tagsMode, ['and', 'or'], true)) {
+                $tagsMode = 'and';
+            }
+
+            $results = $archetypeRepository->findPublishedWithDeckCounts($tags, $sort, $tagsMode);
             $allTags = $archetypeRepository->findAllPublishedPlaystyleTags();
         }
 
@@ -57,6 +63,7 @@ class ArchetypeCatalogController extends AbstractController
             'allTags' => $allTags,
             'currentTags' => $tags,
             'currentSort' => $sort,
+            'currentTagsMode' => $tagsMode,
             'showDrafts' => $showDrafts,
         ]);
     }

--- a/src/Controller/ArchetypeCatalogController.php
+++ b/src/Controller/ArchetypeCatalogController.php
@@ -33,12 +33,16 @@ class ArchetypeCatalogController extends AbstractController
     {
         $showDrafts = $request->query->getBoolean('drafts') && $this->isGranted('ROLE_ARCHETYPE_EDITOR');
 
+        $tagsMode = $request->query->getString('tagsMode', 'and');
+        if (!\in_array($tagsMode, ['and', 'or'], true)) {
+            $tagsMode = 'and';
+        }
+
         if ($showDrafts) {
             $results = $archetypeRepository->findUnpublishedWithDeckCounts();
             $allTags = [];
             $tags = [];
             $sort = 'name';
-            $tagsMode = 'and';
         } else {
             /** @var list<string> $tags */
             $tags = $request->query->all('tags');
@@ -47,11 +51,6 @@ class ArchetypeCatalogController extends AbstractController
 
             if (!\in_array($sort, ['name', 'decks', 'position'], true)) {
                 $sort = 'position';
-            }
-
-            $tagsMode = $request->query->getString('tagsMode', 'and');
-            if (!\in_array($tagsMode, ['and', 'or'], true)) {
-                $tagsMode = 'and';
             }
 
             $results = $archetypeRepository->findPublishedWithDeckCounts($tags, $sort, $tagsMode);

--- a/src/Repository/ArchetypeRepository.php
+++ b/src/Repository/ArchetypeRepository.php
@@ -82,15 +82,20 @@ class ArchetypeRepository extends ServiceEntityRepository
      * Find all published archetypes with their public deck count.
      *
      * Returns an array of [archetype => Archetype, deckCount => int] rows,
-     * optionally filtered by playstyle tags (OR logic) and sorted by the given criteria.
+     * optionally filtered by playstyle tags and sorted by the given criteria.
+     * The tags filter combines selected tags with AND (must match every tag) by
+     * default, or OR (matches any) when `$tagsMode === 'or'`. Any other value is
+     * treated as `'and'`.
      *
      * @see docs/features.md F2.16 — Archetype catalog
+     * @see https://github.com/jbourdin/expandedDecks/issues/548
      *
-     * @param list<string> $tags playstyle tags to filter by (OR: matches any)
+     * @param list<string> $tags     playstyle tags to filter by
+     * @param string       $tagsMode 'and' (default — matches every selected tag) or 'or' (matches any)
      *
      * @return list<array{archetype: Archetype, deckCount: int}>
      */
-    public function findPublishedWithDeckCounts(array $tags = [], string $sort = 'name'): array
+    public function findPublishedWithDeckCounts(array $tags = [], string $sort = 'name', string $tagsMode = 'and'): array
     {
         $qb = $this->createQueryBuilder('a')
             ->select('a AS archetype')
@@ -114,7 +119,8 @@ class ArchetypeRepository extends ServiceEntityRepository
                 $tagConditions[] = 'a.playstyleTags LIKE :'.$paramName;
                 $qb->setParameter($paramName, '%"'.$tag.'"%');
             }
-            $qb->andWhere(implode(' OR ', $tagConditions));
+            $separator = 'or' === $tagsMode ? ' OR ' : ' AND ';
+            $qb->andWhere(implode($separator, $tagConditions));
         }
 
         if ('decks' === $sort) {

--- a/templates/archetype/list.html.twig
+++ b/templates/archetype/list.html.twig
@@ -38,6 +38,14 @@
 {% block body %}
     <h1 class="mb-4">{{ 'app.archetype.catalog_title'|trans }}</h1>
 
+    {#
+     # Build the tagsMode query-string fragment once and reuse it on every
+     # path() that needs to preserve the user's combinator choice. AND is the
+     # default, so we omit it from the URL — only OR is materialised.
+     # @see https://github.com/jbourdin/expandedDecks/issues/548
+     #}
+    {% set tagsModeParam = currentTagsMode == 'or' ? {tagsMode: 'or'} : {} %}
+
     {# Filter / sort bar #}
     <div class="card shadow-sm mb-4">
         <div class="card-body">
@@ -55,7 +63,7 @@
                             {% else %}
                                 {% set newTags = currentTags|merge([tag]) %}
                             {% endif %}
-                            <a href="{{ path('app_archetype_list', {tags: newTags, sort: currentSort}) }}" class="btn btn-sm {{ isActive ? 'btn-gold' : 'btn-outline-secondary' }}">
+                            <a href="{{ path('app_archetype_list', {tags: newTags, sort: currentSort}|merge(tagsModeParam)) }}" class="btn btn-sm {{ isActive ? 'btn-gold' : 'btn-outline-secondary' }}">
                                 {{ tag }}
                             </a>
                         {% endfor %}
@@ -65,18 +73,31 @@
                             </a>
                         {% endif %}
                     </div>
+                    {% if currentTags|length >= 2 %}
+                        <div class="d-flex align-items-center gap-2 mt-2">
+                            <small class="text-muted">{{ 'app.archetype.tags_mode.label'|trans }}</small>
+                            <div class="btn-group btn-group-sm" role="group" aria-label="{{ 'app.archetype.tags_mode.label'|trans }}">
+                                <a href="{{ path('app_archetype_list', {tags: currentTags, sort: currentSort}) }}" class="btn {{ currentTagsMode == 'and' ? 'btn-gold' : 'btn-outline-secondary' }}">
+                                    {{ 'app.archetype.tags_mode.and'|trans }}
+                                </a>
+                                <a href="{{ path('app_archetype_list', {tags: currentTags, sort: currentSort, tagsMode: 'or'}) }}" class="btn {{ currentTagsMode == 'or' ? 'btn-gold' : 'btn-outline-secondary' }}">
+                                    {{ 'app.archetype.tags_mode.or'|trans }}
+                                </a>
+                            </div>
+                        </div>
+                    {% endif %}
                 </div>
                 <div class="col-md-3 ms-auto">
                     <label class="form-label">{{ 'app.archetype.sort_by'|trans }}</label>
                     <select class="form-select form-select-sm" onchange="window.location.href=this.value">
-                        <option value="{{ path('app_archetype_list', {tags: currentTags, sort: 'position'}) }}" {{ currentSort == 'position' ? 'selected' }}>
+                        <option value="{{ path('app_archetype_list', {tags: currentTags, sort: 'position'}|merge(tagsModeParam)) }}" {{ currentSort == 'position' ? 'selected' }}>
                             {{ 'app.archetype.sort_relevance'|trans }}
                         </option>
-                        <option value="{{ path('app_archetype_list', {tags: currentTags, sort: 'name'}) }}" {{ currentSort == 'name' ? 'selected' }}>
+                        <option value="{{ path('app_archetype_list', {tags: currentTags, sort: 'name'}|merge(tagsModeParam)) }}" {{ currentSort == 'name' ? 'selected' }}>
                             {{ 'app.common.name'|trans }}
                         </option>
                         {% if current_channel().enableDecks %}
-                            <option value="{{ path('app_archetype_list', {tags: currentTags, sort: 'decks'}) }}" {{ currentSort == 'decks' ? 'selected' }}>
+                            <option value="{{ path('app_archetype_list', {tags: currentTags, sort: 'decks'}|merge(tagsModeParam)) }}" {{ currentSort == 'decks' ? 'selected' }}>
                                 {{ 'app.archetype.sort_decks'|trans }}
                             </option>
                         {% endif %}

--- a/tests/Functional/ArchetypeCatalogControllerTest.php
+++ b/tests/Functional/ArchetypeCatalogControllerTest.php
@@ -91,11 +91,61 @@ class ArchetypeCatalogControllerTest extends AbstractFunctionalTest
         self::assertResponseIsSuccessful();
     }
 
-    public function testFilterByMultipleTagsUsesOrLogic(): void
+    /**
+     * @see https://github.com/jbourdin/expandedDecks/issues/548
+     */
+    public function testFilterByMultipleTagsUsesAndLogicByDefault(): void
     {
-        $this->client->request('GET', '/en/archetypes?tags[]=Aggro&tags[]=Control');
+        // Fixture: only "Iron Thorns ex" carries both Aggressive and Spread.
+        $crawler = $this->client->request('GET', '/en/archetypes?tags[]=Aggressive&tags[]=Spread');
 
         self::assertResponseIsSuccessful();
+        self::assertCount(1, $crawler->filter('.col-lg-4 .card-title'));
+    }
+
+    /**
+     * @see https://github.com/jbourdin/expandedDecks/issues/548
+     */
+    public function testFilterByMultipleTagsWithOrModeMatchesAny(): void
+    {
+        // Fixture: Aggressive ∪ Spread covers Iron Thorns, Ancient Box, Kyurem, Salamence, Charizard Flareon.
+        $crawler = $this->client->request('GET', '/en/archetypes?tags[]=Aggressive&tags[]=Spread&tagsMode=or');
+
+        self::assertResponseIsSuccessful();
+        self::assertGreaterThan(1, $crawler->filter('.col-lg-4 .card-title')->count());
+    }
+
+    /**
+     * @see https://github.com/jbourdin/expandedDecks/issues/548
+     */
+    public function testInvalidTagsModeFallsBackToAnd(): void
+    {
+        $crawler = $this->client->request('GET', '/en/archetypes?tags[]=Aggressive&tags[]=Spread&tagsMode=banana');
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, $crawler->filter('.col-lg-4 .card-title'));
+    }
+
+    /**
+     * @see https://github.com/jbourdin/expandedDecks/issues/548
+     */
+    public function testTagsModeToggleHiddenWhenFewerThanTwoTagsSelected(): void
+    {
+        $crawler = $this->client->request('GET', '/en/archetypes?tags[]=Aggressive');
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(0, $crawler->filter('.btn-group [href*="tagsMode=or"]'));
+    }
+
+    /**
+     * @see https://github.com/jbourdin/expandedDecks/issues/548
+     */
+    public function testTagsModeToggleVisibleWithTwoOrMoreTagsSelected(): void
+    {
+        $crawler = $this->client->request('GET', '/en/archetypes?tags[]=Aggressive&tags[]=Spread');
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, $crawler->filter('.btn-group [href*="tagsMode=or"]'));
     }
 
     public function testFilterByNonExistentTagShowsEmptyState(): void

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -3923,6 +3923,21 @@
                 <target>Drafts</target>
                 <note>Filter button to show only unpublished archetypes (editors only)</note>
             </trans-unit>
+            <trans-unit id="app.archetype.tags_mode.label">
+                <source>app.archetype.tags_mode.label</source>
+                <target>Combine tags as:</target>
+                <note>#548 — label for the AND/OR toggle on the archetype catalog (visible only when 2+ tags selected)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.tags_mode.and">
+                <source>app.archetype.tags_mode.and</source>
+                <target>Match all</target>
+                <note>#548 — toggle button: archetypes must match every selected tag (default)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.tags_mode.or">
+                <source>app.archetype.tags_mode.or</source>
+                <target>Match any</target>
+                <note>#548 — toggle button: archetypes match at least one selected tag</note>
+            </trans-unit>
             <trans-unit id="app.archetype.sort_by">
                 <source>app.archetype.sort_by</source>
                 <target>Sort by</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -3908,6 +3908,21 @@
                 <target>Brouillons</target>
                 <note>Filter button to show only unpublished archetypes (editors only)</note>
             </trans-unit>
+            <trans-unit id="app.archetype.tags_mode.label">
+                <source>app.archetype.tags_mode.label</source>
+                <target>Combiner les tags :</target>
+                <note>#548 — label for the AND/OR toggle on the archetype catalog (visible only when 2+ tags selected)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.tags_mode.and">
+                <source>app.archetype.tags_mode.and</source>
+                <target>Tous</target>
+                <note>#548 — toggle button: archetypes must match every selected tag (default)</note>
+            </trans-unit>
+            <trans-unit id="app.archetype.tags_mode.or">
+                <source>app.archetype.tags_mode.or</source>
+                <target>Au moins un</target>
+                <note>#548 — toggle button: archetypes match at least one selected tag</note>
+            </trans-unit>
             <trans-unit id="app.archetype.sort_by">
                 <source>app.archetype.sort_by</source>
                 <target>Trier par</target>


### PR DESCRIPTION
## Summary

- Default the playstyle tag filter on `/archetypes` to **AND** logic (must match every selected tag) instead of **OR**. Editors who want the prior "matches any" behaviour can opt in via a new toggle.
- Add a `tagsMode` URL parameter (`and` default, omittable; `or` opt-in). `ArchetypeRepository::findPublishedWithDeckCounts()` accepts a third `string $tagsMode = 'and'` argument and switches the LIKE-glue between `AND` and `OR` accordingly.
- Validate `tagsMode` at the controller boundary — anything outside `['and', 'or']` falls back to `'and'`.
- Add a "Combine tags as: [Match all] [Match any]" segmented toggle in the filter row of `templates/archetype/list.html.twig`, hidden when fewer than 2 tags are selected (combinator has no effect on 0–1 tags).
- Thread `currentTagsMode` through every `path()` call that already threads `currentTags`/`currentSort`, via a single `tagsModeParam` Twig variable assembled at the top of the template — so toggling a chip or changing the sort preserves the user's combinator choice.
- 5 new behavioural functional tests (default-AND match, explicit-OR match, invalid-mode fallback, toggle hidden with <2 tags, toggle visible with ≥2 tags), exercising the fixture's `Aggressive`/`Spread` tag distribution. Renamed the pre-existing `testFilterByMultipleTagsUsesOrLogic` to reflect the new default.
- 3 new translation keys in `en` and `fr`: `app.archetype.tags_mode.{label,and,or}`.

## Behavioural change

Existing bookmarks like `/archetypes?tags[]=A&tags[]=B` now return *fewer* results (intersection instead of union). The new "Match any" toggle is one click away — but worth a line in the next release notes.

## Test plan

- [ ] Visit `/en/archetypes` with no tags selected — confirm no toggle is visible.
- [ ] Select a single tag chip — confirm no toggle is visible.
- [ ] Select 2+ tag chips — confirm the "Combine tags as: [Match all] [Match any]" toggle appears, with "Match all" highlighted by default.
- [ ] Click "Match any" — URL gains `?tagsMode=or`, and the result count visibly grows (more archetypes match the union).
- [ ] With "Match any" active, toggle a tag chip on/off and change the sort dropdown — confirm the URL keeps `tagsMode=or` across each navigation.
- [ ] Click "Match all" — URL drops `tagsMode` (default), result count shrinks back to the intersection.
- [ ] Visit `/en/archetypes?tags[]=Aggressive&tags[]=Spread&tagsMode=banana` — confirm it falls back to AND (not 500, no error).
- [ ] Switch the page locale (EN ↔ FR) — confirm the toggle label and button text are localised.
- [ ] (Editor only) Visit `/en/archetypes?drafts=1` — confirm the drafts list renders without the tag filter UI.

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)