### PR TITLE
:rocket: Release: 1.13.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,16 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.13.1] — 2026-06-06
+
+Patch release: the RSS feed autodiscovery titles introduced in 1.13.0 no longer leak the literal `%brand%` placeholder.
+
+### Bug Fixes
+
+- **Pass brand param to feed autodiscovery link titles** — `app.cms.feed.title_for_category` gained a `%brand%` placeholder in 1.13.0, but the `<link rel="alternate" type="application/rss+xml">` titles on the category list and single-page views still passed only `%category%`. Symfony's translator leaves unknown placeholders verbatim, so browsers and feed readers picking up autodiscovery saw e.g. « News — %brand% » as the feed name. Both templates now pass `channel_param('brand_name', …)` like the feed template does; regression tests assert the rendered titles contain the brand and not the raw placeholder. ([#673](https://github.com/jbourdin/expandedDecks/pull/673))
+
+---
+
 ## [1.13.0] — 2026-06-06
 
 Minor release: content syndication arrives as a new feature family (F21). Readers can subscribe to RSS feeds for each CMS page category and for newly published archetype variants, with branded channels (name + logo) for feed readers and subscribe buttons across the site.

--- a/templates/page/category.html.twig
+++ b/templates/page/category.html.twig
@@ -11,7 +11,7 @@
 {% block title %}{{ category.getName(app.request.locale) }} — {{ parent() }}{% endblock %}
 
 {% block alternate_feeds %}
-    <link rel="alternate" type="application/rss+xml" title="{{ 'app.cms.feed.title_for_category'|trans({'%category%': category.getName(app.request.locale)}) }}" href="{{ url('app_page_category_feed', {id: category.id}) }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ 'app.cms.feed.title_for_category'|trans({'%category%': category.getName(app.request.locale), '%brand%': channel_param('brand_name', 'Expanded Decks')}) }}" href="{{ url('app_page_category_feed', {id: category.id}) }}">
 {% endblock %}
 
 {% block body %}

--- a/templates/page/show.html.twig
+++ b/templates/page/show.html.twig
@@ -24,7 +24,7 @@
 
 {% block alternate_feeds %}
     {% if page.menuCategory %}
-        <link rel="alternate" type="application/rss+xml" title="{{ 'app.cms.feed.title_for_category'|trans({'%category%': page.menuCategory.getName(app.request.locale)}) }}" href="{{ url('app_page_category_feed', {id: page.menuCategory.id}) }}">
+        <link rel="alternate" type="application/rss+xml" title="{{ 'app.cms.feed.title_for_category'|trans({'%category%': page.menuCategory.getName(app.request.locale), '%brand%': channel_param('brand_name', 'Expanded Decks')}) }}" href="{{ url('app_page_category_feed', {id: page.menuCategory.id}) }}">
     {% endif %}
 {% endblock %}
 

--- a/tests/Functional/PageControllerTest.php
+++ b/tests/Functional/PageControllerTest.php
@@ -187,6 +187,31 @@ class PageControllerTest extends AbstractFunctionalTest
         self::assertContains('Cats & "Dogs" <Test>', $titles);
     }
 
+    public function testCategoryPageFeedAutodiscoveryTitleIncludesBrand(): void
+    {
+        $category = $this->findNewsCategory();
+
+        $crawler = $this->client->request('GET', \sprintf('/en/pages/category/%d', $category->getId()), server: self::CONTENT_HOST);
+
+        self::assertResponseIsSuccessful();
+        $linkTitle = $crawler->filter('link[rel="alternate"][type="application/rss+xml"]')->attr('title');
+        self::assertNotNull($linkTitle);
+        // A missing translation parameter would leak the literal placeholder.
+        self::assertStringNotContainsString('%brand%', $linkTitle);
+        self::assertStringContainsString('Expanded Talks', $linkTitle);
+    }
+
+    public function testPageShowFeedAutodiscoveryTitleIncludesBrand(): void
+    {
+        $crawler = $this->client->request('GET', '/en/pages/season-2026-kickoff', server: self::CONTENT_HOST);
+
+        self::assertResponseIsSuccessful();
+        $linkTitle = $crawler->filter('link[rel="alternate"][type="application/rss+xml"]')->attr('title');
+        self::assertNotNull($linkTitle);
+        self::assertStringNotContainsString('%brand%', $linkTitle);
+        self::assertStringContainsString('Expanded Talks', $linkTitle);
+    }
+
     public function testCategoryFeedUnknownCategoryReturns404(): void
     {
         $this->client->request('GET', '/en/pages/category/999999/feed.xml', server: self::CONTENT_HOST);


### PR DESCRIPTION
## Summary
- Release 1.13.1 — fixes the feed autodiscovery titles leaking the literal `%brand%` placeholder (#673). See docs/changelog.md for details.