### PR TITLE
:bug: fix: rel=nofollow on archetype filter buttons to deflect bot crawl

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,10 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **`rel="nofollow"` on archetype catalog filter buttons** — bot crawlers walking every tag combination on `/archetypes` were creating one anonymous session per permutation (tag set × AND/OR mode × sort option = 2^N × 2 × M URLs), driving up DB IOPS and disk usage from session storage. The "All" reset, every tag toggle, the drafts toggle (admin only), and both AND/OR mode anchors in `templates/archetype/list.html.twig` now carry `rel="nofollow"` so well-behaved crawlers stop traversing the filter space. Same treatment should follow on the deck catalog and event-list filter rows in a later PR.
+
 ---
 
 ## [1.12.23] — 2026-05-25

--- a/templates/archetype/list.html.twig
+++ b/templates/archetype/list.html.twig
@@ -52,8 +52,15 @@
             <div class="row g-2 align-items-end">
                 <div class="col-md-6">
                     <label class="form-label">{{ 'app.archetype.filter_by_tag'|trans }}</label>
+                    {#
+                     # rel="nofollow" on every filter anchor: tag combinations are
+                     # combinatorial (2^N tags × 2 modes × M sort options), so a
+                     # crawler that walks every link generates a unique URL per
+                     # permutation, each producing an anonymous session. Telling
+                     # bots not to follow these stops the explosion at the source.
+                     #}
                     <div class="d-flex flex-wrap gap-1">
-                        <a href="{{ path('app_archetype_list', {sort: currentSort}) }}" class="btn btn-sm {{ not showDrafts and currentTags|length == 0 ? 'btn-gold' : 'btn-outline-secondary' }}">
+                        <a href="{{ path('app_archetype_list', {sort: currentSort}) }}" rel="nofollow" class="btn btn-sm {{ not showDrafts and currentTags|length == 0 ? 'btn-gold' : 'btn-outline-secondary' }}">
                             {{ 'app.common.all'|trans }}
                         </a>
                         {% for tag in allTags %}
@@ -63,12 +70,12 @@
                             {% else %}
                                 {% set newTags = currentTags|merge([tag]) %}
                             {% endif %}
-                            <a href="{{ path('app_archetype_list', {tags: newTags, sort: currentSort}|merge(tagsModeParam)) }}" class="btn btn-sm {{ isActive ? 'btn-gold' : 'btn-outline-secondary' }}">
+                            <a href="{{ path('app_archetype_list', {tags: newTags, sort: currentSort}|merge(tagsModeParam)) }}" rel="nofollow" class="btn btn-sm {{ isActive ? 'btn-gold' : 'btn-outline-secondary' }}">
                                 {{ tag }}
                             </a>
                         {% endfor %}
                         {% if is_granted('ROLE_ARCHETYPE_EDITOR') %}
-                            <a href="{{ path('app_archetype_list', {drafts: 1}) }}" class="btn btn-sm {{ showDrafts ? 'btn-warning' : 'btn-outline-warning' }}">
+                            <a href="{{ path('app_archetype_list', {drafts: 1}) }}" rel="nofollow" class="btn btn-sm {{ showDrafts ? 'btn-warning' : 'btn-outline-warning' }}">
                                 <i class="bi bi-eye me-1"></i>{{ 'app.archetype.filter_drafts'|trans }}
                             </a>
                         {% endif %}
@@ -77,10 +84,10 @@
                         <div class="d-flex align-items-center gap-2 mt-2">
                             <small class="text-muted">{{ 'app.archetype.tags_mode.label'|trans }}</small>
                             <div class="btn-group btn-group-sm" role="group" aria-label="{{ 'app.archetype.tags_mode.label'|trans }}">
-                                <a href="{{ path('app_archetype_list', {tags: currentTags, sort: currentSort}) }}" class="btn {{ currentTagsMode == 'and' ? 'btn-gold' : 'btn-outline-secondary' }}">
+                                <a href="{{ path('app_archetype_list', {tags: currentTags, sort: currentSort}) }}" rel="nofollow" class="btn {{ currentTagsMode == 'and' ? 'btn-gold' : 'btn-outline-secondary' }}">
                                     {{ 'app.archetype.tags_mode.and'|trans }}
                                 </a>
-                                <a href="{{ path('app_archetype_list', {tags: currentTags, sort: currentSort, tagsMode: 'or'}) }}" class="btn {{ currentTagsMode == 'or' ? 'btn-gold' : 'btn-outline-secondary' }}">
+                                <a href="{{ path('app_archetype_list', {tags: currentTags, sort: currentSort, tagsMode: 'or'}) }}" rel="nofollow" class="btn {{ currentTagsMode == 'or' ? 'btn-gold' : 'btn-outline-secondary' }}">
                                     {{ 'app.archetype.tags_mode.or'|trans }}
                                 </a>
                             </div>


### PR DESCRIPTION
## Summary

- Hypothesis: the DB IOPS / disk-space climb on production since yesterday is **bot crawlers walking the combinatorial tag-filter space** on `/archetypes`. With N tags, there are 2^N tag subsets × 2 modes (AND/OR) × M sort options = exponentially many unique URLs, and each anonymous request opens a new session row.
- `rel="nofollow"` added to every filter anchor in `templates/archetype/list.html.twig`:
  - The "All" reset link
  - Each tag toggle link (`{% for tag in allTags %}`)
  - The admin-only "Drafts" toggle
  - Both AND / OR mode anchors
- `noopener` was intentionally **not** added — it's a `target="_blank"` security shield (window.opener attack) and is a no-op on same-window internal links, so it would add noise without value here.
- Out of scope (deferred to a follow-up): same treatment on the deck catalog, event list, and any other listing-with-filters page; the broader question of whether to skip session creation entirely for anonymous read-only requests.

## Test plan

- [ ] Curl any tag-filtered URL (e.g. `/en/archetypes?tags%5B%5D=Combo&tags%5B%5D=Lock`) and confirm every filter `<a>` carries `rel="nofollow"`
- [ ] Real browsers still navigate normally when the user clicks a tag
- [ ] After deploy, watch the `sessions` table growth rate over the next 24h — should drop sharply if bots were the source