### PR TITLE
:bug: fix(archetype): inline sprite context for RTE prose

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -817,6 +817,18 @@ footer {
     margin-right: 4px;
 }
 
+// Inline context: sprites embedded in RTE-rendered prose
+// (archetype description tags). Sized in em so they track the
+// surrounding font, with a baseline nudge so the picture doesn't
+// stretch the line box of the paragraph it lives in.
+.archetype-sprites {
+    &--inline .archetype-sprite {
+        height: 1.2em;
+        vertical-align: -0.2em;
+        margin-right: 0.15em;
+    }
+}
+
 // --- Footer ---
 
 .footer-pokemon {

--- a/src/Service/ArchetypeDescriptionRenderer.php
+++ b/src/Service/ArchetypeDescriptionRenderer.php
@@ -104,10 +104,10 @@ class ArchetypeDescriptionRenderer
                 }
 
                 if (null !== $variant) {
-                    $sprites = $this->spriteRuntime->renderDeckSprites($variant);
+                    $sprites = $this->spriteRuntime->renderDeckSprites($variant, 'inline');
                     $name = htmlspecialchars($variant->getName(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
                 } else {
-                    $sprites = $this->spriteRuntime->renderSprites($archetype);
+                    $sprites = $this->spriteRuntime->renderSprites($archetype, 'inline');
                     $name = htmlspecialchars($archetype->getLocalizedName($locale), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
                 }
 

--- a/src/Twig/Runtime/ArchetypeSpriteRuntime.php
+++ b/src/Twig/Runtime/ArchetypeSpriteRuntime.php
@@ -20,6 +20,11 @@ use Twig\Extension\RuntimeExtensionInterface;
 /**
  * Renders Pokemon box sprite images for an archetype's or deck's pokemonSlugs.
  *
+ * The optional `$context` argument controls rendering size:
+ * - `'block'` (default): fixed pixel height for cards, table rows, page headers.
+ * - `'inline'`: em-relative height for sprites inside prose (RTE-rendered archetype
+ *   descriptions), so the line doesn't stretch around the image.
+ *
  * @see docs/features.md F2.12 — Archetype sprite pictograms
  * @see docs/features.md F2.22 — Custom Pokemon sprites on decks
  * @see docs/features.md F2.26 — Upgrade sprites to Pokemon HOME 3D renders
@@ -28,26 +33,31 @@ class ArchetypeSpriteRuntime implements RuntimeExtensionInterface
 {
     /**
      * Renders inline sprite images for the given archetype.
+     *
+     * @param 'block'|'inline' $context
      */
-    public function renderSprites(Archetype $archetype): string
+    public function renderSprites(Archetype $archetype, string $context = 'block'): string
     {
-        return $this->renderSlugs($archetype->getPokemonSlugs());
+        return $this->renderSlugs($archetype->getPokemonSlugs(), $context);
     }
 
     /**
      * Renders inline sprite images for the given deck (deck-level first, archetype fallback).
      *
+     * @param 'block'|'inline' $context
+     *
      * @see docs/features.md F2.22 — Custom Pokemon sprites on decks
      */
-    public function renderDeckSprites(Deck $deck): string
+    public function renderDeckSprites(Deck $deck, string $context = 'block'): string
     {
-        return $this->renderSlugs($deck->getEffectivePokemonSlugs());
+        return $this->renderSlugs($deck->getEffectivePokemonSlugs(), $context);
     }
 
     /**
-     * @param list<string> $slugs
+     * @param list<string>     $slugs
+     * @param 'block'|'inline' $context
      */
-    private function renderSlugs(array $slugs): string
+    private function renderSlugs(array $slugs, string $context = 'block'): string
     {
         if ([] === $slugs) {
             return '';
@@ -65,6 +75,8 @@ class ArchetypeSpriteRuntime implements RuntimeExtensionInterface
             );
         }
 
-        return \sprintf('<span class="archetype-sprites">%s</span> ', $images);
+        $wrapperClass = 'inline' === $context ? 'archetype-sprites archetype-sprites--inline' : 'archetype-sprites';
+
+        return \sprintf('<span class="%s">%s</span> ', $wrapperClass, $images);
     }
 }

--- a/tests/Twig/Runtime/ArchetypeSpriteRuntimeTest.php
+++ b/tests/Twig/Runtime/ArchetypeSpriteRuntimeTest.php
@@ -154,4 +154,44 @@ class ArchetypeSpriteRuntimeTest extends TestCase
 
         self::assertSame('', $this->runtime->renderDeckSprites($deck));
     }
+
+    /**
+     * @see docs/features.md F2.12 — Archetype sprite pictograms
+     */
+    public function testRenderSpritesDefaultContextOmitsInlineModifier(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setPokemonSlugs(['lugia']);
+
+        $html = $this->runtime->renderSprites($archetype);
+
+        self::assertStringContainsString('class="archetype-sprites"', $html);
+        self::assertStringNotContainsString('archetype-sprites--inline', $html);
+    }
+
+    /**
+     * @see docs/features.md F2.12 — Archetype sprite pictograms
+     */
+    public function testRenderSpritesInlineContextAddsModifier(): void
+    {
+        $archetype = new Archetype();
+        $archetype->setPokemonSlugs(['lugia']);
+
+        $html = $this->runtime->renderSprites($archetype, 'inline');
+
+        self::assertStringContainsString('class="archetype-sprites archetype-sprites--inline"', $html);
+    }
+
+    /**
+     * @see docs/features.md F2.22 — Custom Pokemon sprites on decks
+     */
+    public function testRenderDeckSpritesInlineContextAddsModifier(): void
+    {
+        $deck = new Deck();
+        $deck->setPokemonSlugs(['lugia']);
+
+        $html = $this->runtime->renderDeckSprites($deck, 'inline');
+
+        self::assertStringContainsString('class="archetype-sprites archetype-sprites--inline"', $html);
+    }
 }


### PR DESCRIPTION
## Summary

`.archetype-sprite { height: 52px; }` is right for cards/tables/headers but wrong for prose. When an RTE-authored paragraph expands an `[[archetype:slug]]` tag, the 52 px sprite lands inside a ~24 px line of body text and stretches the paragraph.

This adds an inline-context modifier:

- `ArchetypeSpriteRuntime::renderSprites()` and `renderDeckSprites()` gain an optional `string $context = 'block'` argument; `'inline'` appends an `archetype-sprites--inline` modifier class to the wrapping `<span>`.
- `ArchetypeDescriptionRenderer::expandArchetypeTags()` passes `'inline'` at both call sites (variant + archetype branches) — that path is the only one emitting sprites inside Markdown/RTE prose.
- SCSS gains a sibling rule under `.archetype-sprites` that sizes inline sprites in em (1.2em height, -0.2em baseline, 0.15em right margin) so they scale with the surrounding font and align to its baseline.

## Why em, not px

Inline sprites must scale with whatever font-size their host element uses. The RTE renders archetype tags inside paragraphs, list items, table cells, blockquotes — all with different effective font sizes. A fixed 24 px override would look right at default body size but wrong inside an h2 or a small. `1.2em` tracks the font without further tuning.

## Implementation notes

- The Twig functions `archetype_sprites()` / `deck_sprites()` are unchanged behaviorally: their default callers don't pass the new arg, so they get `'block'` and render exactly as before. No template touch needed.
- Followed the codebase's SCSS convention of nesting BEM modifiers under their base class via `&--inline`. The stylelint config (default `selector-class-pattern`) rejects flat `.foo--bar` selectors but accepts them when nested with `&`.

## Test plan

- [x] Unit: `testRenderSpritesDefaultContextOmitsInlineModifier` — base context is unchanged.
- [x] Unit: `testRenderSpritesInlineContextAddsModifier` — `'inline'` emits the modifier class.
- [x] Unit: `testRenderDeckSpritesInlineContextAddsModifier` — same for `renderDeckSprites`.
- [x] All existing sprite tests still green (2382 PHPUnit + 26 Vitest).
- [x] Lint: stylelint + twig-cs-fix + cs-fix + phpstan L10 + lint:twig all green.
- [ ] **Manual browser**: edit an archetype description that uses `[[archetype:lugia-vstar]]` inside a paragraph → confirm the sprite renders at ~1.2× the paragraph font height with the line height unchanged.
- [ ] **Manual browser**: confirm the archetype list cards, archetype show header, deck cards, and admin variant table still render sprites at 52 px (block context unchanged).

Closes #608.