### PR TITLE
:wrench: chore: run CI MySQL on tmpfs datadir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,17 @@ jobs:
           MYSQL_PASSWORD: expanded_decks
         ports:
           - 3306:3306
+        # tmpfs datadir: the test database is dropped and recreated per job and
+        # never needs to survive the run — keeping InnoDB in RAM removes disk
+        # I/O from every migrate/fixture/test cycle. size=1g is a ceiling;
+        # tmpfs only consumes what is written. mode=1777 is required: tmpfs
+        # mounts root:755 and mysqld runs as the mysql user.
         options: >-
           --health-cmd="mysqladmin ping -h localhost"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
+          --tmpfs /var/lib/mysql:rw,size=1g,mode=1777
 
     steps:
       - uses: actions/checkout@v4
@@ -118,11 +124,17 @@ jobs:
           MYSQL_PASSWORD: expanded_decks
         ports:
           - 3306:3306
+        # tmpfs datadir: the test database is dropped and recreated per job and
+        # never needs to survive the run — keeping InnoDB in RAM removes disk
+        # I/O from every migrate/fixture/test cycle. size=1g is a ceiling;
+        # tmpfs only consumes what is written. mode=1777 is required: tmpfs
+        # mounts root:755 and mysqld runs as the mysql user.
         options: >-
           --health-cmd="mysqladmin ping -h localhost"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
+          --tmpfs /var/lib/mysql:rw,size=1g,mode=1777
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,11 +22,17 @@ jobs:
           MYSQL_PASSWORD: expanded_decks
         ports:
           - 3306:3306
+        # tmpfs datadir: the test database is dropped and recreated per job and
+        # never needs to survive the run — keeping InnoDB in RAM removes disk
+        # I/O from every migrate/fixture/test cycle. size=1g is a ceiling;
+        # tmpfs only consumes what is written. mode=1777 is required: tmpfs
+        # mounts root:755 and mysqld runs as the mysql user.
         options: >-
           --health-cmd="mysqladmin ping -h localhost"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
+          --tmpfs /var/lib/mysql:rw,size=1g,mode=1777
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Backports the InnoDB-in-RAM optimization from the Ecommerce-sylius CI: the MySQL service container's data directory (`/var/lib/mysql`) is mounted on a tmpfs, keeping all InnoDB I/O in RAM.

The test database is dropped and recreated per job and never needs to survive the run, so disk persistence buys nothing — removing disk I/O speeds up every migrate/fixture/test cycle.

## Details

- `--tmpfs /var/lib/mysql:rw,size=1g,mode=1777` appended to the existing `--health-*` docker options (both are plain `docker create` flags).
- `size=1g` is a ceiling, not an allocation — tmpfs only consumes what is actually written.
- `mode=1777` is required: tmpfs mounts `root:755` by default and `mysqld` runs as the `mysql` user; init aborts otherwise.

Applied to the three MySQL service blocks: `php-functional` and `php-coverage` in `ci.yml`, and the manual `coverage.yml` workflow.

## Verification

- CI on this PR exercises the functional and coverage jobs against the tmpfs-backed MySQL.
- Compare job wall-clock against a recent `develop` run to confirm the gain.