### PR TITLE
:bug: fix(archetype): variant sprite preview uses dead build URL

### DIFF
--- a/templates/admin/archetype/edit.html.twig
+++ b/templates/admin/archetype/edit.html.twig
@@ -132,7 +132,7 @@
                                     </td>
                                     <td>
                                         {% for slug in variant.effectivePokemonSlugs[:3] %}
-                                            <img src="{{ asset('build/sprites/pokemon/' ~ slug ~ '.png') }}" alt="{{ slug }}" class="archetype-sprite" style="height: 24px;">
+                                            <img src="{{ path('app_sprite_pokemon', {slug: slug}) }}" alt="{{ slug }}" class="archetype-sprite" style="height: 24px;">
                                         {% endfor %}
                                         {% if variant.latestSet %}
                                             <span class="badge bg-light text-dark border">{{ variant.latestSet.ptcgCode }}</span>

--- a/tests/Functional/AdminArchetypeControllerTest.php
+++ b/tests/Functional/AdminArchetypeControllerTest.php
@@ -92,6 +92,29 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
         self::assertSelectorTextContains('h1', 'Iron Thorns ex');
     }
 
+    /**
+     * Regression guard: the variant table on the admin archetype edit page must
+     * render sprites via the proxy route (`/sprites/pokemon/{slug}.png`), not the
+     * dead legacy `build/sprites/pokemon/` URL — webpack no longer copies the
+     * PokéSprite vendor bundle to `public/build/`, so the legacy path 404s.
+     *
+     * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
+     */
+    public function testEditPageDoesNotUseLegacySpriteUrls(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Iron Thorns ex');
+        $this->client->request('GET', '/admin/archetypes/'.$archetype->getId());
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString(
+            'build/sprites/pokemon/',
+            (string) $this->client->getResponse()->getContent(),
+            'Admin archetype edit page must not emit the dead legacy `build/sprites/pokemon/` URL — use the proxy route instead.',
+        );
+    }
+
     public function testEditUpdatesArchetype(): void
     {
         $this->loginAs('admin@example.com');


### PR DESCRIPTION
## Summary

The admin archetype edit page renders variant sprite previews via the **dead legacy URL** `build/sprites/pokemon/{slug}.png`. The webpack config (`webpack.config.js:58-62`) only copies `assets/images/**`, not the PokéSprite vendor bundle at `assets/vendor/sprites/pokemon/`, so `public/build/sprites/pokemon/` doesn't exist and the legacy path 404s.

Every other sprite call site (`ArchetypeSpriteRuntime`, `PokemonSpriteSelect`, `ArchetypeVariantSelector`, `VariantComparePicker`, `ArchetypeFilterSelect`) already uses the proxy route `/sprites/pokemon/{slug}.png` → `SpriteProxyController::pokemon()` → `SpriteResolver` → Pokemon HOME 3D render.

## Diagnosis vs. issue framing

The issue title says "sprite selector autocomplete shows outdated previews" with three hypotheses listed. Tracing all call sites:

- The autocomplete (`PokemonSpriteSelect.tsx:36`) **already** uses the correct proxy URL.
- Server-side `var/cache/sprites/` is full of 512×512 / 60-200KB PNGs — unmistakably HOME 3D, not legacy PokéSprite (which would be ~1KB pixel art).
- The **only** stale URL pattern in the entire codebase is `templates/admin/archetype/edit.html.twig:135`, which renders the variant table on the same page that hosts the autocomplete.

My read: the user saw the broken/missing sprites in the variant table next to the working autocomplete dropdown and described it as "the autocomplete shows outdated". The actual bug is one line over in the variant table.

## Why this change

- Replace the dead URL with the proxy route via Symfony's `path()` helper.
- Using the named route `app_sprite_pokemon` (vs. a hardcoded `/sprites/pokemon/...` literal) means a future route change can't silently re-break this template.

## Regression guard

`AdminArchetypeControllerTest::testEditPageDoesNotUseLegacySpriteUrls` asserts the rendered HTML never contains the string `build/sprites/pokemon/`. Cheap to maintain and pins the contract.

## Test plan

- [x] Full PHPUnit suite green (2379 tests).
- [x] Twig + PHP-CS-Fixer + lint:twig + lint-container + phpstan all green.
- [ ] **Manual browser**: visit `/admin/archetypes/{id}` for an archetype that has variants with `pokemonSlugs` set — confirm the variant table shows Pokemon HOME 3D renders (matching the autocomplete dropdown and the public archetype page).
- [ ] **Optional**: if there's still a visual divergence after a hard refresh, it's almost certainly browser-level cache from before F2.26 — `Cache-Control: max-age=2592000` on the proxy makes that cache linger for 30 days.

Closes #583.