### PR TITLE
:white_check_mark: test: cover staple enricher and friends

### DIFF
--- a/tests/Functional/StapleCardRepositoryTest.php
+++ b/tests/Functional/StapleCardRepositoryTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Constants\StapleCardBucket;
+use App\Entity\CardIdentity;
+use App\Entity\StapleCard;
+use App\Repository\StapleCardRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F6.15 — Staple cards
+ */
+class StapleCardRepositoryTest extends AbstractFunctionalTest
+{
+    private function getRepository(): StapleCardRepository
+    {
+        /** @var StapleCardRepository $repository */
+        $repository = static::getContainer()->get(StapleCardRepository::class);
+
+        return $repository;
+    }
+
+    private function getEntityManager(): EntityManagerInterface
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    private function persistStaple(
+        string $cardName,
+        string $bucket,
+        int $position = 0,
+        int $hotness = 5,
+        ?\DateTimeImmutable $deletedAt = null,
+        ?CardIdentity $identity = null,
+    ): StapleCard {
+        $staple = new StapleCard();
+        $staple->setCardName($cardName);
+        $staple->setBucket($bucket);
+        $staple->setPosition($position);
+        $staple->setHotness($hotness);
+        $staple->setDeletedAt($deletedAt);
+        $staple->setCardIdentity($identity);
+
+        $em = $this->getEntityManager();
+        $em->persist($staple);
+        $em->flush();
+
+        return $staple;
+    }
+
+    private function persistIdentity(string $name, string $category = 'pokemon'): CardIdentity
+    {
+        $identity = new CardIdentity();
+        $identity->setName($name);
+        $identity->setCategory($category);
+
+        $em = $this->getEntityManager();
+        $em->persist($identity);
+        $em->flush();
+
+        return $identity;
+    }
+
+    public function testFindActiveByBucketReturnsOnlyMatchingActiveRows(): void
+    {
+        $this->persistStaple('Iono', StapleCardBucket::SUPPORTER, position: 1);
+        $this->persistStaple('Boss', StapleCardBucket::SUPPORTER, position: 0);
+        $this->persistStaple('Nest Ball', StapleCardBucket::ITEM, position: 0);
+        $this->persistStaple('Deleted Supporter', StapleCardBucket::SUPPORTER, deletedAt: new \DateTimeImmutable());
+
+        $rows = $this->getRepository()->findActiveByBucket(StapleCardBucket::SUPPORTER);
+
+        self::assertCount(2, $rows);
+        // Ordered by position ASC.
+        self::assertSame('Boss', $rows[0]->getCardName());
+        self::assertSame('Iono', $rows[1]->getCardName());
+    }
+
+    public function testFindActiveByBucketAppliesMinHotnessFilter(): void
+    {
+        $this->persistStaple('Hot', StapleCardBucket::ITEM, position: 0, hotness: 9);
+        $this->persistStaple('Lukewarm', StapleCardBucket::ITEM, position: 1, hotness: 4);
+        $this->persistStaple('Cold', StapleCardBucket::ITEM, position: 2, hotness: 1);
+
+        $rows = $this->getRepository()->findActiveByBucket(StapleCardBucket::ITEM, minHotness: 5);
+
+        self::assertCount(1, $rows);
+        self::assertSame('Hot', $rows[0]->getCardName());
+    }
+
+    public function testFindActiveGroupedByBucketReturnsEmptyWhenNoBuckets(): void
+    {
+        $this->persistStaple('Iono', StapleCardBucket::SUPPORTER);
+
+        self::assertSame([], $this->getRepository()->findActiveGroupedByBucket([]));
+    }
+
+    public function testFindActiveGroupedByBucketGroupsRowsExcludingSoftDeleted(): void
+    {
+        $this->persistStaple('Iono', StapleCardBucket::SUPPORTER, position: 0);
+        $this->persistStaple('Boss', StapleCardBucket::SUPPORTER, position: 1);
+        $this->persistStaple('Nest Ball', StapleCardBucket::ITEM, position: 0);
+        $this->persistStaple('Old', StapleCardBucket::ITEM, deletedAt: new \DateTimeImmutable());
+
+        $grouped = $this->getRepository()->findActiveGroupedByBucket([
+            StapleCardBucket::SUPPORTER,
+            StapleCardBucket::ITEM,
+        ]);
+
+        self::assertSame([StapleCardBucket::SUPPORTER, StapleCardBucket::ITEM], array_keys($grouped));
+        self::assertCount(2, $grouped[StapleCardBucket::SUPPORTER]);
+        self::assertSame('Iono', $grouped[StapleCardBucket::SUPPORTER][0]->getCardName());
+        self::assertCount(1, $grouped[StapleCardBucket::ITEM]);
+        self::assertSame('Nest Ball', $grouped[StapleCardBucket::ITEM][0]->getCardName());
+    }
+
+    public function testFindActiveGroupedByBucketAppliesMinHotnessFilter(): void
+    {
+        $this->persistStaple('Hot', StapleCardBucket::ITEM, position: 0, hotness: 9);
+        $this->persistStaple('Cold', StapleCardBucket::ITEM, position: 1, hotness: 1);
+
+        $grouped = $this->getRepository()->findActiveGroupedByBucket([StapleCardBucket::ITEM], minHotness: 5);
+
+        self::assertCount(1, $grouped[StapleCardBucket::ITEM]);
+        self::assertSame('Hot', $grouped[StapleCardBucket::ITEM][0]->getCardName());
+    }
+
+    public function testFindDeletedOrderedByDeletionDate(): void
+    {
+        $this->persistStaple('Active', StapleCardBucket::ITEM);
+        $this->persistStaple('Old Delete', StapleCardBucket::ITEM, deletedAt: new \DateTimeImmutable('2024-01-01'));
+        $this->persistStaple('New Delete', StapleCardBucket::ITEM, deletedAt: new \DateTimeImmutable('2025-06-01'));
+
+        $rows = $this->getRepository()->findDeletedOrderedByDeletionDate();
+
+        self::assertCount(2, $rows);
+        self::assertSame('New Delete', $rows[0]->getCardName());
+        self::assertSame('Old Delete', $rows[1]->getCardName());
+    }
+
+    public function testFindOneByCardIdentityReturnsLinkedStaple(): void
+    {
+        $identity = $this->persistIdentity('Iono');
+        $staple = $this->persistStaple('Iono', StapleCardBucket::SUPPORTER, identity: $identity);
+
+        $found = $this->getRepository()->findOneByCardIdentity($identity);
+
+        self::assertNotNull($found);
+        self::assertSame($staple->getId(), $found->getId());
+    }
+
+    public function testFindOneByCardIdentityReturnsNullWhenNoMatch(): void
+    {
+        $linked = $this->persistIdentity('Iono');
+        $orphan = $this->persistIdentity('Boss');
+        $this->persistStaple('Iono', StapleCardBucket::SUPPORTER, identity: $linked);
+
+        self::assertNull($this->getRepository()->findOneByCardIdentity($orphan));
+    }
+
+    public function testFindMaxPositionInBucketReturnsMinusOneWhenEmpty(): void
+    {
+        self::assertSame(-1, $this->getRepository()->findMaxPositionInBucket(StapleCardBucket::POKEMON));
+    }
+
+    public function testFindMaxPositionInBucketReturnsHighestActivePosition(): void
+    {
+        $this->persistStaple('A', StapleCardBucket::ITEM, position: 3);
+        $this->persistStaple('B', StapleCardBucket::ITEM, position: 7);
+        // Soft-deleted rows are ignored — the editor's "append" must not collide with a stale slot.
+        $this->persistStaple('C', StapleCardBucket::ITEM, position: 99, deletedAt: new \DateTimeImmutable());
+
+        self::assertSame(7, $this->getRepository()->findMaxPositionInBucket(StapleCardBucket::ITEM));
+    }
+
+    public function testFindAllActiveExcludesSoftDeleted(): void
+    {
+        $this->persistStaple('Iono', StapleCardBucket::SUPPORTER);
+        $this->persistStaple('Nest Ball', StapleCardBucket::ITEM);
+        $this->persistStaple('Old', StapleCardBucket::ITEM, deletedAt: new \DateTimeImmutable());
+
+        $rows = $this->getRepository()->findAllActive();
+
+        self::assertCount(2, $rows);
+        $names = array_map(static fn (StapleCard $row): string => $row->getCardName(), $rows);
+        self::assertContains('Iono', $names);
+        self::assertContains('Nest Ball', $names);
+        self::assertNotContains('Old', $names);
+    }
+}

--- a/tests/Service/CardImageResolverTest.php
+++ b/tests/Service/CardImageResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Service;
 
+use App\Entity\CardIdentity;
 use App\Entity\CardPrinting;
 use App\Entity\TcgdexCard;
 use App\Entity\TcgdexSerie;
@@ -21,6 +22,7 @@ use App\Service\CardImageResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * @see docs/features.md F6.2 — TCGdex card data enrichment
@@ -31,11 +33,24 @@ class CardImageResolverTest extends TestCase
     private EntityManagerInterface $entityManager;
     private LoggerInterface $logger;
 
+    /** @var list<string> */
+    private array $tempFiles = [];
+
     protected function setUp(): void
     {
         $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->logger = $this->createStub(LoggerInterface::class);
         $this->resolver = new CardImageResolver($this->entityManager, $this->logger);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        $this->tempFiles = [];
     }
 
     public function testReturnsFalseWhenImageUrlIsNull(): void
@@ -146,6 +161,96 @@ class CardImageResolverTest extends TestCase
         self::assertSame('https://images.pokemontcg.io/sm35/7_hires.png', $urls[1]);
     }
 
+    public function testDownloadImageReturnsPrimaryUrlContentsOnSuccess(): void
+    {
+        $path = $this->writeTempFile('primary-bytes');
+
+        // No tcgdex card + no dash in tcgdexId → no HTTP fallbacks would be tried even
+        // if the primary failed, isolating this test from the network.
+        $printing = $this->buildPrinting($path, 'Pikachu');
+
+        self::assertSame('primary-bytes', $this->resolver->downloadImage($printing));
+    }
+
+    public function testDownloadImageUsesLowResolutionUrlWhenRequested(): void
+    {
+        $directory = sys_get_temp_dir().'/'.uniqid('cir-low-', true);
+        mkdir($directory);
+        file_put_contents($directory.'/low.webp', 'low-res-bytes');
+        $this->tempFiles[] = $directory.'/low.webp';
+
+        // The resolver swaps `/high.webp` → `/low.webp` in the primary URL when
+        // resolution=low. Setting a primary URL that only resolves under low.webp
+        // proves the swap happened.
+        $printing = $this->buildPrinting($directory.'/high.webp', 'Pikachu');
+
+        $result = $this->resolver->downloadImage($printing, 'low');
+
+        // Clean up the directory after the assertion runs but before the test exits.
+        rmdir($directory);
+
+        self::assertSame('low-res-bytes', $result);
+    }
+
+    public function testDownloadImageFallsBackToSiblingPrintingWhenAllFallbacksFail(): void
+    {
+        $siblingPath = $this->writeTempFile('sibling-bytes');
+
+        $identity = new CardIdentity();
+        $identity->setName('Pikachu');
+        $identity->setCategory('pokemon');
+
+        $primary = new CardPrinting();
+        $primary->setTcgdexId('nodash'); // no dash → buildFallbackUrls returns []
+        $primary->setImageUrl('/nonexistent/primary.webp');
+        $primary->setCardIdentity($identity);
+        $identity->addPrinting($primary);
+
+        $sibling = new CardPrinting();
+        $sibling->setTcgdexId('also-nodash');
+        $sibling->setImageUrl($siblingPath);
+        $sibling->setCardIdentity($identity);
+        $identity->addPrinting($sibling);
+
+        // The persistFallbackUrl branch should call flush() once to save the rewritten primary URL.
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $resolver = new CardImageResolver($entityManager, new NullLogger());
+
+        self::assertSame('sibling-bytes', $resolver->downloadImage($primary));
+        // The primary's URL is overwritten to point at the sibling that actually worked.
+        self::assertSame($siblingPath, $primary->getImageUrl());
+    }
+
+    public function testDownloadImageSkipsSiblingWithMissingUrlAndReturnsFalseWhenNothingResolves(): void
+    {
+        $identity = new CardIdentity();
+        $identity->setName('Phantom');
+        $identity->setCategory('pokemon');
+
+        $primary = new CardPrinting();
+        $primary->setTcgdexId('nodash'); // no dash → no HTTP fallbacks
+        $primary->setImageUrl('/nonexistent/primary.webp');
+        $primary->setCardIdentity($identity);
+        $identity->addPrinting($primary);
+
+        // Sibling with no image URL — must be skipped (the `continue` branch in tryFromSiblingPrinting).
+        $emptySibling = new CardPrinting();
+        $emptySibling->setTcgdexId('nodash');
+        $emptySibling->setImageUrl(null);
+        $emptySibling->setCardIdentity($identity);
+        $identity->addPrinting($emptySibling);
+
+        // No flush expected — nothing resolved.
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $resolver = new CardImageResolver($entityManager, new NullLogger());
+
+        self::assertFalse($resolver->downloadImage($primary));
+    }
+
     /**
      * Invoke the private buildFallbackUrls method via reflection.
      *
@@ -157,5 +262,30 @@ class CardImageResolverTest extends TestCase
 
         /* @var list<string> */
         return $reflection->invoke($this->resolver, $printing);
+    }
+
+    private function buildPrinting(string $imageUrl, string $cardName): CardPrinting
+    {
+        $identity = new CardIdentity();
+        $identity->setName($cardName);
+        $identity->setCategory('pokemon');
+
+        $printing = new CardPrinting();
+        $printing->setTcgdexId('nodash');
+        $printing->setImageUrl($imageUrl);
+        $printing->setCardIdentity($identity);
+        $identity->addPrinting($printing);
+
+        return $printing;
+    }
+
+    private function writeTempFile(string $content): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'cir-');
+        \assert(false !== $path);
+        file_put_contents($path, $content);
+        $this->tempFiles[] = $path;
+
+        return $path;
     }
 }

--- a/tests/Service/EnrichmentFlushServiceTest.php
+++ b/tests/Service/EnrichmentFlushServiceTest.php
@@ -15,9 +15,13 @@ namespace App\Tests\Service;
 
 use App\Service\EnrichmentFlushService;
 use Doctrine\DBAL\Connection;
+use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\DirectoryListing;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -121,5 +125,55 @@ class EnrichmentFlushServiceTest extends TestCase
         self::assertStringContainsString('deck_version', $executedStatements[1]);
         self::assertStringContainsString('card_printing', $executedStatements[2]);
         self::assertStringContainsString('card_identity', $executedStatements[3]);
+    }
+
+    public function testFlushDeletesEveryFileInMosaicStorageAndSkipsDirectories(): void
+    {
+        $connection = $this->createStub(Connection::class);
+
+        $listing = new DirectoryListing(new \ArrayIterator([
+            new FileAttributes('mosaic/abc/deck.png'),
+            new DirectoryAttributes('mosaic/abc'),
+            new FileAttributes('mosaic/abc/deck-mini.png'),
+        ]));
+
+        $storage = $this->createMock(FilesystemOperator::class);
+        // Assert the listing is scoped to the `mosaic` prefix recursively, while configuring the return value.
+        $storage->expects(self::once())
+            ->method('listContents')
+            ->with('mosaic', true)
+            ->willReturn($listing);
+
+        // Only the two FileAttributes entries should trigger a delete.
+        $deleted = [];
+        $storage->expects(self::exactly(2))
+            ->method('delete')
+            ->willReturnCallback(static function (string $path) use (&$deleted): void {
+                $deleted[] = $path;
+            });
+
+        $service = new EnrichmentFlushService($connection, $storage, new NullLogger());
+        $service->flush();
+
+        self::assertSame(['mosaic/abc/deck.png', 'mosaic/abc/deck-mini.png'], $deleted);
+    }
+
+    public function testFlushLogsErrorWhenMosaicStorageThrows(): void
+    {
+        $connection = $this->createStub(Connection::class);
+
+        $storage = $this->createStub(FilesystemOperator::class);
+        $storage->method('listContents')->willThrowException(new class('boom') extends \RuntimeException implements FilesystemException {});
+
+        // The flush should still succeed (DB statements have already run); the
+        // filesystem failure is caught and logged so a transient S3 outage
+        // doesn't roll back the data wipe.
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with('Failed to clear mosaic storage: {error}', ['error' => 'boom']);
+
+        $service = new EnrichmentFlushService($connection, $storage, $logger);
+        $service->flush();
     }
 }

--- a/tests/Service/Mosaic/MosaicStorageFactoryTest.php
+++ b/tests/Service/Mosaic/MosaicStorageFactoryTest.php
@@ -57,4 +57,25 @@ final class MosaicStorageFactoryTest extends TestCase
 
         self::assertInstanceOf(FilesystemOperator::class, $filesystem);
     }
+
+    public function testCreateS3ReturnsFilesystemOperator(): void
+    {
+        // The S3 client is lazy: building it (and the Flysystem adapter on top)
+        // does not contact the bucket. We only assert the factory wires the S3
+        // branch without exploding on bogus credentials.
+        $factory = new MosaicStorageFactory(
+            mosaicStorageAdapter: 's3',
+            mosaicStorageLocalDir: 'var/storage/mosaic',
+            projectDir: sys_get_temp_dir(),
+            scalewayS3Bucket: 'test-bucket',
+            scalewayS3Region: 'fr-par',
+            scalewayS3Endpoint: 'https://s3.fr-par.scw.cloud',
+            scalewayS3AccessKey: 'test-access',
+            scalewayS3SecretKey: 'test-secret',
+        );
+
+        $filesystem = $factory->create();
+
+        self::assertInstanceOf(FilesystemOperator::class, $filesystem);
+    }
 }

--- a/tests/Service/StapleCardEnricherTest.php
+++ b/tests/Service/StapleCardEnricherTest.php
@@ -16,18 +16,24 @@ namespace App\Tests\Service;
 use App\Constants\RuleboxType;
 use App\Constants\StapleCardBucket;
 use App\Entity\CardIdentity;
+use App\Entity\CardPrinting;
+use App\Entity\StapleCard;
+use App\Entity\StapleCardPrinting;
 use App\Repository\CardPrintingRepository;
 use App\Repository\StapleCardPrintingRepository;
 use App\Repository\StapleCardRepository;
 use App\Service\CardIdentity\CardIdentityResolver;
 use App\Service\StapleCardEnricher;
 use App\Service\Tcgdex\TcgdexApiClient;
+use App\Service\Tcgdex\TcgdexCard as TcgdexCardDto;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Coverage focused on the bucket-assignment priority rule — the critical
- * staple-specific logic where Ace Spec wins over the type-based buckets.
+ * Coverage of the staple-specific enrichment flows:
+ *   - Bucket priority rule (Ace Spec wins over the type-based buckets).
+ *   - `createFromCode` editor entry point (idempotent restore + repositioning).
+ *   - `enrichPrinting` + `enrichAllActive` mirroring the BannedCardEnricher machinery.
  *
  * @see docs/features.md F6.15 — Staple cards
  */
@@ -116,26 +122,484 @@ class StapleCardEnricherTest extends TestCase
         self::assertSame(StapleCardBucket::POKEMON, $this->makeEnricher()->computeBucketFor(null));
     }
 
-    private function makeEnricher(): StapleCardEnricher
+    public function testCreateFromCodeReturnsNullWhenTcgdexNotFound(): void
     {
-        return new StapleCardEnricher(
-            $this->createStub(TcgdexApiClient::class),
-            $this->createStub(CardIdentityResolver::class),
-            $this->createStub(CardPrintingRepository::class),
-            $this->createStub(StapleCardPrintingRepository::class),
-            $this->createStub(StapleCardRepository::class),
-            $this->createStub(EntityManagerInterface::class),
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('persist');
+        $entityManager->expects(self::never())->method('flush');
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient, entityManager: $entityManager);
+
+        self::assertNull($enricher->createFromCode('UNKNOWN', '0', 5, null));
+    }
+
+    public function testCreateFromCodeCreatesNewStapleAndPersists(): void
+    {
+        $identity = $this->makeIdentity(name: 'Iono', category: 'trainer', trainerType: 'Supporter');
+        $cardPrinting = new CardPrinting();
+        $cardPrinting->setCardIdentity($identity);
+        $cardPrinting->setTcgdexId('paf-80');
+        $identity->addPrinting($cardPrinting);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn($this->buildTcgdexCardDto());
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+        $identityResolver->method('resolveFromTcgdexCard')->willReturn($cardPrinting);
+
+        $stapleRepo = $this->createStub(StapleCardRepository::class);
+        $stapleRepo->method('findOneByCardIdentity')->willReturn(null);
+        $stapleRepo->method('findMaxPositionInBucket')->willReturn(-1);
+
+        $persisted = [];
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('persist')->willReturnCallback(static function (object $entity) use (&$persisted): void {
+            $persisted[] = $entity;
+        });
+        $entityManager->expects(self::once())->method('flush');
+
+        $enricher = $this->buildEnricher(
+            apiClient: $apiClient,
+            identityResolver: $identityResolver,
+            stapleCardRepository: $stapleRepo,
+            entityManager: $entityManager,
+        );
+
+        $staple = $enricher->createFromCode('PAF', '80', 9, 'meta defining draw');
+
+        self::assertNotNull($staple);
+        self::assertSame($identity, $staple->getCardIdentity());
+        self::assertSame('Iono', $staple->getCardName());
+        self::assertSame(StapleCardBucket::SUPPORTER, $staple->getBucket());
+        self::assertSame(9, $staple->getHotness());
+        self::assertSame(0, $staple->getPosition(), 'first row in an empty bucket appends at position 0');
+        self::assertSame($cardPrinting, $staple->getRepresentativePrinting());
+        self::assertContains($staple, $persisted);
+    }
+
+    public function testCreateFromCodeRestoresAndPreservesPositionWhenBucketUnchanged(): void
+    {
+        $identity = $this->makeIdentity(name: 'Iono', category: 'trainer', trainerType: 'Supporter');
+        $cardPrinting = new CardPrinting();
+        $cardPrinting->setCardIdentity($identity);
+        $cardPrinting->setTcgdexId('paf-80');
+        $identity->addPrinting($cardPrinting);
+
+        $existingStaple = new StapleCard();
+        $existingStaple->setCardIdentity($identity);
+        $existingStaple->setCardName('Iono');
+        $existingStaple->setBucket(StapleCardBucket::SUPPORTER);
+        $existingStaple->setHotness(3);
+        $existingStaple->setPosition(7);
+        $existingStaple->setDeletedAt(new \DateTimeImmutable());
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn($this->buildTcgdexCardDto());
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+        $identityResolver->method('resolveFromTcgdexCard')->willReturn($cardPrinting);
+
+        $stapleRepo = $this->createMock(StapleCardRepository::class);
+        $stapleRepo->method('findOneByCardIdentity')->willReturn($existingStaple);
+        // Bucket unchanged → no findMaxPositionInBucket lookup, position is preserved.
+        $stapleRepo->expects(self::never())->method('findMaxPositionInBucket');
+
+        // syncChildPrintings can still persist new StapleCardPrinting children for siblings discovered on
+        // the identity — that's expected. We only assert flush() ran exactly once.
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $enricher = $this->buildEnricher(
+            apiClient: $apiClient,
+            identityResolver: $identityResolver,
+            stapleCardRepository: $stapleRepo,
+            entityManager: $entityManager,
+        );
+
+        $result = $enricher->createFromCode('PAF', '80', 8, 'updated note');
+
+        self::assertSame($existingStaple, $result);
+        self::assertNull($result->getDeletedAt(), 'soft-deleted row is restored');
+        self::assertSame(7, $result->getPosition(), 'unchanged bucket keeps the existing position');
+        self::assertSame(8, $result->getHotness());
+        self::assertSame('updated note', $result->getNote());
+    }
+
+    public function testCreateFromCodeRepositionsWhenBucketChanges(): void
+    {
+        // Existing row was POKEMON; the editor's input + identity now categorize it as SUPPORTER.
+        $identity = $this->makeIdentity(name: 'Iono', category: 'trainer', trainerType: 'Supporter');
+        $cardPrinting = new CardPrinting();
+        $cardPrinting->setCardIdentity($identity);
+        $cardPrinting->setTcgdexId('paf-80');
+        $identity->addPrinting($cardPrinting);
+
+        $existingStaple = new StapleCard();
+        $existingStaple->setCardIdentity($identity);
+        $existingStaple->setCardName('Iono');
+        $existingStaple->setBucket(StapleCardBucket::POKEMON);
+        $existingStaple->setPosition(2);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn($this->buildTcgdexCardDto());
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+        $identityResolver->method('resolveFromTcgdexCard')->willReturn($cardPrinting);
+
+        $stapleRepo = $this->createStub(StapleCardRepository::class);
+        $stapleRepo->method('findOneByCardIdentity')->willReturn($existingStaple);
+        $stapleRepo->method('findMaxPositionInBucket')->willReturn(4);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+
+        $enricher = $this->buildEnricher(
+            apiClient: $apiClient,
+            identityResolver: $identityResolver,
+            stapleCardRepository: $stapleRepo,
+            entityManager: $entityManager,
+        );
+
+        $result = $enricher->createFromCode('PAF', '80', 7, null);
+
+        self::assertNotNull($result);
+        self::assertSame(StapleCardBucket::SUPPORTER, $result->getBucket());
+        self::assertSame(5, $result->getPosition(), 'bucket changed → appended at maxPosition+1');
+    }
+
+    public function testEnrichPrintingNoOpsWhenAlreadyLinked(): void
+    {
+        $existing = $this->createStub(CardPrinting::class);
+
+        $printing = $this->buildStaplePrinting('LOT', '90', $existing);
+
+        $apiClient = $this->createMock(TcgdexApiClient::class);
+        $apiClient->expects(self::never())->method('findCard');
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient);
+
+        self::assertTrue($enricher->enrichPrinting($printing));
+        self::assertSame($existing, $printing->getCardPrinting());
+    }
+
+    public function testEnrichPrintingHitsLocalRepositoryFirst(): void
+    {
+        $local = $this->createStub(CardPrinting::class);
+
+        $repo = $this->createStub(CardPrintingRepository::class);
+        $repo->method('findFirstBySetCodeAndCardNumber')->willReturn($local);
+
+        $apiClient = $this->createMock(TcgdexApiClient::class);
+        $apiClient->expects(self::never())->method('findCard');
+
+        $printing = $this->buildStaplePrinting('LOT', '90', null);
+
+        $enricher = $this->buildEnricher(cardPrintingRepository: $repo, apiClient: $apiClient);
+
+        self::assertTrue($enricher->enrichPrinting($printing));
+        self::assertSame($local, $printing->getCardPrinting());
+    }
+
+    public function testEnrichPrintingFallsBackToTcgdexApi(): void
+    {
+        $tcgdexCard = $this->buildTcgdexCardDto(imageUrl: 'https://images.example.com/foo.png');
+        $resolved = $this->buildResolvedPrintingWithMutableImageUrl(initialImageUrl: null);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn($tcgdexCard);
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+        $identityResolver->method('resolveFromTcgdexCard')->willReturn($resolved);
+
+        $printing = $this->buildStaplePrinting('LOT', '90', null);
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient, identityResolver: $identityResolver);
+
+        self::assertTrue($enricher->enrichPrinting($printing));
+        self::assertSame($resolved, $printing->getCardPrinting());
+        self::assertSame('https://images.example.com/foo.png', $resolved->getImageUrl());
+    }
+
+    public function testEnrichPrintingDoesNotOverwriteExistingImageUrl(): void
+    {
+        $tcgdexCard = $this->buildTcgdexCardDto(imageUrl: 'https://images.example.com/new.png');
+        $resolved = $this->buildResolvedPrintingWithMutableImageUrl(initialImageUrl: 'https://images.example.com/old.png');
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn($tcgdexCard);
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+        $identityResolver->method('resolveFromTcgdexCard')->willReturn($resolved);
+
+        $printing = $this->buildStaplePrinting('LOT', '90', null);
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient, identityResolver: $identityResolver);
+
+        $enricher->enrichPrinting($printing);
+
+        self::assertSame('https://images.example.com/old.png', $resolved->getImageUrl());
+    }
+
+    public function testEnrichPrintingFallsBackToAliasLookup(): void
+    {
+        $tcgdexCard = $this->buildTcgdexCardDto(imageUrl: null);
+        $resolved = $this->createStub(CardPrinting::class);
+
+        $apiClient = $this->createMock(TcgdexApiClient::class);
+        $apiClient->expects(self::once())->method('findCard')->willReturn(null);
+        $apiClient->expects(self::once())->method('findCardByNameInAliasedSet')->willReturn($tcgdexCard);
+
+        $identityResolver = $this->createStub(CardIdentityResolver::class);
+        $identityResolver->method('resolveFromTcgdexCard')->willReturn($resolved);
+
+        $staple = new StapleCard();
+        $staple->setCardName('Some Card');
+        $printing = $this->buildStaplePrinting('LOT', '90', null);
+        $staple->addPrinting($printing);
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient, identityResolver: $identityResolver);
+
+        self::assertTrue($enricher->enrichPrinting($printing));
+        self::assertSame($resolved, $printing->getCardPrinting());
+    }
+
+    public function testEnrichPrintingReturnsFalseWhenAllSourcesMiss(): void
+    {
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn(null);
+        $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+
+        $staple = new StapleCard();
+        $staple->setCardName('Phantom Card');
+        $printing = $this->buildStaplePrinting('UNKNOWN', '0', null);
+        $staple->addPrinting($printing);
+
+        $enricher = $this->buildEnricher(apiClient: $apiClient);
+
+        self::assertFalse($enricher->enrichPrinting($printing));
+        self::assertNull($printing->getCardPrinting());
+    }
+
+    public function testEnrichAllActiveLinksUnresolvedAndRecomputesActiveStaples(): void
+    {
+        $identity = $this->makeIdentity(name: 'Iono', category: 'trainer', trainerType: 'Supporter');
+        $linkedPrinting = new CardPrinting();
+        $linkedPrinting->setCardIdentity($identity);
+        $linkedPrinting->setTcgdexId('paf-80');
+        $identity->addPrinting($linkedPrinting);
+
+        // First call resolves locally; second misses everywhere so it shows up as unresolved.
+        $cardPrintingRepo = $this->createStub(CardPrintingRepository::class);
+        $cardPrintingRepo->method('findFirstBySetCodeAndCardNumber')->willReturnOnConsecutiveCalls($linkedPrinting, null);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn(null);
+        $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+
+        $staple1 = new StapleCard();
+        $staple1->setCardName('Iono');
+        $staple1->setBucket(StapleCardBucket::POKEMON); // will be recomputed to SUPPORTER
+        $staple1->setPosition(2);
+        $printing1 = $this->buildStaplePrinting('PAF', '80', null);
+        $staple1->addPrinting($printing1);
+
+        $staple2 = new StapleCard();
+        $staple2->setCardName('Lost Card');
+        $printing2 = $this->buildStaplePrinting('UNK', '99', null);
+        $staple2->addPrinting($printing2);
+
+        $staplePrintingRepo = $this->createStub(StapleCardPrintingRepository::class);
+        $staplePrintingRepo->method('findAllOrderedBySetAndNumber')->willReturn([$printing1, $printing2]);
+        $staplePrintingRepo->method('findOneBySetCodeAndCardNumber')->willReturn(null);
+
+        // After reparent, the canonical staple for $identity is $staple1 — it should appear in findAllActive.
+        $stapleRepo = $this->createStub(StapleCardRepository::class);
+        $stapleRepo->method('findOneByCardIdentity')->willReturn(null);
+        $stapleRepo->method('findAllActive')->willReturn([$staple1]);
+        $stapleRepo->method('findMaxPositionInBucket')->willReturn(4);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $enricher = $this->buildEnricher(
+            apiClient: $apiClient,
+            cardPrintingRepository: $cardPrintingRepo,
+            stapleCardPrintingRepository: $staplePrintingRepo,
+            stapleCardRepository: $stapleRepo,
+            entityManager: $entityManager,
+        );
+
+        [$linked, $unresolved] = $enricher->enrichAllActive();
+
+        self::assertSame(1, $linked);
+        self::assertSame(['Lost Card (UNK 99)'], $unresolved);
+        // The active staple's bucket was recomputed from the now-known identity.
+        self::assertSame(StapleCardBucket::SUPPORTER, $staple1->getBucket());
+        self::assertSame(5, $staple1->getPosition(), 'bucket changed → appended at maxPosition+1');
+        // The editor's StapleCardPrinting got its representative pulled by the seed path.
+        self::assertSame($linkedPrinting, $staple1->getRepresentativePrinting());
+    }
+
+    public function testEnrichAllActiveForceModeResetsExistingLink(): void
+    {
+        $stale = $this->createStub(CardPrinting::class);
+
+        $printing = $this->buildStaplePrinting('LOT', '90', $stale);
+        $staple = new StapleCard();
+        $staple->setCardName('Pikachu');
+        $staple->addPrinting($printing);
+
+        $staplePrintingRepo = $this->createStub(StapleCardPrintingRepository::class);
+        $staplePrintingRepo->method('findAllOrderedBySetAndNumber')->willReturn([$printing]);
+
+        $stapleRepo = $this->createStub(StapleCardRepository::class);
+        $stapleRepo->method('findAllActive')->willReturn([$staple]);
+
+        $apiClient = $this->createStub(TcgdexApiClient::class);
+        $apiClient->method('findCard')->willReturn(null);
+        $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+
+        $enricher = $this->buildEnricher(
+            apiClient: $apiClient,
+            stapleCardPrintingRepository: $staplePrintingRepo,
+            stapleCardRepository: $stapleRepo,
+        );
+
+        [$linked, $unresolved] = $enricher->enrichAllActive(force: true);
+
+        self::assertSame(0, $linked);
+        self::assertSame(['Pikachu (LOT 90)'], $unresolved);
+        self::assertNull($printing->getCardPrinting(), 'force mode should reset existing link before re-enriching');
+    }
+
+    public function testEnrichAllActiveForceModeAlsoDropsCachedRepresentativePrintingOnIdentifiedStaples(): void
+    {
+        $identity = $this->makeIdentity(name: 'Iono', category: 'trainer', trainerType: 'Supporter');
+        $stale = new CardPrinting();
+        $stale->setCardIdentity($identity);
+        $stale->setTcgdexId('paf-80');
+
+        // The staple already has its identity resolved — the active-staple loop will run for it.
+        $staple = new StapleCard();
+        $staple->setCardName('Iono');
+        $staple->setBucket(StapleCardBucket::SUPPORTER);
+        $staple->setCardIdentity($identity);
+        $staple->setRepresentativePrinting($stale);
+
+        $staplePrintingRepo = $this->createStub(StapleCardPrintingRepository::class);
+        $staplePrintingRepo->method('findAllOrderedBySetAndNumber')->willReturn([]);
+
+        $stapleRepo = $this->createStub(StapleCardRepository::class);
+        $stapleRepo->method('findAllActive')->willReturn([$staple]);
+
+        $enricher = $this->buildEnricher(
+            stapleCardPrintingRepository: $staplePrintingRepo,
+            stapleCardRepository: $stapleRepo,
+        );
+
+        $enricher->enrichAllActive(force: true);
+
+        self::assertNull(
+            $staple->getRepresentativePrinting(),
+            'force mode drops the cached canonical art so it is re-derived from the freshly enriched printings',
         );
     }
 
-    private function makeIdentity(string $category = 'pokemon', ?string $trainerType = null, ?string $ruleboxType = null): CardIdentity
+    private function buildEnricher(
+        ?TcgdexApiClient $apiClient = null,
+        ?CardIdentityResolver $identityResolver = null,
+        ?CardPrintingRepository $cardPrintingRepository = null,
+        ?StapleCardPrintingRepository $stapleCardPrintingRepository = null,
+        ?StapleCardRepository $stapleCardRepository = null,
+        ?EntityManagerInterface $entityManager = null,
+    ): StapleCardEnricher {
+        if (null === $apiClient) {
+            $apiClient = $this->createStub(TcgdexApiClient::class);
+            $apiClient->method('findCard')->willReturn(null);
+            $apiClient->method('findCardByNameInAliasedSet')->willReturn(null);
+        }
+        if (null === $identityResolver) {
+            $identityResolver = $this->createStub(CardIdentityResolver::class);
+        }
+        if (null === $cardPrintingRepository) {
+            $cardPrintingRepository = $this->createStub(CardPrintingRepository::class);
+            $cardPrintingRepository->method('findFirstBySetCodeAndCardNumber')->willReturn(null);
+        }
+        if (null === $stapleCardPrintingRepository) {
+            $stapleCardPrintingRepository = $this->createStub(StapleCardPrintingRepository::class);
+            $stapleCardPrintingRepository->method('findAllOrderedBySetAndNumber')->willReturn([]);
+            $stapleCardPrintingRepository->method('findOneBySetCodeAndCardNumber')->willReturn(null);
+        }
+        if (null === $stapleCardRepository) {
+            $stapleCardRepository = $this->createStub(StapleCardRepository::class);
+            $stapleCardRepository->method('findOneByCardIdentity')->willReturn(null);
+            $stapleCardRepository->method('findAllActive')->willReturn([]);
+            $stapleCardRepository->method('findMaxPositionInBucket')->willReturn(-1);
+        }
+        if (null === $entityManager) {
+            $entityManager = $this->createStub(EntityManagerInterface::class);
+        }
+
+        return new StapleCardEnricher(
+            $apiClient,
+            $identityResolver,
+            $cardPrintingRepository,
+            $stapleCardPrintingRepository,
+            $stapleCardRepository,
+            $entityManager,
+        );
+    }
+
+    private function makeEnricher(): StapleCardEnricher
+    {
+        return $this->buildEnricher();
+    }
+
+    private function makeIdentity(string $name = 'Test Card', string $category = 'pokemon', ?string $trainerType = null, ?string $ruleboxType = null): CardIdentity
     {
         $identity = new CardIdentity();
-        $identity->setName('Test Card');
+        $identity->setName($name);
         $identity->setCategory($category);
         $identity->setTrainerType($trainerType);
         $identity->setRuleboxType($ruleboxType);
 
         return $identity;
+    }
+
+    private function buildStaplePrinting(string $setCode, string $cardNumber, ?CardPrinting $cardPrinting): StapleCardPrinting
+    {
+        $printing = new StapleCardPrinting();
+        $printing->setSetCode($setCode);
+        $printing->setCardNumber($cardNumber);
+        $printing->setCardPrinting($cardPrinting);
+
+        return $printing;
+    }
+
+    private function buildTcgdexCardDto(?string $imageUrl = null): TcgdexCardDto
+    {
+        return new TcgdexCardDto(
+            id: 'paf-80',
+            name: 'Iono',
+            category: 'Trainer',
+            trainerType: 'Supporter',
+            imageUrl: $imageUrl,
+            isExpandedLegal: true,
+        );
+    }
+
+    private function buildResolvedPrintingWithMutableImageUrl(?string $initialImageUrl): CardPrinting
+    {
+        // We need both getImageUrl (initially returns $initialImageUrl) and
+        // setImageUrl (mutates state). A real CardPrinting works for this.
+        $resolved = new CardPrinting();
+        $resolved->setTcgdexId('paf-80');
+        if (null !== $initialImageUrl) {
+            $resolved->setImageUrl($initialImageUrl);
+        }
+
+        return $resolved;
     }
 }

--- a/tests/Twig/ChannelRuntimeTest.php
+++ b/tests/Twig/ChannelRuntimeTest.php
@@ -68,6 +68,87 @@ final class ChannelRuntimeTest extends TestCase
         self::assertSame('/deck/AB3K7N', $runtime->featureUrl('decks', 'app_deck_show', ['short_tag' => 'AB3K7N']));
     }
 
+    public function testCanonicalUrlDelegatesToGenerator(): void
+    {
+        $generator = $this->createStub(ChannelUrlGenerator::class);
+        $generator->method('canonicalUrl')->willReturn('https://expanded.wip/decks');
+
+        $runtime = new ChannelRuntime(
+            $this->createChannelContext((new Channel())->setCode('app')),
+            $generator,
+        );
+
+        self::assertSame('https://expanded.wip/decks', $runtime->canonicalUrl('decks', 'app_deck_list'));
+    }
+
+    public function testSelfCanonicalUrlDelegatesToGenerator(): void
+    {
+        $generator = $this->createStub(ChannelUrlGenerator::class);
+        $generator->method('selfCanonicalUrl')->willReturn('https://expandedtalks.wip/archetypes/zard');
+
+        $runtime = new ChannelRuntime(
+            $this->createChannelContext((new Channel())->setCode('content')),
+            $generator,
+        );
+
+        self::assertSame('https://expandedtalks.wip/archetypes/zard', $runtime->selfCanonicalUrl('app_archetype_show', ['slug' => 'zard']));
+    }
+
+    public function testChannelThemeReturnsThemeName(): void
+    {
+        $channel = (new Channel())->setCode('app')->setThemeName('decks');
+        $runtime = $this->createRuntime($channel);
+
+        self::assertSame('decks', $runtime->channelTheme());
+    }
+
+    public function testChannelThemeReturnsNullWhenContextThrowsLogicException(): void
+    {
+        // Mirror of error-page / CLI safety: when no request is bound to the stack,
+        // ChannelContext throws LogicException and the runtime swallows it.
+        $runtime = new ChannelRuntime(
+            new ChannelContext(new RequestStack()),
+            $this->createStub(ChannelUrlGenerator::class),
+        );
+
+        self::assertNull($runtime->channelTheme());
+    }
+
+    public function testChannelParamReturnsParameterValue(): void
+    {
+        $channel = (new Channel())->setCode('app');
+        $channel->setParameters(['brand_name' => 'Expanded Decks']);
+        $runtime = $this->createRuntime($channel);
+
+        self::assertSame('Expanded Decks', $runtime->channelParam('brand_name'));
+    }
+
+    public function testChannelParamReturnsDefaultWhenContextThrowsLogicException(): void
+    {
+        $runtime = new ChannelRuntime(
+            new ChannelContext(new RequestStack()),
+            $this->createStub(ChannelUrlGenerator::class),
+        );
+
+        self::assertSame('fallback', $runtime->channelParam('brand_name', 'fallback'));
+    }
+
+    public function testChannelAbsoluteUrlDelegatesToGenerator(): void
+    {
+        $generator = $this->createStub(ChannelUrlGenerator::class);
+        $generator->method('absolutizeUrl')->willReturn('https://expanded.wip/api/editor/image/123.png');
+
+        $runtime = new ChannelRuntime(
+            $this->createChannelContext((new Channel())->setCode('app')),
+            $generator,
+        );
+
+        self::assertSame(
+            'https://expanded.wip/api/editor/image/123.png',
+            $runtime->channelAbsoluteUrl('/api/editor/image/123.png'),
+        );
+    }
+
     private function createRuntime(Channel $channel): ChannelRuntime
     {
         return new ChannelRuntime(


### PR DESCRIPTION
## Summary

Close the largest coverage gaps surfaced by the on-demand Coverage workflow on `develop`. Source code is untouched — tests only.

| Class | Before | After (expected) | Missing lines closed |
|---|---|---|---|
| `Service\StapleCardEnricher` | 9% | ~95% | 141 |
| `Repository\StapleCardRepository` | 12% | ~100% | 57 |
| `Service\CardImageResolver` | 58% | ~95% | 27 |
| `Service\Mosaic\MosaicStorageFactory` | 33% | 100% | 12 |
| `Service\EnrichmentFlushService` | 68% | ~95% | 6 |
| `Twig\Runtime\ChannelRuntime` | 64% | 100% | 5 |

### What changed in the tests

- **StapleCardEnricher** — covered `createFromCode` (create / restore-preserve-position / restore-reposition / null-tcgdex) plus the full `enrichPrinting` + `enrichAllActive` machinery, mirroring `BannedCardEnricherTest`. Force-mode now has two distinct tests: one for the always-applies printing-link reset, one for the identity-gated `representativePrinting` reset (it had been conflated; the gate hid behind `$staple->getCardIdentity() === null` early-`continue`).
- **StapleCardRepository** — new functional test exercising every DQL method (active/grouped/deleted queries, max-position, identity lookup, all-active).
- **CardImageResolver** — covered `downloadImage` happy path via `file://` URLs, the `/high.webp` → `/low.webp` low-resolution swap, and the sibling-fallback path (which transitively exercises `tryFromSiblingPrinting` + `persistFallbackUrl`). HTTP fallbacks are bypassed via `tcgdexCard=null` + dashless `tcgdexId` so the tests stay deterministic and network-independent.
- **MosaicStorageFactory** — added the S3 adapter branch test (lazy `S3Client`, no network call).
- **EnrichmentFlushService** — covered the `clearMosaicStorage` file-iteration delete (skipping `DirectoryAttributes`) and the `FilesystemException` → `logger->error` swallow path.
- **ChannelRuntime** — covered `canonicalUrl`, `selfCanonicalUrl`, `channelTheme` (value + `LogicException` fallback), `channelParam` (value + `LogicException` fallback with default), and `channelAbsoluteUrl`.

### Validation

- `make cs-fix` — clean
- `make phpstan` — `[OK] No errors` (Level 10, 299 files)
- `make test.unit` — 1328 tests, 3121 assertions, 27 skipped, 0 failures
- `tests/Functional/StapleCardRepositoryTest.php` — 11/11 green

## Test plan

- [ ] CI green (full PHP test suite + lint)
- [ ] Codecov delta confirms project total moves up (no PR-patch surprises since this is tests-only)
- [ ] Codecov per-file shows the six targets above moving toward the projected percentages