### PR TITLE
:sparkles: feat: collapse navbar search to icon on mobile

### DIFF
--- a/assets/components/NavbarSearch.tsx
+++ b/assets/components/NavbarSearch.tsx
@@ -8,8 +8,8 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Combobox, TextInput, useCombobox } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { ActionIcon, Combobox, TextInput, useCombobox } from '@mantine/core';
+import { useClickOutside, useDebouncedValue, useMediaQuery } from '@mantine/hooks';
 import { IconSearch } from '@tabler/icons-react';
 
 /**
@@ -35,6 +35,7 @@ interface NavbarSearchProps {
         placeholder: string;
         seeAll: string;
         noResults: string;
+        openSearch: string;
     };
 }
 
@@ -51,8 +52,23 @@ const NavbarSearch: React.FC<NavbarSearchProps> = ({ searchUrl, searchPageUrl, l
     const [debouncedQuery] = useDebouncedValue(query, 300);
     const [groups, setGroups] = useState<SearchGroup[]>([]);
     const [loading, setLoading] = useState(false);
+    const [isExpanded, setIsExpanded] = useState(false);
+    const isMobile = useMediaQuery('(max-width: 991.98px)', false, { getInitialValueInEffect: false });
     const abortRef = useRef<AbortController | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
     const combobox = useCombobox();
+    const containerRef = useClickOutside(() => {
+        if (isMobile && isExpanded) {
+            setIsExpanded(false);
+            combobox.closeDropdown();
+        }
+    });
+
+    useEffect(() => {
+        if (isExpanded) {
+            inputRef.current?.focus();
+        }
+    }, [isExpanded]);
 
     useEffect(() => {
         if (debouncedQuery.length < 2) {
@@ -102,10 +118,28 @@ const NavbarSearch: React.FC<NavbarSearchProps> = ({ searchUrl, searchPageUrl, l
     const handleKeyDown = (event: React.KeyboardEvent) => {
         if (event.key === 'Enter' && !combobox.dropdownOpened) {
             window.location.href = `${searchPageUrl}?q=${encodeURIComponent(query)}`;
+        } else if (event.key === 'Escape' && isMobile) {
+            setIsExpanded(false);
+            combobox.closeDropdown();
         }
     };
 
+    if (isMobile && !isExpanded) {
+        return (
+            <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="lg"
+                aria-label={labels.openSearch}
+                onClick={() => setIsExpanded(true)}
+            >
+                <IconSearch size={20} />
+            </ActionIcon>
+        );
+    }
+
     return (
+        <div ref={containerRef}>
         <Combobox
             store={combobox}
             onOptionSubmit={handleOptionSubmit}
@@ -113,6 +147,7 @@ const NavbarSearch: React.FC<NavbarSearchProps> = ({ searchUrl, searchPageUrl, l
         >
             <Combobox.Target>
                 <TextInput
+                    ref={inputRef}
                     placeholder={labels.placeholder}
                     value={query}
                     onChange={(event) => {
@@ -177,6 +212,7 @@ const NavbarSearch: React.FC<NavbarSearchProps> = ({ searchUrl, searchPageUrl, l
                 </Combobox.Options>
             </Combobox.Dropdown>
         </Combobox>
+        </div>
     );
 };
 

--- a/assets/navbar-search.tsx
+++ b/assets/navbar-search.tsx
@@ -25,6 +25,7 @@ if (root) {
     const labelPlaceholder = root.dataset.labelPlaceholder ?? 'Search…';
     const labelSeeAll = root.dataset.labelSeeAll ?? 'See all results';
     const labelNoResults = root.dataset.labelNoResults ?? 'No results';
+    const labelOpenSearch = root.dataset.labelOpen ?? 'Open search';
 
     createRoot(root).render(
         <AppMantineProvider>
@@ -35,6 +36,7 @@ if (root) {
                     placeholder: labelPlaceholder,
                     seeAll: labelSeeAll,
                     noResults: labelNoResults,
+                    openSearch: labelOpenSearch,
                 }}
             />
         </AppMantineProvider>,

--- a/templates/_partials/navbar_search.html.twig
+++ b/templates/_partials/navbar_search.html.twig
@@ -4,6 +4,7 @@
          data-search-page-url="{{ path('app_search') }}"
          data-label-placeholder="{{ 'app.search.navbar_placeholder'|trans }}"
          data-label-see-all="{{ 'app.search.navbar_see_all'|trans }}"
-         data-label-no-results="{{ 'app.search.navbar_no_results'|trans }}">
+         data-label-no-results="{{ 'app.search.navbar_no_results'|trans }}"
+         data-label-open="{{ 'app.search.navbar_open'|trans }}">
     </div>
 </li>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5790,6 +5790,11 @@
                 <target>No results</target>
                 <note>Navbar autocomplete: empty state</note>
             </trans-unit>
+            <trans-unit id="app.search.navbar_open">
+                <source>app.search.navbar_open</source>
+                <target>Open search</target>
+                <note>Mobile navbar: aria-label on the icon button that expands the search input</note>
+            </trans-unit>
 
             <!-- Decklist PDF (F5.13) -->
             <trans-unit id="app.decklist.player_name">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -5753,6 +5753,11 @@
                 <target>Aucun résultat</target>
                 <note>Navbar autocomplete: empty state</note>
             </trans-unit>
+            <trans-unit id="app.search.navbar_open">
+                <source>app.search.navbar_open</source>
+                <target>Ouvrir la recherche</target>
+                <note>Mobile navbar: aria-label on the icon button that expands the search input</note>
+            </trans-unit>
 
             <!-- Decklist PDF (F5.13) -->
             <trans-unit id="app.decklist.player_name">


### PR DESCRIPTION
## Summary

- On viewports below the navbar's `lg` breakpoint, `NavbarSearch` renders as a Mantine `ActionIcon` instead of the wide inline `TextInput`. The collapsed navbar row no longer carries a full-width input centered against the right-aligned text links.
- Tapping the icon swaps in the existing search input expanded inline with keyboard focus on. The autocomplete behavior is identical to desktop (same `Combobox`, same `withinPortal={false}` dropdown, same submit handlers).
- Collapses back to the icon on **Escape**, **tap-outside** (via `useClickOutside`), or successful navigation.
- Desktop (`≥ lg`) is unchanged: the existing inline `Combobox` + `TextInput` renders exactly as today.

## Implementation notes

- `useMediaQuery('(max-width: 991.98px)', false, { getInitialValueInEffect: false })` reads the viewport synchronously on first render so the icon variant paints from the very first frame on mobile — no flicker from "wide input → icon".
- `useClickOutside` is wired on a wrapper `<div ref={containerRef}>` around the expanded `Combobox`. Because the autocomplete dropdown is `withinPortal={false}`, clicks on autocomplete results stay inside the container and don't trigger collapse.
- `inputRef` + a focus `useEffect` on `isExpanded` calls `inputRef.current?.focus()` the frame after expansion so the keyboard pops up on mobile without an extra tap.
- New translation key `app.search.navbar_open` ("Open search" / "Ouvrir la recherche") wired through the existing `data-label-*` pipeline as the `aria-label` on the trigger button.

Closes #590

## Test plan

**Mobile (`< lg`, hamburger collapsed):**

- [ ] Open the navbar — search row shows a single icon button on the right side, no wide input.
- [ ] Tap the icon → input appears inline, auto-focused, keyboard pops up.
- [ ] Type ≥ 2 characters → autocomplete dropdown opens with results (same as desktop).
- [ ] Tap an autocomplete result → navigates to the target page.
- [ ] Tap outside the search → input collapses back to icon.
- [ ] Press Escape → input collapses back to icon.
- [ ] Switch locale to French and inspect the icon button — `aria-label` reads "Ouvrir la recherche".

**Desktop (`≥ lg`):**

- [ ] Search renders inline as before, no icon-only state, no behavioral change.

**Both viewports:**

- [ ] Submitting via Enter still navigates to `/search?q=…`.
- [ ] Autocomplete results render with the existing type icons (archetype / variant / page / event / deck).