### PR TITLE
:zap: perf: skip session allocation for anonymous read-only requests

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,10 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ## [Unreleased]
 
+### Performance
+
+- **Anonymous read-only requests no longer allocate a session (#634)** — the same root cause that drove the post-1.12.22 production IOPS / disk climb: every anonymous GET was opening a session row. Two changes close that off. **(1)** `LocaleListener::__invoke()` now refactors `applyLocale()` into a pure `setLocale()` that touches `Request::setLocale()` + `LocaleSwitcher` but never the session bag — the listener was previously calling `getSession()->set('_locale', $locale)` on every request, including locale-prefixed URLs like `/en/archetypes` where the URL is already authoritative. The session is now only *read* (for the `_locale` fallback chain) when a session cookie or `REMEMBERME` cookie says the visitor has prior state; cookieless visitors take the Accept-Language branch without consulting Symfony's session storage at all. `LocaleSwitchController` and `ProfileController` (the explicit user-action paths) keep their own `getSession()->set(...)` calls — by the time those fire the session cookie is already present. **(2)** `base.html.twig` and `home/blocks/_hero.html.twig` gate every `app.user` and `app.flashes` access on the same cookie-presence check via a local `current_user = has_session_cookie ? app.user : null` set at the top of the navbar block. Reading `app.user` consults Symfony's `SessionTokenStorage` even with `lazy: true` on the firewall, which was the second-largest session-starter after `LocaleListener`. The cookie-name check is dynamic — `Session::getName()` server-side, `app.session.name` in Twig — so it works against the production `PHPSESSID` cookie and the test env's `MOCKSESSID` (mock file session factory) without hard-coding either. Verified end-to-end: `DELETE FROM sessions; curl six anonymous URLs;` leaves `sessions` empty and no `Set-Cookie` of the session cookie on any response, which unblocks the next step — emitting `Cache-Control: public, s-maxage=…` on the anonymous public-page response path so a CDN can cache them.
+
 ---
 
 ## [1.12.24] — 2026-05-25

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -25,8 +25,8 @@ use Symfony\Component\Translation\LocaleSwitcher;
 /**
  * Sets the request locale based on (in order of priority):
  * 1. Route-level _locale parameter (e.g. /{_locale}/archetypes)
- * 2. Authenticated user's preferredLocale
- * 3. Existing session locale
+ * 2. Authenticated user's preferredLocale (only consulted when a session cookie is present)
+ * 3. Existing session locale (only consulted when a session cookie is present)
  * 4. Accept-Language header detection
  * 5. Default locale (en)
  *
@@ -34,6 +34,13 @@ use Symfony\Component\Translation\LocaleSwitcher;
  * and uses LocaleSwitcher to propagate the locale to the Translator and all
  * other locale-aware services (since Symfony's LocaleAwareListener already ran
  * at priority 15).
+ *
+ * **Session-allocation contract:** this listener never *writes* to the session.
+ * `LocaleSwitchController` and `ProfileController` are the only places that
+ * persist `_locale` — they fire on an explicit user action, by which point
+ * the request has already produced a session cookie. The session is only
+ * *read* when a session cookie is present, so anonymous cookieless requests
+ * stay 100% session-free here and can be CDN-cached safely.
  *
  * @see docs/features.md F9.1 — User language preference
  * @see docs/features.md F18.29 — Locale-prefixed URL routing
@@ -63,37 +70,41 @@ class LocaleListener
 
         // Route-level _locale takes precedence (e.g. /{_locale}/archetypes).
         // Symfony's router already set this attribute; honour it so the URL
-        // always dictates the rendering language.
+        // always dictates the rendering language. No session touch here so
+        // cookieless visitors stay cacheable.
         $routeLocale = $request->attributes->get('_locale');
         if (\is_string($routeLocale) && \in_array($routeLocale, self::SUPPORTED_LOCALES, true)) {
-            $locale = $this->constrainToChannel($routeLocale, $channelLocales);
-            $this->applyLocale($request, $locale);
+            $this->setLocale($request, $this->constrainToChannel($routeLocale, $channelLocales));
 
             return;
         }
 
-        $user = $this->security->getUser();
+        // Only consult the security token / session bag when a session cookie or
+        // remember-me cookie says the visitor has prior state. Without either,
+        // we MUST stay off the session entirely (Security::getUser() would touch
+        // it via SessionTokenStorage) so the response avoids `Set-Cookie` and
+        // can sit behind a CDN.
+        if ($this->hasSessionCookie($request)) {
+            $user = $this->security->getUser();
 
-        if ($user instanceof User) {
-            $locale = $this->constrainToChannel($user->getPreferredLocale(), $channelLocales);
-            $this->applyLocale($request, $locale);
+            if ($user instanceof User) {
+                $this->setLocale($request, $this->constrainToChannel($user->getPreferredLocale(), $channelLocales));
 
-            return;
+                return;
+            }
+
+            $sessionLocale = $request->getSession()->get('_locale');
+            if (\is_string($sessionLocale) && \in_array($sessionLocale, self::SUPPORTED_LOCALES, true)) {
+                $this->setLocale($request, $this->constrainToChannel($sessionLocale, $channelLocales));
+
+                return;
+            }
         }
 
-        $sessionLocale = $request->getSession()->get('_locale');
-        if (\is_string($sessionLocale) && \in_array($sessionLocale, self::SUPPORTED_LOCALES, true)) {
-            $locale = $this->constrainToChannel($sessionLocale, $channelLocales);
-            $this->applyLocale($request, $locale);
-
-            return;
-        }
-
-        $locale = $this->constrainToChannel(
+        $this->setLocale($request, $this->constrainToChannel(
             $this->detectFromAcceptLanguage($request->headers->get('Accept-Language', '')),
             $channelLocales,
-        );
-        $this->applyLocale($request, $locale);
+        ));
     }
 
     /**
@@ -110,11 +121,23 @@ class LocaleListener
         return $channelLocales[0] ?? self::DEFAULT_LOCALE;
     }
 
-    private function applyLocale(Request $request, string $locale): void
+    private function setLocale(Request $request, string $locale): void
     {
         $request->setLocale($locale);
-        $request->getSession()->set('_locale', $locale);
         $this->localeSwitcher->setLocale($locale);
+    }
+
+    private function hasSessionCookie(Request $request): bool
+    {
+        // Read the configured session cookie name from the storage rather than
+        // hard-coding `PHPSESSID`: production uses the PHP default, the test
+        // env uses `MOCKSESSID` via the mock file session factory, and any
+        // future `framework.session.name` override would silently break a
+        // literal check. Session::getName() does NOT start the session — it
+        // only returns the cookie name from the storage's metadata bag.
+        $sessionName = $request->getSession()->getName();
+
+        return $request->cookies->has($sessionName) || $request->cookies->has('REMEMBERME');
     }
 
     private function detectFromAcceptLanguage(string $header): string

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -55,7 +55,15 @@
                 <div class="collapse navbar-collapse" id="navbarNav">
                     <ul class="navbar-nav ms-auto align-items-end align-items-lg-center">
                         {% set channel = current_channel() %}
-                        {% if app.user %}
+                        {#
+                         # Reading app.user starts the session (TokenStorage consults
+                         # _security_main via SessionTokenStorage), even with a lazy
+                         # firewall. Gate on the actual cookie so cookieless visitors
+                         # render the anonymous navbar without allocating a session.
+                         #}
+                        {% set has_session_cookie = app.request.cookies.has(app.session.name) or app.request.cookies.has('REMEMBERME') %}
+                        {% set current_user = has_session_cookie ? app.user : null %}
+                        {% if current_user %}
                             {% if channel.enableDecks %}
                                 <li class="nav-item">
                                     <a class="nav-link" href="{{ path('app_dashboard') }}">{{ 'app.nav.dashboard'|trans }}</a>
@@ -124,8 +132,8 @@
                             {% endif %}
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle nav-link-user d-flex align-items-center" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                    <img src="{{ gravatar(app.user.email, 64) }}" alt="" width="32" height="32" class="rounded-circle me-1">
-                                    {{ app.user.screenName }}
+                                    <img src="{{ gravatar(current_user.email, 64) }}" alt="" width="32" height="32" class="rounded-circle me-1">
+                                    {{ current_user.screenName }}
                                 </a>
                                 <ul class="dropdown-menu dropdown-menu-end">
                                     {% if channel.enableDecks %}
@@ -247,14 +255,20 @@
         </nav>
 
         <main class="container py-4">
-            {% for label, messages in app.flashes %}
-                {% for message in messages %}
-                    <div class="alert alert-{{ label }} alert-dismissible fade show">
-                        {{ message }}
-                        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                    </div>
+            {# Iterating app.flashes opens the session bag and forces a session start.
+               Anonymous cookieless visitors cannot have queued flashes (those only
+               exist after a write via $this->addFlash() which itself sets a cookie),
+               so skip the loop entirely when no cookie is present. #}
+            {% if has_session_cookie %}
+                {% for label, messages in app.flashes %}
+                    {% for message in messages %}
+                        <div class="alert alert-{{ label }} alert-dismissible fade show">
+                            {{ message }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                        </div>
+                    {% endfor %}
                 {% endfor %}
-            {% endfor %}
+            {% endif %}
 
             {% block body %}{% endblock %}
         </main>
@@ -299,7 +313,7 @@
             {{ encore_entry_script_tags('navbar_search') }}
             {{ encore_entry_link_tags('navbar_search') }}
             {{ encore_entry_script_tags('event_datetime_localize') }}
-            {% if app.user and channel is defined and channel.enableDecks %}
+            {% if current_user and channel is defined and channel.enableDecks %}
                 {{ encore_entry_script_tags('notification_bell') }}
                 {{ encore_entry_link_tags('notification_bell') }}
             {% endif %}

--- a/templates/home/blocks/_hero.html.twig
+++ b/templates/home/blocks/_hero.html.twig
@@ -17,9 +17,14 @@
         {% endif %}
         {% if entry.translations.ctaButtons is defined and entry.translations.ctaButtons is not empty %}
             <div class="d-flex gap-2">
+                {# Same cookie-gated app.user pattern as base.html.twig: only consult
+                   the security token when a session cookie is present, otherwise the
+                   anonymous-cookieless homepage stays session-free and CDN-cacheable. #}
+                {% set has_session_cookie = app.request.cookies.has(app.session.name) or app.request.cookies.has('REMEMBERME') %}
+                {% set current_user = has_session_cookie ? app.user : null %}
                 {% for button in entry.translations.ctaButtons %}
                     {# Hide auth-related CTAs for logged-in users #}
-                    {% if app.user and (button.route == 'app_register' or button.route == 'app_login') %}
+                    {% if current_user and (button.route == 'app_register' or button.route == 'app_login') %}
                     {% else %}
                         {% set buttonClass = button.style == 'primary' ? 'btn-gold' : 'btn-outline-light-gold' %}
                         <a href="{{ path(button.route, {_target_path: app.request.requestUri}) }}" class="btn {{ buttonClass }} btn-lg">{{ button.label }}</a>

--- a/tests/EventListener/LocaleListenerTest.php
+++ b/tests/EventListener/LocaleListenerTest.php
@@ -38,14 +38,19 @@ class LocaleListenerTest extends TestCase
         $localeSwitcher = $this->createMock(LocaleSwitcher::class);
         $localeSwitcher->expects(self::once())->method('setLocale')->with('fr');
 
+        // Session cookie must be present for the listener to consult the security
+        // service — in production an authenticated user always carries one.
         $request = $this->createRequestWithSession();
+        $this->addSessionCookie($request);
         $event = $this->createRequestEvent($request);
 
         $listener = new LocaleListener($security, $localeSwitcher);
         $listener($event);
 
         self::assertSame('fr', $request->getLocale());
-        self::assertSame('fr', $request->getSession()->get('_locale'));
+        // Listener no longer writes to the session; persisting the user's
+        // preferred locale is now User::preferredLocale's job, kept fresh by
+        // ProfileController on explicit changes.
     }
 
     public function testSessionLocaleUsedForAnonymousUser(): void
@@ -58,6 +63,7 @@ class LocaleListenerTest extends TestCase
 
         $request = $this->createRequestWithSession();
         $request->getSession()->set('_locale', 'fr');
+        $this->addSessionCookie($request);
         $event = $this->createRequestEvent($request);
 
         $listener = new LocaleListener($security, $localeSwitcher);
@@ -82,7 +88,9 @@ class LocaleListenerTest extends TestCase
         $listener($event);
 
         self::assertSame('fr', $request->getLocale());
-        self::assertSame('fr', $request->getSession()->get('_locale'));
+        // No session write — anonymous cookieless visitors must stay session-free
+        // so the response can sit behind a CDN.
+        self::assertNull($request->getSession()->get('_locale'));
     }
 
     public function testDefaultLocaleWhenNoSignal(): void
@@ -182,7 +190,7 @@ class LocaleListenerTest extends TestCase
         $listener($event);
 
         self::assertSame('en', $request->getLocale());
-        self::assertSame('en', $request->getSession()->get('_locale'));
+        self::assertNull($request->getSession()->get('_locale'));
     }
 
     public function testNonStringSessionLocaleIsIgnored(): void
@@ -282,6 +290,7 @@ class LocaleListenerTest extends TestCase
         $channel = (new Channel())->setCode('app')->setDomain('expandeddecks.wip')->setLocales(['en', 'fr']);
 
         $request = $this->createRequestWithSession();
+        $this->addSessionCookie($request);
         $request->attributes->set('_channel', $channel);
         $event = $this->createRequestEvent($request);
 
@@ -391,6 +400,43 @@ class LocaleListenerTest extends TestCase
         $request->setSession($session);
 
         return $request;
+    }
+
+    /**
+     * Simulate "this request comes from a visitor with prior server-side state"
+     * by attaching a cookie under the configured session name — the trigger
+     * `LocaleListener` uses to decide whether it's safe to consult the security
+     * service / session bag without breaking the anonymous-cacheable contract.
+     */
+    private function addSessionCookie(Request $request): void
+    {
+        $request->cookies->set($request->getSession()->getName(), 'fake-session-id');
+    }
+
+    /**
+     * @see docs/features.md F14.x — anonymous request session-allocation guarantee
+     */
+    public function testAnonymousCookielessRequestStaysSessionFree(): void
+    {
+        $security = $this->createMock(Security::class);
+        // The security service must NOT be consulted on a cookieless request —
+        // calling getUser() would trigger the session-backed token storage and
+        // start a session, defeating the CDN-cacheability contract.
+        $security->expects(self::never())->method('getUser');
+
+        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
+        $localeSwitcher->expects(self::once())->method('setLocale')->with('fr');
+
+        $request = $this->createRequestWithSession();
+        $request->headers->set('Accept-Language', 'fr-FR,fr;q=0.9');
+        // Deliberately no cookie attached.
+        $event = $this->createRequestEvent($request);
+
+        $listener = new LocaleListener($security, $localeSwitcher);
+        $listener($event);
+
+        self::assertSame('fr', $request->getLocale());
+        self::assertNull($request->getSession()->get('_locale'));
     }
 
     private function createRequestEvent(Request $request): RequestEvent


### PR DESCRIPTION
## Summary

Closes #634 — the durable fix for the production IOPS / disk climb that #632 (`rel=\"nofollow\"`) only deflected at the surface.

Two changes close off the largest session-trigger sites in the codebase so cookieless anonymous GETs can produce a response without `Set-Cookie` of the session cookie — which unblocks CDN caching of the public listing surface.

### Fix 1 — `LocaleListener` no longer writes to the session

- `applyLocale()` is refactored into a pure `setLocale()` that touches `Request::setLocale()` + `LocaleSwitcher` only.
- The listener was previously writing `_locale` to the session on **every** request — including locale-prefixed URLs (`/{_locale}/...`) where the URL is already authoritative. **That was the dominant source of anonymous-session inserts.**
- The session is now only **read** (on the fallback chain) when a session-name or `REMEMBERME` cookie says the visitor has prior state. Cookieless visitors take the Accept-Language branch without consulting the session at all.
- `LocaleSwitchController` and `ProfileController` keep their own `getSession()->set('_locale', ...)` calls — those fire on explicit user actions where a session is already in flight.

### Fix 2 — `base.html.twig` / `_hero.html.twig` gate `app.user` and `app.flashes` on cookie presence

- A local `current_user = has_session_cookie ? app.user : null` at the top of the navbar block. Replaces every `app.user` access (4 sites in `base.html.twig`, 1 in `_hero.html.twig`).
- `{% if has_session_cookie %}` wrap around the `app.flashes` iteration. Anonymous cookieless visitors can't have queued flashes anyway (flashes only exist after a write that itself sets a cookie).
- Accessing `app.user` consults Symfony's `SessionTokenStorage` even with `lazy: true` on the firewall — the second-largest session-starter on the cacheable surface after `LocaleListener`.

### Implementation note — dynamic cookie name

`Session::getName()` server-side and `app.session.name` in Twig — so the check works against the production `PHPSESSID` cookie and the test env's `MOCKSESSID` (mock_file session factory) without hard-coding either. Caught by the test suite when the first hard-coded `PHPSESSID` variant landed 226 failures; the dynamic-name fix brought it back to all-green.

### Regression guard

`LocaleListenerTest::testAnonymousCookielessRequestStaysSessionFree` asserts `Security::getUser()` is **never** consulted on a cookieless request — any future refactor that re-introduces a session read at this priority will fail the build.

## Verification

- **Empty `sessions` table after six anonymous GETs:** `DELETE FROM sessions; for url in /en/archetypes /en/archetypes/regidrago /en/deck /en/event / "/en/archetypes?tags[]=Combo"; do curl …; done; SELECT COUNT(*) FROM sessions; → 0`
- **No `Set-Cookie: PHPSESSID=…`** on any of those responses (only the dev-only `main_*_profile_token` debug cookies from the Symfony profiler, which are not set in prod)
- `make phpstan` (level 10) clean
- `make test` — **2453 tests pass** (1 new regression guard, 29 pre-existing skips)
- Authenticated flows still work: login, flash messages on POST → redirect → display, locale switching

## Test plan

- [ ] Curl anonymous GET on a public URL, confirm no `Set-Cookie: PHPSESSID=…` and `sessions` table stays empty
- [ ] Log in via the normal flow, confirm cookie is set, navbar shows username, flash messages still appear
- [ ] Switch locale via the language switcher on an authenticated request, confirm the locale persists across navigations
- [ ] Confirm anonymous archetype catalog still renders with the right locale based on URL prefix (`/en/...` shows EN, `/fr/...` shows FR)

## Out of scope (queued for a later PR)

- Emitting `Cache-Control: public, s-maxage=…` on the anonymous public-page response path so a CDN can actually cache them
- Applying the same `rel=\"nofollow\"` treatment from #632 to the deck and event list filter rows

Closes #634