### PR TITLE
:rocket: Release: 1.14.2

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -71,6 +71,7 @@ security:
         - { path: ^/admin/pages, roles: ROLE_CMS_EDITOR }
         - { path: ^/admin/homepage, roles: ROLE_CMS_EDITOR }
         - { path: ^/admin/menu-categories, roles: ROLE_CMS_EDITOR }
+        - { path: ^/admin/og-image-builder, roles: [ROLE_CMS_EDITOR, ROLE_ARCHETYPE_EDITOR] }
         - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/dashboard, roles: ROLE_USER }
         - { path: ^/deck, roles: ROLE_USER }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,16 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.14.2] — 2026-06-07
+
+Patch release: editors who are not full admins can now reach the OG image builder admin tool.
+
+### Bug Fixes
+
+- **Grant editors access to the OG image builder route** — The OG image builder (introduced in 1.14.0) is gated `ROLE_CMS_EDITOR` or `ROLE_ARCHETYPE_EDITOR` on the controller, and the navbar link shows for those roles, but clicking it returned 403 for editors without `ROLE_ADMIN`. Symfony evaluates `access_control` firewall rules before controller `#[IsGranted]` attributes and stops at the first path match, so `/admin/og-image-builder` fell through to the catch-all `^/admin` → `ROLE_ADMIN` rule. A specific `^/admin/og-image-builder` rule (allowing both editor roles) now precedes the catch-all, mirroring the other editor-accessible admin sections, and covers the `/generate` endpoint via the shared prefix. The pre-existing functional test passed despite the bug because it logged in as a `ROLE_ADMIN` user; an editor-only fixture user (`editor@example.com`) now backs a genuine regression test. ([#680](https://github.com/jbourdin/expandedDecks/pull/680))
+
+---
+
 ## [1.14.1] — 2026-06-07
 
 Patch release: card fans generated in production now show the Pokemon card back fillers instead of grey placeholders.

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -65,6 +65,7 @@ class DevFixtures extends Fixture
         $staff1 = $this->createStaff1($manager);
         $staff2 = $this->createStaff2($manager);
         $lender = $this->createLender($manager);
+        $this->createEditor($manager);
         $this->createUnverifiedUser($manager);
         $todayEvent = $this->createEventToday($manager, $admin, $borrower, $staff1);
         $futureEvent = $this->createEventInTwoMonths($manager, $admin, $lender, $staff1, $staff2);
@@ -291,6 +292,25 @@ MARKDOWN;
         $user->setScreenName('Lender');
         $user->setPlayerId('301');
         $user->setPassword($this->passwordHasher->hashPassword($user, 'password'));
+        $user->setIsVerified(true);
+        $user->setPreferredLocale('en');
+        $user->setTimezone('Europe/Paris');
+
+        $manager->persist($user);
+
+        return $user;
+    }
+
+    private function createEditor(ObjectManager $manager): User
+    {
+        $user = new User();
+        $user->setEmail('editor@example.com');
+        $user->setFirstName('Gwen');
+        $user->setLastName('Editeur');
+        $user->setScreenName('Editor');
+        $user->setPlayerId('401');
+        $user->setPassword($this->passwordHasher->hashPassword($user, 'password'));
+        $user->setRoles(['ROLE_CMS_EDITOR']);
         $user->setIsVerified(true);
         $user->setPreferredLocale('en');
         $user->setTimezone('Europe/Paris');

--- a/tests/Functional/OgImageBuilderControllerTest.php
+++ b/tests/Functional/OgImageBuilderControllerTest.php
@@ -33,7 +33,9 @@ class OgImageBuilderControllerTest extends AbstractFunctionalTest
 
     public function testPageRendersForEditor(): void
     {
-        $this->loginAs('admin@example.com');
+        // editor@example.com holds only ROLE_CMS_EDITOR (no ROLE_ADMIN), which is
+        // the case the `^/admin/og-image-builder` firewall rule must allow through.
+        $this->loginAs('editor@example.com');
         $this->client->request('GET', '/admin/og-image-builder');
 
         self::assertResponseIsSuccessful();


### PR DESCRIPTION
## Summary

- Release 1.14.2 — patch release.
- **Bug Fixes:** grant editors (`ROLE_CMS_EDITOR` / `ROLE_ARCHETYPE_EDITOR`) access to the `/admin/og-image-builder` route, which was shadowed by the `^/admin` → `ROLE_ADMIN` catch-all firewall rule ([#680](https://github.com/jbourdin/expandedDecks/pull/680)).

See `docs/changelog.md` for details.