### PR TITLE
:bug: Bugfix: grant editors access to OG image builder

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -71,6 +71,7 @@ security:
         - { path: ^/admin/pages, roles: ROLE_CMS_EDITOR }
         - { path: ^/admin/homepage, roles: ROLE_CMS_EDITOR }
         - { path: ^/admin/menu-categories, roles: ROLE_CMS_EDITOR }
+        - { path: ^/admin/og-image-builder, roles: [ROLE_CMS_EDITOR, ROLE_ARCHETYPE_EDITOR] }
         - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/dashboard, roles: ROLE_USER }
         - { path: ^/deck, roles: ROLE_USER }

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -65,6 +65,7 @@ class DevFixtures extends Fixture
         $staff1 = $this->createStaff1($manager);
         $staff2 = $this->createStaff2($manager);
         $lender = $this->createLender($manager);
+        $this->createEditor($manager);
         $this->createUnverifiedUser($manager);
         $todayEvent = $this->createEventToday($manager, $admin, $borrower, $staff1);
         $futureEvent = $this->createEventInTwoMonths($manager, $admin, $lender, $staff1, $staff2);
@@ -291,6 +292,25 @@ MARKDOWN;
         $user->setScreenName('Lender');
         $user->setPlayerId('301');
         $user->setPassword($this->passwordHasher->hashPassword($user, 'password'));
+        $user->setIsVerified(true);
+        $user->setPreferredLocale('en');
+        $user->setTimezone('Europe/Paris');
+
+        $manager->persist($user);
+
+        return $user;
+    }
+
+    private function createEditor(ObjectManager $manager): User
+    {
+        $user = new User();
+        $user->setEmail('editor@example.com');
+        $user->setFirstName('Gwen');
+        $user->setLastName('Editeur');
+        $user->setScreenName('Editor');
+        $user->setPlayerId('401');
+        $user->setPassword($this->passwordHasher->hashPassword($user, 'password'));
+        $user->setRoles(['ROLE_CMS_EDITOR']);
         $user->setIsVerified(true);
         $user->setPreferredLocale('en');
         $user->setTimezone('Europe/Paris');

--- a/tests/Functional/OgImageBuilderControllerTest.php
+++ b/tests/Functional/OgImageBuilderControllerTest.php
@@ -33,7 +33,9 @@ class OgImageBuilderControllerTest extends AbstractFunctionalTest
 
     public function testPageRendersForEditor(): void
     {
-        $this->loginAs('admin@example.com');
+        // editor@example.com holds only ROLE_CMS_EDITOR (no ROLE_ADMIN), which is
+        // the case the `^/admin/og-image-builder` firewall rule must allow through.
+        $this->loginAs('editor@example.com');
         $this->client->request('GET', '/admin/og-image-builder');
 
         self::assertResponseIsSuccessful();


### PR DESCRIPTION
## Summary

- **Root cause:** the `^/admin → ROLE_ADMIN` catch-all in `config/packages/security.yaml` `access_control` is matched before any controller `#[IsGranted]`, so it shadowed `OgImageBuilderController`'s `ROLE_CMS_EDITOR or ROLE_ARCHETYPE_EDITOR` grant. Editors saw the navbar link but got a 403 on click (reported for an editor holding `ROLE_CMS_EDITOR` + `ROLE_ARCHETYPE_EDITOR`).
- **Fix:** added a specific `^/admin/og-image-builder` rule (allowing `ROLE_CMS_EDITOR` and `ROLE_ARCHETYPE_EDITOR`) before the catch-all, mirroring the existing per-section rules. The rule also covers the `/generate` POST endpoint via the shared path prefix.
- **Test gap closed:** `testPageRendersForEditor` previously logged in as `admin@example.com` (a `ROLE_ADMIN` user that satisfies the catch-all), so it passed despite the firewall blocking real editors. Added an editor-only fixture user (`editor@example.com`, `ROLE_CMS_EDITOR`) and pointed the test at it, so it now guards the firewall rule.

## Test plan

- [x] `OgImageBuilderControllerTest` passes (8 tests)
- [x] Verified the regression guard: removing the new firewall rule makes `testPageRendersForEditor` fail with access-denied; restoring it passes
- [x] PHPStan L10, PHP-CS-Fixer, `lint:container`, `lint:yaml` all green
- [ ] Manual: log in as an editor-only account in dev and confirm `/admin/og-image-builder` loads and generates an image