### PR TITLE
:bug: Bugfix: exclude Standard decks from catalog self-owner filter

### DIFF
--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -522,6 +522,12 @@ class DeckRepository extends ServiceEntityRepository
                 ->setParameter('public', true)
                 ->andWhere('d.format = :format')
                 ->setParameter('format', DeckFormat::Expanded);
+        } elseif (!isset($filters['format']) || '' === $filters['format']) {
+            // Self-owner without an explicit format filter is still browsing the
+            // catalog: Standard decks stay out of /deck and only appear under
+            // /mydecks/standard (F2.23).
+            $qb->andWhere('d.format = :format')
+                ->setParameter('format', DeckFormat::Expanded);
         }
 
         if (isset($filters['search']) && '' !== $filters['search']) {

--- a/tests/Functional/DeckCatalogControllerTest.php
+++ b/tests/Functional/DeckCatalogControllerTest.php
@@ -16,6 +16,7 @@ namespace App\Tests\Functional;
 use App\Entity\Deck;
 use App\Entity\Event;
 use App\Entity\User;
+use App\Enum\DeckFormat;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -330,6 +331,34 @@ class DeckCatalogControllerTest extends AbstractFunctionalTest
         $allText = implode(' ', $cardTitles);
         self::assertStringContainsString('Iron Thorns', $allText);
         self::assertStringContainsString('Ancient Box', $allText);
+    }
+
+    /**
+     * @see docs/features.md F2.23 — Standard format personal decks
+     */
+    public function testSelfOwnerFilterExcludesStandardDecks(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        /** @var User $admin */
+        $admin = $em->getRepository(User::class)->findOneBy(['email' => 'admin@example.com']);
+
+        // Make Ancient Box a Standard-format deck — it must disappear from
+        // the catalog even when the owner filters on their own decks
+        /** @var Deck $ancientBox */
+        $ancientBox = $em->getRepository(Deck::class)->findOneBy(['name' => 'Ancient Box']);
+        $ancientBox->setFormat(DeckFormat::Standard);
+        $em->flush();
+
+        $crawler = $this->client->request('GET', '/deck?owner='.$admin->getId());
+
+        self::assertResponseIsSuccessful();
+        $cardTitles = $crawler->filter('.card-title')->each(static fn ($node) => $node->text());
+        $allText = implode(' ', $cardTitles);
+        self::assertStringContainsString('Iron Thorns', $allText);
+        self::assertStringNotContainsString('Ancient Box', $allText);
     }
 
     public function testOtherOwnerFilterHidesPrivateDecks(): void


### PR DESCRIPTION
## Summary
- `/deck?owner=<self>` leaked Standard-format decks into the public catalog: the repository only enforced the `DeckFormat::Expanded` constraint in the `!$selfOwner` branch, and the catalog controller (unlike `/mydecks`) never sets an explicit `format` filter.
- `DeckRepository::createCatalogQueryBuilder()` now applies the Expanded constraint for self-owners too when no explicit format filter is given — Standard decks remain reachable via `/mydecks/standard` (F2.23), which passes the format explicitly.
- Adds a regression test (`testSelfOwnerFilterExcludesStandardDecks`), verified red before the fix and green after.

## Test plan
- [ ] Log in, open `/deck?owner=<your id>` — Standard decks no longer listed
- [ ] `/mydecks/standard` still lists Standard decks
- [ ] `/mydecks` still lists Expanded decks only