### PR TITLE
:bug: Fix: self-heal container when worker-messenger hits FATAL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,13 +135,22 @@ RUN mkdir -p /var/lib/meilisearch/data && chown -R www-data:www-data /var/lib/me
 # Supervisor config
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
+# Supervisord eventlistener: shuts down PID 1 when worker-messenger reaches
+# FATAL so the orchestrator replaces the instance instead of leaving the
+# container alive with a dead consumer.
+COPY supervisor-fatal-listener.sh /usr/local/bin/supervisor-fatal-listener.sh
+RUN chmod +x /usr/local/bin/supervisor-fatal-listener.sh
+
 # Startup script: clears and warms cache, then execs Supervisor
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+# Probe the readiness endpoint so a dead worker (state FATAL) surfaces as an
+# unhealthy container locally. Scaleway Serverless Containers ignore this
+# directive; production self-healing is driven by the supervisord eventlistener.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/health/ready || exit 1
 
 EXPOSE 8080
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -156,6 +156,12 @@ The application exposes health check endpoints for container orchestration:
 
 Point your orchestrator's readiness probe at `/health/ready` to gate new container rollouts on the worker actually being up inside that container.
 
+### Self-healing on worker failure
+
+The container is designed to self-recycle when the messenger consumer can no longer be revived locally. Supervisor manages `worker-messenger` with `autorestart=true` and `startretries=5`; once that retry budget is exhausted Supervisor marks the program `FATAL` and stops trying. A dedicated supervisord eventlistener (`supervisor-fatal-listener.sh`) subscribes to `PROCESS_STATE_FATAL` and runs `supervisorctl shutdown` when the offending program is `worker-messenger`. That terminates supervisord (PID 1) and exits the container, so the orchestrator — Scaleway Serverless Containers, `docker run --restart=always`, Kubernetes, etc. — spawns a fresh instance with a clean supervisor tree.
+
+No orchestrator-side configuration is required; the recovery path relies only on PID-1 exit semantics. The Dockerfile `HEALTHCHECK` is wired to `/health/ready` for visibility when running under plain Docker.
+
 ---
 
 ## Minimal Production Example

--- a/supervisor-fatal-listener.sh
+++ b/supervisor-fatal-listener.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Supervisord eventlistener that shuts supervisord (PID 1) down when
+# worker-messenger reaches the FATAL state. Exiting PID 1 lets the
+# orchestrator (Scaleway Serverless Containers, Docker --restart=always, ...)
+# replace the instance with a fresh one. Without this, supervisord keeps
+# serving HTTP traffic while the messenger consumer stays dead.
+#
+# Subscribed to PROCESS_STATE_FATAL only (see supervisord.conf), so the only
+# filter needed in here is "which program just went FATAL?".
+#
+# Protocol: https://supervisord.org/events.html#event-listeners
+
+set -u
+
+while :; do
+    printf "READY\n"
+
+    # Header line: space-separated key:value pairs, one of which is len:<N>.
+    if ! IFS= read -r header; then
+        exit 0
+    fi
+
+    payload_length=""
+    for pair in $header; do
+        case "$pair" in
+            len:*) payload_length="${pair#len:}"; break ;;
+        esac
+    done
+
+    case "$payload_length" in
+        ''|*[!0-9]*)
+            printf "RESULT 4\nFAIL"
+            continue
+            ;;
+    esac
+
+    if [ "$payload_length" -gt 0 ]; then
+        payload=$(head -c "$payload_length")
+    else
+        payload=""
+    fi
+
+    # Acknowledge before acting: supervisord blocks on the RESULT line, so
+    # initiating shutdown without acking can wedge supervisord's own shutdown.
+    printf "RESULT 2\nOK"
+
+    case "$payload" in
+        *"processname:worker-messenger"*)
+            echo "worker-fatal-killer: worker-messenger entered FATAL — shutting supervisord down so the container is replaced" >&2
+            supervisorctl -c /etc/supervisor/conf.d/supervisord.conf shutdown
+            exit 0
+            ;;
+    esac
+done

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -50,6 +50,22 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 autorestart=true
+# Default startretries is 3, which can flip to FATAL on transient DB blips.
+# Bumped because the FATAL transition now terminates the whole container.
+startretries=5
 priority=20
 stopsignal=TERM
 stopwaitsecs=30
+
+# Watch worker-messenger and shut supervisord (PID 1) down if it reaches FATAL.
+# Pairs with supervisor-fatal-listener.sh — see that script for the protocol.
+# The container exiting triggers the orchestrator to spawn a fresh instance,
+# which is the only way to recover from supervisord giving up on autorestart.
+[eventlistener:worker-fatal-killer]
+command=/usr/local/bin/supervisor-fatal-listener.sh
+events=PROCESS_STATE_FATAL
+autorestart=unexpected
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
## Summary

`https://expandeddecks.app/health/ready` was correctly returning **HTTP 503** with body `worker-messenger state: FATAL`, but nothing was rotating the instance — supervisord stays alive serving FrankenPHP HTTP traffic even after marking the messenger consumer `FATAL`, and Scaleway Serverless Containers only respawn on PID-1 exit (it ignores Docker's `HEALTHCHECK` directive).

This PR closes that gap.

- Adds `supervisor-fatal-listener.sh`, a tiny POSIX-sh supervisord eventlistener subscribed to `PROCESS_STATE_FATAL`. When `processname:worker-messenger` shows up, it calls `supervisorctl shutdown`, which exits PID 1 and lets the orchestrator (Scaleway, Docker `restart=always`, K8s, …) replace the instance.
- Registers the listener as `[eventlistener:worker-fatal-killer]` in `supervisord.conf`.
- Bumps `worker-messenger` `startretries` from the default 3 to 5: a FATAL transition now costs a full respawn, so we tolerate transient DB blips more generously before declaring the worker dead.
- Switches the Dockerfile `HEALTHCHECK` target from `/health` to `/health/ready` so a stuck consumer is visible to plain `docker run` / Compose users. (No effect on Scaleway prod, which ignores `HEALTHCHECK`.)
- Documents the self-healing pathway in `docs/installation.md` § Health Check.

A companion docs-only change for `expandedDecksInfra/docs/platform.md` will land in a follow-up PR in that repo, **after** this merges, so the infra docs never reference behavior that isn't live.

## Test plan

- [ ] CI green (PHPStan, PHP-CS-Fixer, Twig-CS-Fixer, lint-container, lint-yaml, PHPUnit).
- [ ] Build the production image locally (`docker buildx build --platform linux/amd64 -t expanded-decks:fatal-test .`) and run it.
- [ ] Inside the container, force `worker-messenger` into `FATAL` (e.g., temporarily point the `command` at a missing binary, or `supervisorctl stop worker-messenger && supervisorctl start worker-messenger` in a tight loop).
- [ ] Verify supervisord exits within ~1 s of the FATAL transition (`docker ps` shows the container exited).
- [ ] Re-run with `--restart=always` and confirm Docker respawns the container automatically.
- [ ] After deploy to Scaleway: `curl -i https://expandeddecks.app/health/ready` returns HTTP 200 with `worker: ok` on the fresh instance.
- [ ] Monitor Scaleway Cockpit / Grafana for instance recycling next time `worker-messenger` enters FATAL.