### PR TITLE
:rocket: Release: 1.12.33

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,16 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.12.33] — 2026-06-01
+
+Patch release: editing only a CMS page or archetype *translation* now refreshes the parent's publication date, so the public "Updated on" caption reflects real content edits instead of freezing at the last metadata change.
+
+### Bug Fixes
+
+- **Refresh publication date on translation edits** — The public "Updated on" date is read from `lastPublishedAt`, refreshed only by the entity's `#[ORM\PreUpdate]` hook. But content edits go through a standalone `saveTranslation()` action that mutates **only** the `PageTranslation` / `ArchetypeTranslation` child and flushes — and Doctrine fires `PreUpdate` per-entity, only when *that* entity's own fields are dirty. A child change in a `OneToMany` never dirties the owning `Page`/`Archetype`, so the hook (and the `PublishableTimestampsTrait` refresh) was skipped and the date stayed frozen at the last time a parent-level field changed. A new `PageFreshnessListener` mirrors the existing freshness pattern — on `PageTranslation` insert/update it buffers the parent page id and emits a single guarded bulk `UPDATE page SET last_published_at = :now WHERE id IN (:ids) AND is_published = 1` in `postFlush`, keeping the write off the in-progress UnitOfWork and avoiding any parent lifecycle re-entry. `ArchetypeFreshnessListener` (which already bumped freshness on variant-deck activity) is extended so its `collect()` also reacts to `ArchetypeTranslation` edits, which had the identical latent bug. The `is_published = 1` SQL guard reproduces the trait's "drafts never bump" rule; `firstPublishedAt` is left untouched. This is a behavioral fix with no backfill — after deploy, re-saving an affected translation once sets its date to the current day. Coverage: a new functional `PageFreshnessListenerTest` (published parent bumps, draft does not) plus an added `ArchetypeFreshnessListenerTest` case proving a translation edit bumps the archetype. ([#658](https://github.com/jbourdin/expandedDecks/pull/658))
+
+---
+
 ## [1.12.32] — 2026-05-31
 
 Patch release: the incremental TCGdex sync (F6.13) becomes multi-locale. TCGdex publishes a set in English first and adds French (and other) translations over the following days, so production previously never picked up the late-arriving translations. The sync now fetches the locale-independent data plus every configured locale, filling translation gaps as they become available, and captures a per-card `updated` baseline for future set-level freshness diffing.

--- a/src/EventListener/ArchetypeFreshnessListener.php
+++ b/src/EventListener/ArchetypeFreshnessListener.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
+use App\Entity\Archetype;
+use App\Entity\ArchetypeTranslation;
 use App\Entity\Deck;
 use App\Entity\DeckVersion;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
@@ -23,9 +25,9 @@ use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Events;
 
 /**
- * Bumps `Archetype.lastPublishedAt` whenever one of its variants is created or
- * modified, so the catalog freshness signal reflects real variant activity
- * rather than only direct edits to the archetype metadata.
+ * Bumps `Archetype.lastPublishedAt` whenever one of its variants or translations
+ * is created or modified, so the catalog freshness signal reflects real variant
+ * and content activity rather than only direct edits to the archetype metadata.
  *
  * Modifications are buffered during flush and emitted as a single bulk SQL
  * `UPDATE` in `postFlush` — this avoids re-entering Archetype's lifecycle
@@ -95,7 +97,27 @@ final class ArchetypeFreshnessListener
 
         if ($entity instanceof DeckVersion) {
             $this->collectFromDeck($entity->getDeck());
+
+            return;
         }
+
+        // Editing a localized name/description is real content activity that
+        // should refresh the catalog freshness signal — the change dirties only
+        // the translation child, never the owning Archetype, so its lifecycle
+        // callbacks would otherwise be skipped.
+        if ($entity instanceof ArchetypeTranslation) {
+            $this->collectArchetype($entity->getArchetype());
+        }
+    }
+
+    private function collectArchetype(Archetype $archetype): void
+    {
+        $archetypeId = $archetype->getId();
+        if (null === $archetypeId) {
+            return;
+        }
+
+        $this->pendingArchetypeIds[$archetypeId] = true;
     }
 
     private function collectFromDeck(Deck $deck): void
@@ -111,11 +133,6 @@ final class ArchetypeFreshnessListener
             return;
         }
 
-        $archetypeId = $archetype->getId();
-        if (null === $archetypeId) {
-            return;
-        }
-
-        $this->pendingArchetypeIds[$archetypeId] = true;
+        $this->collectArchetype($archetype);
     }
 }

--- a/src/EventListener/PageFreshnessListener.php
+++ b/src/EventListener/PageFreshnessListener.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\EventListener;
+
+use App\Entity\PageTranslation;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Events;
+
+/**
+ * Bumps `Page.lastPublishedAt` whenever one of its translations is created or
+ * modified, so the public "Updated on" date reflects real content edits and not
+ * only direct edits to the page metadata.
+ *
+ * A content edit goes through {@see \App\Controller\AdminPageController::saveTranslation()},
+ * which mutates only the `PageTranslation` child and flushes. Doctrine fires
+ * `PreUpdate` per-entity, only when that entity's own fields are dirty — a child
+ * change in a `OneToMany` never dirties the owning `Page`, so the page's lifecycle
+ * callbacks (and thus the trait's `lastPublishedAt` refresh) would otherwise be
+ * skipped.
+ *
+ * Modifications are buffered during flush and emitted as a single bulk SQL
+ * `UPDATE` in `postFlush` — this keeps the write off the in-progress UnitOfWork
+ * and avoids re-entering Page's lifecycle callbacks. The `is_published = 1` guard
+ * reproduces {@see \App\Entity\PublishableTimestampsTrait::stampPublicationOnUpdate()}'s
+ * "drafts never bump" rule; `firstPublishedAt` is intentionally left untouched.
+ *
+ * @see docs/features.md F11.4 — CMS publication dates
+ */
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::preUpdate)]
+#[AsDoctrineListener(event: Events::postFlush)]
+final class PageFreshnessListener
+{
+    /** @var array<int, true> */
+    private array $pendingPageIds = [];
+
+    public function postPersist(PostPersistEventArgs $args): void
+    {
+        $this->collect($args->getObject());
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args): void
+    {
+        $this->collect($args->getObject());
+    }
+
+    public function postFlush(PostFlushEventArgs $args): void
+    {
+        if ([] === $this->pendingPageIds) {
+            return;
+        }
+
+        $ids = array_keys($this->pendingPageIds);
+        $this->pendingPageIds = [];
+
+        $args->getObjectManager()->getConnection()->executeStatement(
+            'UPDATE page SET last_published_at = :now WHERE id IN (:ids) AND is_published = 1',
+            ['now' => new \DateTimeImmutable(), 'ids' => $ids],
+            ['now' => 'datetime_immutable', 'ids' => ArrayParameterType::INTEGER],
+        );
+    }
+
+    private function collect(object $entity): void
+    {
+        if (!$entity instanceof PageTranslation) {
+            return;
+        }
+
+        $pageId = $entity->getPage()->getId();
+        if (null === $pageId) {
+            return;
+        }
+
+        $this->pendingPageIds[$pageId] = true;
+    }
+}

--- a/tests/Functional/ArchetypeFreshnessListenerTest.php
+++ b/tests/Functional/ArchetypeFreshnessListenerTest.php
@@ -163,4 +163,33 @@ class ArchetypeFreshnessListenerTest extends AbstractFunctionalTest
         self::assertGreaterThan($archetypeBefore, $archetype->getLastPublishedAt());
         self::assertNotNull($variant->getUpdatedAt());
     }
+
+    /**
+     * Editing a localized name/description dirties only the translation child,
+     * never the owning archetype — the freshness signal must still refresh.
+     *
+     * @see docs/features.md F2.27 — Archetype publication dates
+     */
+    public function testEditingATranslationBumpsArchetypeLastPublishedAt(): void
+    {
+        $em = $this->getEntityManager();
+
+        $archetype = $em->getRepository(Archetype::class)->findOneBy(['slug' => 'regidrago']);
+        self::assertNotNull($archetype);
+        $em->refresh($archetype);
+        $archetypeBefore = $archetype->getLastPublishedAt();
+        self::assertNotNull($archetypeBefore);
+
+        $translation = $archetype->getTranslation('en');
+        self::assertInstanceOf(ArchetypeTranslation::class, $translation);
+
+        sleep(1);
+
+        $translation->setDescription(($translation->getDescription() ?? '').' (edited)');
+        $em->flush();
+
+        $em->refresh($archetype);
+
+        self::assertGreaterThan($archetypeBefore, $archetype->getLastPublishedAt());
+    }
 }

--- a/tests/Functional/PageFreshnessListenerTest.php
+++ b/tests/Functional/PageFreshnessListenerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use App\Entity\Page;
+use App\Entity\PageTranslation;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @see docs/features.md F11.4 — CMS publication dates
+ */
+class PageFreshnessListenerTest extends AbstractFunctionalTest
+{
+    private function getEntityManager(): EntityManagerInterface
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    private function createPage(string $slug, bool $isPublished): Page
+    {
+        $em = $this->getEntityManager();
+
+        $page = new Page();
+        $page->setSlug($slug);
+        $page->setIsPublished($isPublished);
+
+        $translation = new PageTranslation();
+        $translation->setLocale('en');
+        $translation->setTitle('Freshness Subject');
+        $translation->setContent('Initial content.');
+        $page->addTranslation($translation);
+
+        $em->persist($page);
+        $em->persist($translation);
+        $em->flush();
+
+        return $page;
+    }
+
+    public function testEditingATranslationBumpsPublishedPageLastPublishedAt(): void
+    {
+        $em = $this->getEntityManager();
+
+        $page = $this->createPage('freshness-published-page', true);
+
+        // Re-read so we capture the listener's post-flush bump from the row.
+        $em->refresh($page);
+        $initialLastPublishedAt = $page->getLastPublishedAt();
+        self::assertNotNull($initialLastPublishedAt);
+
+        sleep(1);
+
+        $translation = $page->getTranslation('en');
+        self::assertNotNull($translation);
+        $translation->setContent('Edited content.');
+        $em->flush();
+
+        $em->refresh($page);
+        $bumpedLastPublishedAt = $page->getLastPublishedAt();
+
+        self::assertNotNull($bumpedLastPublishedAt);
+        self::assertGreaterThan($initialLastPublishedAt, $bumpedLastPublishedAt);
+    }
+
+    public function testEditingATranslationDoesNotBumpDraftPage(): void
+    {
+        $em = $this->getEntityManager();
+
+        $page = $this->createPage('freshness-draft-page', false);
+
+        $em->refresh($page);
+        self::assertNull($page->getLastPublishedAt());
+
+        sleep(1);
+
+        $translation = $page->getTranslation('en');
+        self::assertNotNull($translation);
+        $translation->setContent('Edited draft content.');
+        $em->flush();
+
+        $em->refresh($page);
+        self::assertNull($page->getLastPublishedAt());
+    }
+}


### PR DESCRIPTION
## Summary

- Release 1.12.33 — patch release.
- **Fix:** editing only a CMS page or archetype translation now refreshes the parent's `lastPublishedAt`, so the public "Updated on" date reflects real content edits instead of freezing at the last metadata change ([#658](https://github.com/jbourdin/expandedDecks/pull/658)).

See `docs/changelog.md` for full details.