### PR TITLE
:sparkles: feat: per-slide brightness filter on carousel images

### DIFF
--- a/assets/components/BlockEditModal.tsx
+++ b/assets/components/BlockEditModal.tsx
@@ -60,6 +60,7 @@ interface CarouselItem {
     endAt: string | null;
     caption?: string;
     captionStyle?: string;
+    brightness?: number;
 }
 
 interface CategoryInfo {
@@ -341,6 +342,24 @@ export default function BlockEditModal({
                                         />
                                     </div>
                                 )}
+                                <NumberInput
+                                    label={label('carouselBrightness')}
+                                    description={label('carouselBrightnessHelp')}
+                                    value={carouselItem.brightness ?? 80}
+                                    onChange={(value) => {
+                                        const items = [...(editedBlock.items as CarouselItem[])];
+                                        items[itemIndex] = {
+                                            ...items[itemIndex],
+                                            brightness: typeof value === 'number' ? value : 80,
+                                        };
+                                        updateBlock('items', items);
+                                    }}
+                                    min={0}
+                                    max={200}
+                                    step={5}
+                                    suffix="%"
+                                    mt="xs"
+                                />
                             </Card>
                         ))}
                         <Button
@@ -349,7 +368,7 @@ export default function BlockEditModal({
                             leftSection={<IconPlus size={14} />}
                             onClick={() => {
                                 const items = Array.isArray(editedBlock.items) ? [...(editedBlock.items as CarouselItem[])] : [];
-                                items.push({ image: '', alt: '', link: '', startAt: null, endAt: null });
+                                items.push({ image: '', alt: '', link: '', startAt: null, endAt: null, brightness: 80 });
                                 updateBlock('items', items);
                             }}
                         >

--- a/docs/models/homepage.md
+++ b/docs/models/homepage.md
@@ -99,7 +99,7 @@ Each entry in `HomepageLayout.blocks` is an object with common and type-specific
 
 **pageEmbed** — `pageSlug` (CMS page slug to embed). Content comes from the referenced page's translation, not from `HomepageLayoutTranslation`.
 
-**carousel** — `items[]` (each with `image`, `alt`, `link`, `startAt`, `endAt`, plus optional `caption` + `captionStyle`) and an optional `variant` key controlling the layout.
+**carousel** — `items[]` (each with `image`, `alt`, `link`, `startAt`, `endAt`, plus optional `caption`, `captionStyle`, `brightness`) and an optional `variant` key controlling the layout.
 
 Per-item caption (#555):
 
@@ -107,6 +107,7 @@ Per-item caption (#555):
 |---|---|---|
 | `caption` | `string` (optional) | Text rendered centered over the image. When empty/absent, no overlay is rendered. |
 | `captionStyle` | `string` (optional, one of `white_on_black`, `black_on_white`, `brand`) | Color preset for the caption text + outline. Defaults to `white_on_black`. The renderer normalises unrecognised values to the default. See `App\Enum\HomepageCarouselCaptionStyle`. |
+| `brightness` | `int` (optional, 0–200) | Percent applied via `filter: brightness(N%)` on the `<img>` only — the caption overlay is rendered as a sibling and is therefore unaffected. Defaults to 80; the renderer clamps the value and normalises missing or non-numeric input to the default. |
 
 | `variant` value | Behaviour |
 |---|---|

--- a/src/Service/HomepageRenderer.php
+++ b/src/Service/HomepageRenderer.php
@@ -337,6 +337,11 @@ class HomepageRenderer
                         \is_string($rawStyle) ? $rawStyle : null,
                     )->value;
                 }
+                // Clamp brightness to [0, 200] and default to 80 when missing
+                // or non-numeric. Storing as int keeps the inline `style`
+                // injection deterministic (`brightness(N%)`) and prevents
+                // arbitrary CSS from being smuggled through the JSON payload.
+                $item['brightness'] = $this->normaliseBrightness($item['brightness'] ?? null);
                 $visibleItems[] = $item;
             }
         }
@@ -350,5 +355,26 @@ class HomepageRenderer
         }
 
         return ['items' => $visibleItems, 'variant' => $variant->value];
+    }
+
+    /**
+     * Normalise the per-item brightness percentage applied via `filter:
+     * brightness(N%)` on the carousel image. The default of 80 matches the
+     * historical visual treatment introduced with the per-item caption
+     * overlays so images sit slightly darker than the surrounding page.
+     */
+    private function normaliseBrightness(mixed $value): int
+    {
+        $default = 80;
+
+        if (\is_int($value)) {
+            $number = $value;
+        } elseif (\is_string($value) && '' !== $value && is_numeric($value)) {
+            $number = (int) $value;
+        } else {
+            return $default;
+        }
+
+        return max(0, min(200, $number));
     }
 }

--- a/templates/admin/homepage/editor.html.twig
+++ b/templates/admin/homepage/editor.html.twig
@@ -87,6 +87,8 @@
              carouselCaptionStyleWhiteOnBlack: 'app.homepage.admin.carousel_caption.style.white_on_black'|trans,
              carouselCaptionStyleBlackOnWhite: 'app.homepage.admin.carousel_caption.style.black_on_white'|trans,
              carouselCaptionStyleBrand: 'app.homepage.admin.carousel_caption.style.brand'|trans,
+             carouselBrightness: 'app.homepage.admin.carousel_brightness.label'|trans,
+             carouselBrightnessHelp: 'app.homepage.admin.carousel_brightness.help'|trans,
              image: 'app.homepage.admin.image'|trans,
              altText: 'app.homepage.admin.alt_text'|trans,
              link: 'app.homepage.admin.link'|trans,

--- a/templates/home/blocks/_carousel_item.html.twig
+++ b/templates/home/blocks/_carousel_item.html.twig
@@ -27,14 +27,18 @@
  # @var item.caption        string  optional, overlay text (#555)
  # @var item.captionStyle   string  optional, one of HomepageCarouselCaptionStyle (#555);
  #                                  the renderer normalises invalid values to the default
+ # @var item.brightness     int     optional, 0–200; CSS `filter: brightness(N%)` applied
+ #                                  to the <img> only. Defaults to 80; the renderer
+ #                                  normalises invalid values to the default.
  # @var imgClass            string  optional, extra classes for the <img>
  #}
 {% set imgClass = imgClass|default('d-block w-100') %}
 {% set hasCaption = item.caption is defined and item.caption %}
+{% set brightness = item.brightness|default(80) %}
 
 {% if item.link is defined and item.link is not empty %}
     <a href="{{ item.link }}">
-        <img src="{{ item.image }}" class="{{ imgClass }}" alt="{{ item.alt|default('') }}">
+        <img src="{{ item.image }}" class="{{ imgClass }}" alt="{{ item.alt|default('') }}" style="filter: brightness({{ brightness }}%);">
         {% if hasCaption %}
             <span class="carousel-caption-overlay carousel-caption-overlay--{{ item.captionStyle|default('white_on_black') }}" style="--caption-length: {{ item.caption|length }};">
                 <span class="carousel-caption-overlay-text">{{ item.caption }}</span>
@@ -42,7 +46,7 @@
         {% endif %}
     </a>
 {% else %}
-    <img src="{{ item.image }}" class="{{ imgClass }}" alt="{{ item.alt|default('') }}">
+    <img src="{{ item.image }}" class="{{ imgClass }}" alt="{{ item.alt|default('') }}" style="filter: brightness({{ brightness }}%);">
     {% if hasCaption %}
         <span class="carousel-caption-overlay carousel-caption-overlay--{{ item.captionStyle|default('white_on_black') }}">
             <span class="carousel-caption-overlay-text">{{ item.caption }}</span>

--- a/tests/Service/HomepageRendererTest.php
+++ b/tests/Service/HomepageRendererTest.php
@@ -612,6 +612,92 @@ class HomepageRendererTest extends TestCase
         self::assertSame('white_on_black', $result[0]->resolvedData['items'][0]['captionStyle']);
     }
 
+    public function testCarouselItemWithMissingBrightnessDefaultsToEighty(): void
+    {
+        $layout = new HomepageLayout();
+        $layout->setBlocks([
+            [
+                'type' => 'carousel',
+                'startAt' => null,
+                'endAt' => null,
+                'columnWidth' => null,
+                'cssClasses' => null,
+                'items' => [
+                    ['image' => 'a.jpg', 'alt' => 'A', 'link' => '/', 'startAt' => null, 'endAt' => null],
+                ],
+            ],
+        ]);
+
+        $result = $this->renderer->resolve($layout, 'en');
+
+        self::assertSame(80, $result[0]->resolvedData['items'][0]['brightness']);
+    }
+
+    public function testCarouselItemWithValidBrightnessIsPreserved(): void
+    {
+        $layout = new HomepageLayout();
+        $layout->setBlocks([
+            [
+                'type' => 'carousel',
+                'startAt' => null,
+                'endAt' => null,
+                'columnWidth' => null,
+                'cssClasses' => null,
+                'items' => [
+                    ['image' => 'a.jpg', 'alt' => 'A', 'link' => '/', 'startAt' => null, 'endAt' => null, 'brightness' => 120],
+                ],
+            ],
+        ]);
+
+        $result = $this->renderer->resolve($layout, 'en');
+
+        self::assertSame(120, $result[0]->resolvedData['items'][0]['brightness']);
+    }
+
+    public function testCarouselItemBrightnessIsClampedToTheValidRange(): void
+    {
+        $layout = new HomepageLayout();
+        $layout->setBlocks([
+            [
+                'type' => 'carousel',
+                'startAt' => null,
+                'endAt' => null,
+                'columnWidth' => null,
+                'cssClasses' => null,
+                'items' => [
+                    ['image' => 'a.jpg', 'alt' => 'A', 'link' => '/', 'startAt' => null, 'endAt' => null, 'brightness' => -50],
+                    ['image' => 'b.jpg', 'alt' => 'B', 'link' => '/', 'startAt' => null, 'endAt' => null, 'brightness' => 999],
+                ],
+            ],
+        ]);
+
+        $result = $this->renderer->resolve($layout, 'en');
+
+        self::assertSame(0, $result[0]->resolvedData['items'][0]['brightness']);
+        self::assertSame(200, $result[0]->resolvedData['items'][1]['brightness']);
+    }
+
+    public function testCarouselItemBrightnessFallsBackToDefaultOnNonNumericInput(): void
+    {
+        $layout = new HomepageLayout();
+        $layout->setBlocks([
+            [
+                'type' => 'carousel',
+                'startAt' => null,
+                'endAt' => null,
+                'columnWidth' => null,
+                'cssClasses' => null,
+                'items' => [
+                    ['image' => 'a.jpg', 'alt' => 'A', 'link' => '/', 'startAt' => null, 'endAt' => null, 'brightness' => 'rgb(255,0,0)'],
+                ],
+            ],
+        ]);
+
+        $result = $this->renderer->resolve($layout, 'en');
+
+        self::assertSame(80, $result[0]->resolvedData['items'][0]['brightness']);
+    }
+
     /**
      * @see https://github.com/jbourdin/expandedDecks/issues/553
      */

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -4862,6 +4862,16 @@
                 <target>Brand</target>
                 <note>#555 — caption preset using brand palette colors</note>
             </trans-unit>
+            <trans-unit id="app.homepage.admin.carousel_brightness.label">
+                <source>app.homepage.admin.carousel_brightness.label</source>
+                <target>Image brightness</target>
+                <note>per-item CSS `filter: brightness()` applied to the image only (not the caption). 0–200%, default 80%.</note>
+            </trans-unit>
+            <trans-unit id="app.homepage.admin.carousel_brightness.help">
+                <source>app.homepage.admin.carousel_brightness.help</source>
+                <target>Percent applied via CSS filter. 100% is unchanged; lower values darken the image. Default 80%.</target>
+                <note>helper text under the brightness input</note>
+            </trans-unit>
             <trans-unit id="app.homepage.admin.image">
                 <source>app.homepage.admin.image</source>
                 <target>Image URL</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -4837,6 +4837,16 @@
                 <target>Couleur de marque</target>
                 <note>#555 — caption preset using brand palette colors</note>
             </trans-unit>
+            <trans-unit id="app.homepage.admin.carousel_brightness.label">
+                <source>app.homepage.admin.carousel_brightness.label</source>
+                <target>Luminosité de l'image</target>
+                <note>per-item CSS `filter: brightness()` applied to the image only (not the caption). 0–200%, default 80%.</note>
+            </trans-unit>
+            <trans-unit id="app.homepage.admin.carousel_brightness.help">
+                <source>app.homepage.admin.carousel_brightness.help</source>
+                <target>Pourcentage appliqué via un filtre CSS. 100 % laisse l'image inchangée ; en-dessous l'image est assombrie. Par défaut 80 %.</target>
+                <note>helper text under the brightness input</note>
+            </trans-unit>
             <trans-unit id="app.homepage.admin.image">
                 <source>app.homepage.admin.image</source>
                 <target>URL de l'image</target>


### PR DESCRIPTION
## Summary
- Adds an optional `brightness` field (0–200, default 80) to each carousel item, rendered as `filter: brightness(N%)` on the `<img>` only — the caption overlay is a DOM sibling and stays unfiltered.
- `HomepageRenderer::resolveCarousel()` now normalises the value: clamps to `[0, 200]`, falls back to `80` for missing / non-numeric input. This keeps the inline `style` attribute deterministic and blocks injection of arbitrary CSS filter functions via hand-crafted layout JSON.
- Admin block editor exposes a per-slide `NumberInput` (step 5, `%` suffix). New slides are seeded with `brightness: 80` so existing layouts keep their current look.
- Two new translation keys (`app.homepage.admin.carousel_brightness.label` and `.help`) in `en` and `fr`.
- Four new tests cover the four branches of `normaliseBrightness()`: missing value, valid value preserved, out-of-range clamped, non-numeric falls back to default.
- Docs updated: `docs/models/homepage.md` now lists `brightness` in the carousel item schema table.

## Test plan
- [ ] `make cs-fix && make twig-cs-fix && make eslint-fix && make stylelint-fix` clean
- [ ] `make phpstan` — 0 errors
- [ ] `make test` — `HomepageRendererTest` green (34/34)
- [ ] `make test.front` — vitest green
- [ ] `make lint-i18n && make lint-container` — both OK
- [ ] `make assets` builds production bundle
- [ ] Visual: open the homepage editor, edit an existing carousel block, verify legacy slides show `80%` in the new field
- [ ] Visual: change a slide's brightness to `40%`, save, reload `/` — image visibly darker, caption text unchanged
- [ ] Visual: change brightness to `120%`, confirm image lightens; caption colour & outline still rendered crisply
- [ ] Visual: add a new slide, confirm the field defaults to `80`