### PR TITLE
:sparkles: Feature: Enlarge homepage carousel caption text

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -185,7 +185,7 @@ footer {
     align-items: center;
     justify-content: center;
     text-align: center;
-    padding: 1rem;
+    padding: 1rem min(10%, 24px);
     pointer-events: none;
     container-type: inline-size;
 
@@ -217,7 +217,7 @@ footer {
     font-family: inherit;
     font-weight: 700;
     line-height: 1.2;
-    font-size: clamp(1rem, min(7cqi, calc(80cqi / var(--caption-length, 12))), 3.5rem);
+    font-size: clamp(1.5rem, min(13cqi, calc(150cqi / var(--caption-length, 12))), 7rem);
 }
 
 // --- Buttons ---


### PR DESCRIPTION
## Summary
- Bumps `.carousel-caption-overlay-text` font-size clamp from `clamp(1rem, min(7cqi, 80cqi/length), 3.5rem)` to `clamp(1.5rem, min(13cqi, 150cqi/length), 7rem)` so captions feel substantially larger in both the slideshow layout and the `feature_grid` supporter cells.
- Tightens horizontal padding on `.carousel-caption-overlay` from a fixed `1rem` (16px on every side) to `1rem min(10%, 24px)`. The 10% rule still applies on narrow overlays; the cap drops from 32px to 24px so wider cells leave more room for text without losing the breathing-room feel.
- Vertical padding stays at `1rem`. No template, enum, or React changes — markup and class names are unchanged.

## Test plan
- [ ] On the homepage, verify the carousel block (slideshow layout) renders captions noticeably larger than before, with side breathing room around 24px on wide viewports.
- [ ] On the homepage feature_grid layout, verify the feature cell caption hits the new ~7rem ceiling on wide viewports and supporter cell captions also grow proportionally (no more "stuck near 1rem" feel for long strings like "Browse the Library").
- [ ] Test a long caption (~30+ characters) in a supporter cell to confirm the length-divisor still scales the text down to fit without clipping.
- [ ] Verify the three caption color modifiers (`white_on_black`, `black_on_white`, `brand`) still render their text-shadow outlines correctly at the new sizes.
- [ ] Spot-check on a narrow viewport (mobile) that the lower clamp (1.5rem) keeps captions readable.