### PR TITLE
:wrench: chore: consolidate Messenger workers into a single supervisord program

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -27,61 +27,9 @@ priority=10
 stopsignal=TERM
 stopwaitsecs=30
 
-[program:worker-transactional-email]
+[program:worker-messenger]
 user=www-data
-command=php bin/console messenger:consume transactional_email --time-limit=3600 --memory-limit=256 --sleep=20 --env=prod --no-debug
-directory=/app
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-autorestart=true
-priority=20
-stopsignal=TERM
-stopwaitsecs=30
-
-[program:worker-deck-enrichment]
-user=www-data
-command=php bin/console messenger:consume deck_enrichment --time-limit=3600 --memory-limit=512 --limit=5 --sleep=20 --env=prod --no-debug
-directory=/app
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-autorestart=true
-priority=20
-stopsignal=TERM
-stopwaitsecs=30
-
-[program:worker-notification]
-user=www-data
-command=php bin/console messenger:consume notification --time-limit=3600 --memory-limit=256 --sleep=20 --env=prod --no-debug
-directory=/app
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-autorestart=true
-priority=20
-stopsignal=TERM
-stopwaitsecs=30
-
-[program:worker-borrow-lifecycle]
-user=www-data
-command=php bin/console messenger:consume borrow_lifecycle --time-limit=3600 --memory-limit=256 --sleep=20 --env=prod --no-debug
-directory=/app
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-autorestart=true
-priority=20
-stopsignal=TERM
-stopwaitsecs=30
-
-[program:worker-tcgdex-sync]
-user=www-data
-command=php bin/console messenger:consume tcgdex_sync_series tcgdex_sync_serie tcgdex_sync_set tcgdex_sync_card --time-limit=3600 --memory-limit=256 --sleep=20 --env=prod --no-debug
+command=php bin/console messenger:consume transactional_email notification borrow_lifecycle deck_enrichment tcgdex_sync_series tcgdex_sync_serie tcgdex_sync_set tcgdex_sync_card --time-limit=1200 --memory-limit=512 --sleep=60 --env=prod --no-debug
 directory=/app
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
## Summary

- Replace the five `[program:worker-*]` blocks in `supervisord.conf` with one `[program:worker-messenger]` that consumes all 8 transports in priority order: `transactional_email` → `notification` → `borrow_lifecycle` → `deck_enrichment` → `tcgdex_sync_series` → `tcgdex_sync_serie` → `tcgdex_sync_set` → `tcgdex_sync_card`. User-facing queues are first so they pre-empt bulk background work.
- Lower idle-poll pressure: `--sleep=60` (was `20`). When all queues are empty, the single worker sleeps a minute between polls instead of five workers polling every 20 s.
- Tighter memory recycle: `--time-limit=1200` (was `3600`). The worker exits cleanly between messages every 20 min and supervisord auto-restarts it (`autorestart=true`), bounding PHP memory drift without dropping in-flight work.
- `--memory-limit=512` keeps the headroom previously reserved for the `deck_enrichment` worker (TCGdex JSON + GD mosaic buffers). Other queues won't approach it.
- `--limit=5` (previously only on `deck_enrichment` for image-job hygiene) is dropped — the global time/memory limits cover the same use case.
- Net effect on a low-throughput instance: 5 long-running PHP processes → 1, fewer Doctrine `SELECT … FOR UPDATE SKIP LOCKED` polls per minute, and lower idle CPU/RAM footprint.

## Tradeoff

`transactional_email` messages dispatched right after the worker enters its idle sleep can now wait up to 60 s before pickup (was up to 20 s). Acceptable for password-reset / verification UX; if it bites, the simple follow-up is `--sleep=30`.

## Test plan

- [ ] Build the prod image and confirm `supervisord.conf` is embedded without syntax errors.
- [ ] Boot the container and run `supervisorctl status`: expect `worker-messenger RUNNING` alongside `meilisearch` and `frankenphp`; the five old `worker-*` entries should be gone.
- [ ] Trigger one job per domain (email send, push notification, borrow lifecycle transition, deck enrichment, TCGdex sync) and verify `messenger:stats` returns to 0 within ~60 s for each, with `Received message …` log lines from the single worker.
- [ ] Leave the container idle ~25 min and confirm `supervisorctl status worker-messenger` shows the uptime resets at the `--time-limit=1200` boundary.
- [ ] `docker stats` shows ~1 PHP worker process and near-0% idle CPU.