### PR TITLE
:bug: Fix: feed autodiscovery titles leak literal %brand% placeholder

### DIFF
--- a/templates/page/category.html.twig
+++ b/templates/page/category.html.twig
@@ -11,7 +11,7 @@
 {% block title %}{{ category.getName(app.request.locale) }} — {{ parent() }}{% endblock %}
 
 {% block alternate_feeds %}
-    <link rel="alternate" type="application/rss+xml" title="{{ 'app.cms.feed.title_for_category'|trans({'%category%': category.getName(app.request.locale)}) }}" href="{{ url('app_page_category_feed', {id: category.id}) }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ 'app.cms.feed.title_for_category'|trans({'%category%': category.getName(app.request.locale), '%brand%': channel_param('brand_name', 'Expanded Decks')}) }}" href="{{ url('app_page_category_feed', {id: category.id}) }}">
 {% endblock %}
 
 {% block body %}

--- a/templates/page/show.html.twig
+++ b/templates/page/show.html.twig
@@ -24,7 +24,7 @@
 
 {% block alternate_feeds %}
     {% if page.menuCategory %}
-        <link rel="alternate" type="application/rss+xml" title="{{ 'app.cms.feed.title_for_category'|trans({'%category%': page.menuCategory.getName(app.request.locale)}) }}" href="{{ url('app_page_category_feed', {id: page.menuCategory.id}) }}">
+        <link rel="alternate" type="application/rss+xml" title="{{ 'app.cms.feed.title_for_category'|trans({'%category%': page.menuCategory.getName(app.request.locale), '%brand%': channel_param('brand_name', 'Expanded Decks')}) }}" href="{{ url('app_page_category_feed', {id: page.menuCategory.id}) }}">
     {% endif %}
 {% endblock %}
 

--- a/tests/Functional/PageControllerTest.php
+++ b/tests/Functional/PageControllerTest.php
@@ -187,6 +187,31 @@ class PageControllerTest extends AbstractFunctionalTest
         self::assertContains('Cats & "Dogs" <Test>', $titles);
     }
 
+    public function testCategoryPageFeedAutodiscoveryTitleIncludesBrand(): void
+    {
+        $category = $this->findNewsCategory();
+
+        $crawler = $this->client->request('GET', \sprintf('/en/pages/category/%d', $category->getId()), server: self::CONTENT_HOST);
+
+        self::assertResponseIsSuccessful();
+        $linkTitle = $crawler->filter('link[rel="alternate"][type="application/rss+xml"]')->attr('title');
+        self::assertNotNull($linkTitle);
+        // A missing translation parameter would leak the literal placeholder.
+        self::assertStringNotContainsString('%brand%', $linkTitle);
+        self::assertStringContainsString('Expanded Talks', $linkTitle);
+    }
+
+    public function testPageShowFeedAutodiscoveryTitleIncludesBrand(): void
+    {
+        $crawler = $this->client->request('GET', '/en/pages/season-2026-kickoff', server: self::CONTENT_HOST);
+
+        self::assertResponseIsSuccessful();
+        $linkTitle = $crawler->filter('link[rel="alternate"][type="application/rss+xml"]')->attr('title');
+        self::assertNotNull($linkTitle);
+        self::assertStringNotContainsString('%brand%', $linkTitle);
+        self::assertStringContainsString('Expanded Talks', $linkTitle);
+    }
+
     public function testCategoryFeedUnknownCategoryReturns404(): void
     {
         $this->client->request('GET', '/en/pages/category/999999/feed.xml', server: self::CONTENT_HOST);


### PR DESCRIPTION
## Summary
- `app.cms.feed.title_for_category` gained a `%brand%` placeholder in 1.13.0 (#671), but the `<link rel="alternate">` autodiscovery titles on `page/category.html.twig` and `page/show.html.twig` still passed only `%category%` — Symfony's translator leaves unknown placeholders verbatim, so browsers saw e.g. `News — %brand%` as the feed name
- Both calls now pass `channel_param('brand_name', 'Expanded Decks')` like the feed template does
- Regression tests assert the rendered link title contains the brand and not the literal placeholder, on both the category and single-page views

## Test plan
- [ ] View source on `https://expandedtalks.wip/en/pages/category/{id}` and a page view — the RSS `<link>` title reads "News — Expanded Talks"