### PR TITLE
:bug: fix: wrap long navbar dropdown items on mobile

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -139,6 +139,26 @@ footer {
 .navbar-pokemon .dropdown-menu {
     border: 1px solid rgba($ed-navy, .15);
     box-shadow: 0 .25rem .75rem rgb(0 0 0 / 15%);
+
+    .dropdown-item {
+        white-space: normal;
+        overflow-wrap: break-word;
+    }
+}
+
+// In the collapsed mobile navbar, Bootstrap positions dropdowns statically,
+// so the menu's intrinsic width would inflate its parent .nav-item and pull
+// the toggle off the right edge. Stretch the .nav-item to fill the navbar
+// instead, and pin the toggle to the right via text-align / justify-content.
+@include media-breakpoint-down(lg) {
+    .navbar-pokemon .navbar-nav .nav-item.dropdown {
+        align-self: stretch;
+
+        > .dropdown-toggle {
+            text-align: end;
+            justify-content: flex-end;
+        }
+    }
 }
 
 // Hide Bootstrap dropdown caret on icon-only toggle buttons (three-dots menus)

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -139,17 +139,15 @@ footer {
 .navbar-pokemon .dropdown-menu {
     border: 1px solid rgba($ed-navy, .15);
     box-shadow: 0 .25rem .75rem rgb(0 0 0 / 15%);
-
-    .dropdown-item {
-        white-space: normal;
-        overflow-wrap: break-word;
-    }
 }
 
 // In the collapsed mobile navbar, Bootstrap positions dropdowns statically,
 // so the menu's intrinsic width would inflate its parent .nav-item and pull
 // the toggle off the right edge. Stretch the .nav-item to fill the navbar
-// instead, and pin the toggle to the right via text-align / justify-content.
+// instead, pin the toggle right via text-align / justify-content, and let
+// long dropdown items wrap inside the now-full-width menu. Wrapping is
+// mobile-only because on desktop white-space: normal causes shrink-to-fit
+// to collapse the dropdown to its min-width (10rem), wrapping every item.
 @include media-breakpoint-down(lg) {
     .navbar-pokemon .navbar-nav .nav-item.dropdown {
         align-self: stretch;
@@ -158,6 +156,11 @@ footer {
             text-align: end;
             justify-content: flex-end;
         }
+    }
+
+    .navbar-pokemon .dropdown-menu .dropdown-item {
+        white-space: normal;
+        overflow-wrap: break-word;
     }
 }
 


### PR DESCRIPTION
## Summary

- Long CMS page titles in the navbar dropdown (e.g. news article headlines under a multi-page menu category) used to overflow the mobile viewport because Bootstrap's `.dropdown-item` defaults to `white-space: nowrap`. Items now wrap to multiple lines, and `overflow-wrap: break-word` handles non-breakable strings.
- In the collapsed mobile navbar Bootstrap positions dropdowns statically, so the menu's intrinsic width inflates its parent `.nav-item` and shifts the toggle off the right edge. Resolved by stretching the `.nav-item.dropdown` to the full collapse width (below the `lg` breakpoint only) and re-pinning the toggle right via `text-align: end` (plain `<a>` toggles) and `justify-content: flex-end` (the `d-flex` user-account toggle).
- Desktop behavior is unchanged: the stretch rule lives inside `@include media-breakpoint-down(lg)`.

## Test plan

- [x] Mobile (< lg): open hamburger → "News" / "Getting started" dropdown → long page titles wrap to multiple lines, dropdown stays within viewport.
- [x] Mobile (< lg): "News ▾" / "Getting started ▾" stay right-aligned both when closed and when open.
- [x] Mobile (< lg), logged in: user-account dropdown (gravatar + name) stays right-aligned.
- [x] Mobile (< lg): single-page categories like "Rules & Info" still render as right-aligned narrow items (not affected by the rule).
- [ ] Desktop (≥ lg): dropdowns behave identically to before — toggle position, menu width, item alignment unchanged.