### PR TITLE
:sparkles: Feature: channel-aware post-login redirect

### DIFF
--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -15,6 +15,7 @@ namespace App\Controller;
 
 use App\Entity\User;
 use App\Form\RegistrationFormType;
+use App\Security\LoginRedirectResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -38,18 +39,18 @@ class RegistrationController extends AbstractAppController
         UserPasswordHasherInterface $passwordHasher,
         EntityManagerInterface $entityManager,
         MailerInterface $mailer,
+        LoginRedirectResolver $redirectResolver,
         #[Autowire('%app.verification_token_ttl%')] int $tokenTtl,
         #[Autowire('%app.mail_sender%')] string $mailSender,
         #[Autowire('%app.mail_sender_name%')] string $mailSenderName,
     ): Response {
         $targetPath = $request->query->getString('_target_path');
+        $safeTarget = $redirectResolver->isSafePath($targetPath) ? $targetPath : null;
 
         if ($this->getUser()) {
-            if ('' !== $targetPath && $this->isSafeRedirectPath($targetPath)) {
-                return $this->redirect($targetPath);
-            }
-
-            return $this->redirectToRoute('app_dashboard');
+            return null !== $safeTarget
+                ? $this->redirect($safeTarget)
+                : $this->redirectToRoute($redirectResolver->defaultRouteName());
         }
 
         $user = new User();
@@ -89,7 +90,7 @@ class RegistrationController extends AbstractAppController
 
             $this->addFlash('success', 'app.flash.auth.account_created');
 
-            $loginParams = ('' !== $targetPath && $this->isSafeRedirectPath($targetPath)) ? ['_target_path' => $targetPath] : [];
+            $loginParams = null !== $safeTarget ? ['_target_path' => $safeTarget] : [];
 
             return $this->redirectToRoute('app_login', $loginParams);
         }
@@ -97,25 +98,5 @@ class RegistrationController extends AbstractAppController
         return $this->render('registration/register.html.twig', [
             'registrationForm' => $form,
         ]);
-    }
-
-    private function isSafeRedirectPath(string $path): bool
-    {
-        return str_starts_with($path, '/')
-            && !str_starts_with($path, '//')
-            && !str_contains($path, '://')
-            && !$this->containsNestedTargetPath($path);
-    }
-
-    private function containsNestedTargetPath(string $path): bool
-    {
-        $decoded = $path;
-
-        do {
-            $previous = $decoded;
-            $decoded = urldecode($decoded);
-        } while ($decoded !== $previous);
-
-        return str_contains($decoded, '_target_path');
     }
 }

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Security\LoginRedirectResolver;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,13 +29,18 @@ class SecurityController extends AbstractController
     use TargetPathTrait;
 
     #[Route('/login', name: 'app_login')]
-    public function login(Request $request, AuthenticationUtils $authenticationUtils): Response
-    {
+    public function login(
+        Request $request,
+        AuthenticationUtils $authenticationUtils,
+        LoginRedirectResolver $redirectResolver,
+    ): Response {
         $targetPath = $request->query->getString('_target_path');
-        $safeTarget = ('' !== $targetPath && $this->isSafeRedirectPath($targetPath)) ? $targetPath : null;
+        $safeTarget = $redirectResolver->isSafePath($targetPath) ? $targetPath : null;
 
         if ($this->getUser()) {
-            return $this->redirect($safeTarget ?? $this->generateUrl('app_dashboard'));
+            return null !== $safeTarget
+                ? $this->redirect($safeTarget)
+                : $this->redirectToRoute($redirectResolver->defaultRouteName());
         }
 
         if (null !== $safeTarget) {
@@ -45,26 +51,6 @@ class SecurityController extends AbstractController
             'last_email' => $authenticationUtils->getLastUsername(),
             'error' => $authenticationUtils->getLastAuthenticationError(),
         ]);
-    }
-
-    private function isSafeRedirectPath(string $path): bool
-    {
-        return str_starts_with($path, '/')
-            && !str_starts_with($path, '//')
-            && !str_contains($path, '://')
-            && !$this->containsNestedTargetPath($path);
-    }
-
-    private function containsNestedTargetPath(string $path): bool
-    {
-        $decoded = $path;
-
-        do {
-            $previous = $decoded;
-            $decoded = urldecode($decoded);
-        } while ($decoded !== $previous);
-
-        return str_contains($decoded, '_target_path');
     }
 
     #[Route('/logout', name: 'app_logout')]

--- a/src/Security/LoginRedirectResolver.php
+++ b/src/Security/LoginRedirectResolver.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Security;
+
+use App\Service\Channel\ChannelContext;
+
+/**
+ * Centralizes post-login redirect decisions:
+ *
+ *  - {@see isSafePath()} rejects any value that would escape the current site
+ *    (absolute URLs, protocol-relative URLs, nested `_target_path` payloads).
+ *  - {@see defaultRouteName()} picks the channel-appropriate landing route when
+ *    no explicit `_target_path` was provided. Channels with the deck feature
+ *    disabled land on the public home page (the dashboard 404s there via
+ *    {@see \App\EventListener\ChannelFeatureGateListener}).
+ *
+ * @see docs/features.md F1.2 — Log in / Log out
+ * @see docs/features.md F18.7 — Feature-gate middleware for deck, event, and borrow routes
+ */
+final readonly class LoginRedirectResolver
+{
+    public function __construct(
+        private ChannelContext $channelContext,
+    ) {
+    }
+
+    public function isSafePath(string $path): bool
+    {
+        if ('' === $path) {
+            return false;
+        }
+
+        return str_starts_with($path, '/')
+            && !str_starts_with($path, '//')
+            && !str_contains($path, '://')
+            && !$this->containsNestedTargetPath($path);
+    }
+
+    /**
+     * Route name to redirect to when no explicit target path was provided.
+     */
+    public function defaultRouteName(): string
+    {
+        return $this->channelContext->getChannel()->getEnableDecks()
+            ? 'app_dashboard'
+            : 'app_home';
+    }
+
+    private function containsNestedTargetPath(string $path): bool
+    {
+        $decoded = $path;
+
+        do {
+            $previous = $decoded;
+            $decoded = urldecode($decoded);
+        } while ($decoded !== $previous);
+
+        return str_contains($decoded, '_target_path');
+    }
+}

--- a/src/Security/SafeAuthenticationSuccessHandler.php
+++ b/src/Security/SafeAuthenticationSuccessHandler.php
@@ -13,24 +13,40 @@ declare(strict_types=1);
 
 namespace App\Security;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
+use Symfony\Component\Security\Http\HttpUtils;
 
 /**
- * Sanitizes _target_path to prevent open-redirect attacks.
- *
- * If the request contains an unsafe _target_path (absolute URL, protocol-relative, etc.),
- * it is removed so the parent handler falls through to session/default.
+ * Strips any `_target_path` that would redirect outside of the current site,
+ * then defers to the parent handler. When no safe target path is provided,
+ * the default target is chosen per channel so users on channels without the
+ * deck feature don't land on the deck dashboard (which 404s there).
  *
  * @see docs/features.md F1.2 — Log in / Log out
+ * @see docs/features.md F18.7 — Feature-gate middleware for deck, event, and borrow routes
  */
 class SafeAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandler
 {
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        HttpUtils $httpUtils,
+        private readonly LoginRedirectResolver $resolver,
+        array $options = [],
+        ?LoggerInterface $logger = null,
+    ) {
+        parent::__construct($httpUtils, $options, $logger);
+    }
+
     public function onAuthenticationSuccess(Request $request, TokenInterface $token): ?Response
     {
         $this->sanitizeTargetPath($request);
+        $this->options['default_target_path'] = $this->resolver->defaultRouteName();
 
         return parent::onAuthenticationSuccess($request, $token);
     }
@@ -39,29 +55,9 @@ class SafeAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandl
     {
         foreach ([$request->request, $request->query] as $bag) {
             $targetPath = $bag->getString('_target_path');
-            if ('' !== $targetPath && !$this->isSafeRedirectPath($targetPath)) {
+            if ('' !== $targetPath && !$this->resolver->isSafePath($targetPath)) {
                 $bag->remove('_target_path');
             }
         }
-    }
-
-    private function isSafeRedirectPath(string $path): bool
-    {
-        return str_starts_with($path, '/')
-            && !str_starts_with($path, '//')
-            && !str_contains($path, '://')
-            && !$this->containsNestedTargetPath($path);
-    }
-
-    private function containsNestedTargetPath(string $path): bool
-    {
-        $decoded = $path;
-
-        do {
-            $previous = $decoded;
-            $decoded = urldecode($decoded);
-        } while ($decoded !== $previous);
-
-        return str_contains($decoded, '_target_path');
     }
 }

--- a/tests/Functional/AuthControllerTest.php
+++ b/tests/Functional/AuthControllerTest.php
@@ -172,6 +172,23 @@ class AuthControllerTest extends AbstractFunctionalTest
         self::assertResponseRedirects('/deck');
     }
 
+    /**
+     * Channels without the deck feature must land authenticated users on the
+     * public home (/) rather than the deck dashboard, which 404s there.
+     *
+     * @see docs/features.md F18.7 — Feature-gate middleware for deck, event, and borrow routes
+     */
+    public function testLoginOnChannelWithoutDecksRedirectsToHome(): void
+    {
+        $this->client->request('GET', 'https://expandedtalks.wip/login');
+        $this->client->submitForm('Login', [
+            '_email' => 'admin@example.com',
+            '_password' => 'password',
+        ]);
+
+        self::assertResponseRedirects('https://expandedtalks.wip/');
+    }
+
     public function testRegistrationPreservesTargetPathInLoginRedirect(): void
     {
         $this->client->request('GET', '/register?_target_path=/deck/ABC123');

--- a/tests/Functional/RegistrationControllerCoverageTest.php
+++ b/tests/Functional/RegistrationControllerCoverageTest.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Functional;
 
+use App\Entity\Channel;
+use Doctrine\ORM\EntityManagerInterface;
+
 /**
  * Additional coverage tests for RegistrationController uncovered branches.
  *
@@ -85,5 +88,48 @@ class RegistrationControllerCoverageTest extends AbstractFunctionalTest
         $this->client->request('GET', '/register?_target_path=/login%3F_target_path%3D/register');
 
         self::assertResponseRedirects('/dashboard');
+    }
+
+    /**
+     * On a channel without the deck feature, a logged-in user hitting /register
+     * with no target path lands on the public home (/) instead of the dashboard.
+     *
+     * Uses a custom channel where register stays enabled (so the controller is
+     * reachable) but decks are disabled (so the dashboard would 404).
+     *
+     * @see docs/features.md F18.7 — Feature-gate middleware for deck, event, and borrow routes
+     */
+    public function testRegisterRedirectsToHomeWhenLoggedInOnChannelWithoutDecks(): void
+    {
+        $this->persistNoDecksChannel('register-no-decks.wip');
+
+        $this->client->request('GET', 'https://register-no-decks.wip/login');
+        $this->client->submitForm('Login', [
+            '_email' => 'admin@example.com',
+            '_password' => 'password',
+        ]);
+        self::assertResponseRedirects('https://register-no-decks.wip/');
+
+        $this->client->request('GET', 'https://register-no-decks.wip/register');
+
+        self::assertResponseRedirects('https://register-no-decks.wip/');
+    }
+
+    private function persistNoDecksChannel(string $domain): void
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $channel = (new Channel())
+            ->setCode('no-decks-'.bin2hex(random_bytes(3)))
+            ->setDomain($domain)
+            ->setEnableDecks(false)
+            ->setEnableRegister(true)
+            ->setEnableEvents(false)
+            ->setEnableBorrows(false)
+            ->setEnableArchetypes(false)
+            ->setEnableBannedCards(false)
+            ->setLocales(['en']);
+        $entityManager->persist($channel);
+        $entityManager->flush();
     }
 }

--- a/tests/Functional/SecurityControllerCoverageTest.php
+++ b/tests/Functional/SecurityControllerCoverageTest.php
@@ -110,4 +110,25 @@ class SecurityControllerCoverageTest extends AbstractFunctionalTest
 
         self::assertResponseRedirects('/dashboard');
     }
+
+    /**
+     * On a channel without the deck feature, a logged-in user visiting /login
+     * with no target path lands on the public home (/) — the dashboard 404s
+     * on that channel because ChannelFeatureGateListener blocks it.
+     *
+     * @see docs/features.md F18.7 — Feature-gate middleware for deck, event, and borrow routes
+     */
+    public function testLoginPageRedirectsToHomeWhenLoggedInOnChannelWithoutDecks(): void
+    {
+        $this->client->request('GET', 'https://expandedtalks.wip/login');
+        $this->client->submitForm('Login', [
+            '_email' => 'admin@example.com',
+            '_password' => 'password',
+        ]);
+        self::assertResponseRedirects('https://expandedtalks.wip/');
+
+        $this->client->request('GET', 'https://expandedtalks.wip/login');
+
+        self::assertResponseRedirects('https://expandedtalks.wip/');
+    }
 }

--- a/tests/Security/LoginRedirectResolverTest.php
+++ b/tests/Security/LoginRedirectResolverTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Security;
+
+use App\Entity\Channel;
+use App\Security\LoginRedirectResolver;
+use App\Service\Channel\ChannelContext;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @see docs/features.md F1.2 — Log in / Log out
+ */
+class LoginRedirectResolverTest extends TestCase
+{
+    /**
+     * @return list<array{string}>
+     */
+    public static function unsafePathsProvider(): array
+    {
+        return [
+            [''],
+            ['relative/path'],
+            ['//evil.com/path'],
+            ['https://evil.com'],
+            ['http://evil.com'],
+            ['/foo://bar'],
+            ['/register?_target_path=/login'],
+            ['/register%3F_target_path%3D/login'],
+            ['/register%3F_target_path%253D/login'],
+        ];
+    }
+
+    #[DataProvider('unsafePathsProvider')]
+    public function testIsSafePathRejectsUnsafeValues(string $path): void
+    {
+        $resolver = new LoginRedirectResolver($this->buildChannelContext(new Channel()));
+
+        self::assertFalse($resolver->isSafePath($path));
+    }
+
+    /**
+     * @return list<array{string}>
+     */
+    public static function safePathsProvider(): array
+    {
+        return [
+            ['/'],
+            ['/deck'],
+            ['/deck/ABC123'],
+            ['/profile?tab=notifications'],
+        ];
+    }
+
+    #[DataProvider('safePathsProvider')]
+    public function testIsSafePathAcceptsRelativeSamesite(string $path): void
+    {
+        $resolver = new LoginRedirectResolver($this->buildChannelContext(new Channel()));
+
+        self::assertTrue($resolver->isSafePath($path));
+    }
+
+    public function testDefaultRouteIsDashboardWhenChannelHasDecks(): void
+    {
+        $channel = (new Channel())->setEnableDecks(true);
+        $resolver = new LoginRedirectResolver($this->buildChannelContext($channel));
+
+        self::assertSame('app_dashboard', $resolver->defaultRouteName());
+    }
+
+    public function testDefaultRouteIsHomeWhenChannelLacksDecks(): void
+    {
+        $channel = (new Channel())->setEnableDecks(false);
+        $resolver = new LoginRedirectResolver($this->buildChannelContext($channel));
+
+        self::assertSame('app_home', $resolver->defaultRouteName());
+    }
+
+    private function buildChannelContext(Channel $channel): ChannelContext
+    {
+        $request = new Request();
+        $request->attributes->set('_channel', $channel);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return new ChannelContext($requestStack);
+    }
+}


### PR DESCRIPTION
## Summary
- New `App\Security\LoginRedirectResolver` consolidates two concerns previously duplicated across `SafeAuthenticationSuccessHandler`, `SecurityController` and `RegistrationController`:
  - `isSafePath()` rejects any `_target_path` that would escape the current site (absolute URLs, protocol-relative URLs, nested `_target_path` payloads).
  - `defaultRouteName()` returns `app_dashboard` on channels with the deck feature enabled and `app_home` (`/`) otherwise.
- `SafeAuthenticationSuccessHandler` now overrides the firewall's `default_target_path` per request before delegating to the parent, so users on channels without `enableDecks` no longer land on `/dashboard` (which 404s there via `ChannelFeatureGateListener`).
- `SecurityController::login()` and `RegistrationController::register()` switch to the resolver for both their safety check and their already-logged-in default redirect; the duplicated helper methods are removed.

## Test plan
- [x] Unit: `LoginRedirectResolverTest` covers the safe/unsafe path matrix and the channel-aware default-route choice.
- [x] Functional: new tests confirm that on the `expandedtalks.wip` (no-decks) channel, form login lands on `/`, the already-logged-in `/login` branch redirects to `/`, and a custom no-decks-but-register-enabled channel redirects `/register` to `/` as well.
- [x] Existing auth, registration and security tests still pass on the default `app` channel (decks enabled → `/dashboard` unchanged).
- [x] `make phpstan`, `make cs-fix`, `make lint-container`, full `make test` suite green.
- [ ] Manual check on dev: log in on `expandeddecks.wip` (lands on `/dashboard`) and on `expandedtalks.wip` (lands on `/`).