### PR TITLE
:white_check_mark: test: cover TCGdex admin Sync & Force update happy paths

### DIFF
--- a/tests/Functional/AdminTechnicalControllerCoverageTest.php
+++ b/tests/Functional/AdminTechnicalControllerCoverageTest.php
@@ -184,6 +184,59 @@ class AdminTechnicalControllerCoverageTest extends AbstractFunctionalTest
         self::assertSelectorExists('.alert-danger');
     }
 
+    /**
+     * @see docs/features.md F6.17 — TCGdex multi-locale sync (gap-fill + force update)
+     */
+    public function testTcgdexSyncSucceedsWithValidCsrf(): void
+    {
+        $this->loginAs('admin@example.com');
+        $this->client->request('GET', '/admin/technical');
+
+        $this->client->request('POST', '/admin/technical/tcgdex-sync', [
+            '_token' => $this->getCsrfToken('technical-tcgdex-sync'),
+        ]);
+
+        self::assertResponseRedirects('/admin/technical');
+        $this->client->followRedirect();
+        // Gap-fill series sync was dispatched.
+        self::assertSelectorExists('.alert-success');
+    }
+
+    /**
+     * @see docs/features.md F6.17 — TCGdex multi-locale sync (gap-fill + force update)
+     */
+    public function testTcgdexForceUpdateSucceedsWithValidSet(): void
+    {
+        // The force-update set list comes from createExpandedSetsQueryBuilder(): a set
+        // needs a release date, a non-promo PTCG code, and an Expanded-era serie.
+        /** @var \Doctrine\ORM\EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $serie = new \App\Entity\TcgdexSerie('sv');
+        $set = new \App\Entity\TcgdexSet('sv05', $serie);
+        $set->setName(['en' => 'Paldea Evolved']);
+        $set->setPtcgCode('PAL');
+        $set->setReleaseDate(new \DateTimeImmutable('2023-06-09'));
+        $entityManager->persist($serie);
+        $entityManager->persist($set);
+        $entityManager->flush();
+
+        $this->loginAs('admin@example.com');
+        // Render the dashboard so the force-update form (and its set choices) is built.
+        $this->client->request('GET', '/admin/technical');
+
+        $this->client->request('POST', '/admin/technical/tcgdex-force-update', [
+            'tcgdex_force_update_form' => [
+                'set' => 'sv05',
+                '_token' => $this->getCsrfToken('technical-tcgdex-force-update'),
+            ],
+        ]);
+
+        self::assertResponseRedirects('/admin/technical');
+        $this->client->followRedirect();
+        // A force-update for the chosen set was dispatched.
+        self::assertSelectorExists('.alert-success');
+    }
+
     public function testBannedCardsSyncRejectsInvalidCsrf(): void
     {
         $this->loginAs('admin@example.com');


### PR DESCRIPTION
## Summary

Closes the coverage gap that left `codecov/patch` red on the F6.17 release (PR #655 merged at 88.34% patch vs a 91.21% target). The uncovered lines were the two new `AdminTechnicalController` actions' **success branches** — the existing tests only exercised CSRF / invalid-submission rejection.

- **`testTcgdexSyncSucceedsWithValidCsrf`** — a valid POST to `tcgdex-sync` dispatches the gap-fill series sync and flashes success (mirrors the proven `testMosaicGenerateSucceedsWithValidCsrf` pattern; the sync transport is `doctrine://`, so the message is queued, not run inline).
- **`testTcgdexForceUpdateSucceedsWithValidSet`** — persists a qualifying `TcgdexSet` (release date + non-promo PTCG code + Expanded-era serie), submits the force-update form, and asserts the dispatch + success flash. This also covers `TcgdexForceUpdateFormType`'s `query_builder` and `choice_label` closures, which never ran before (DevFixtures has no `TcgdexSet` rows, so the form's choice list was empty in tests).

No source changes — tests only.

## Test plan
- [x] `make cs-fix`, `make phpstan` — clean
- [ ] CI runs the functional suite (no local DB available) — confirm both new tests pass and `codecov/patch` goes green