### PR TITLE
:bug: Fix: messenger worker memory-limit unit (MB, not bytes)

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -43,7 +43,10 @@ stopwaitsecs=30
 
 [program:worker-messenger]
 user=www-data
-command=php bin/console messenger:consume transactional_email notification borrow_lifecycle deck_enrichment tcgdex_sync_series tcgdex_sync_serie tcgdex_sync_set tcgdex_sync_card --time-limit=1200 --memory-limit=512 --sleep=60 --env=prod --no-debug
+# --memory-limit needs a K/M/G suffix; an unsuffixed integer is parsed as
+# raw bytes by Symfony's ConsumeMessagesCommand::convertToBytes(), making
+# the listener fire on the worker's first idle tick.
+command=php bin/console messenger:consume transactional_email notification borrow_lifecycle deck_enrichment tcgdex_sync_series tcgdex_sync_serie tcgdex_sync_set tcgdex_sync_card --time-limit=1200 --memory-limit=512M --sleep=60 --env=prod --no-debug
 directory=/app
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
## Summary

Root cause of the FATAL state the 1.12.18 self-heal was meant to catch: the `worker-messenger` supervisor command had `--memory-limit=512` *without* a suffix. Symfony's `ConsumeMessagesCommand::convertToBytes()` only multiplies by 1024 when the last character is `k/m/g/t`, so a plain `512` parses as **512 bytes** — and `StopWorkerOnMemoryLimitListener` fires on the worker's first idle tick because any bootstrapped PHP process is well past 512 bytes of memory.

The worker exits cleanly with status 0 after ~1 second, repeatedly. Supervisor sometimes counts each cycle as a successful `RUNNING → EXITED → respawn` (autorestart=true), but sometimes the bootstrap is slightly slower and the worker exits in *under* `startsecs=1` — that increments `startretries`, and once exhausted the program flips to `FATAL`. The container then reports `worker-messenger state: FATAL` on `/health/ready`.

This was introduced unintentionally in 1.12.14 during the worker consolidation: the changelog stated the intent was 512 MB (matching the previous `deck_enrichment` ceiling), but the `M` got dropped from the command. Static analysis can't catch this — the argument is a stringly-typed value that happens to parse silently as bytes.

## Changes

- `supervisord.conf`: `--memory-limit=512` → `--memory-limit=512M`.
- Adds a comment above the command explaining the suffix requirement so the bug doesn't regress.

## Test plan

- [ ] CI green.
- [ ] After deploy: tail Scaleway Cockpit logs for the `expanded-decks` container. The `worker-messenger` process should stay alive for the full `--time-limit=1200` (20 minutes) between respawns instead of cycling every ~2 seconds.
- [ ] `curl -i https://expandeddecks.app/health/ready` returns HTTP 200 with `worker: ok` and stays that way.
- [ ] No further `worker-messenger entered FATAL` events in Cockpit; the 1.12.18 self-heal eventlistener should remain idle.