### PR TITLE
:bug: Bugfix: restore PHPStan green on develop (workflow CompletedEvent)

### DIFF
--- a/src/EventListener/BorrowApprovedListener.php
+++ b/src/EventListener/BorrowApprovedListener.php
@@ -34,12 +34,12 @@ class BorrowApprovedListener
     ) {
     }
 
-    /**
-     * @param CompletedEvent<Borrow> $event
-     */
     public function onApproved(CompletedEvent $event): void
     {
         $borrow = $event->getSubject();
+        if (!$borrow instanceof Borrow) {
+            return;
+        }
 
         $borrowId = $borrow->getId();
         if (null === $borrowId) {


### PR DESCRIPTION
## What

Fixes 3 PHPStan level-10 errors currently failing on **develop** in `BorrowApprovedListener`.

## Root cause

PR #682 ("bump 36 composer updates") upgraded `symfony/workflow` to **8.0.9**, where `CompletedEvent` is no longer generic. That invalidated the `@param CompletedEvent<Borrow>` annotation in `BorrowApprovedListener` (introduced in F4.11, valid against the prior version), and left `$event->getSubject()` typed as `mixed`:

- `@param` references a non-generic class → `generics.notGeneric`
- `mixed` subject → `$borrow->getId()` `method.notFound` and `int` arg `argument.type`

No baseline, so all three surface. Pure transitive breakage — the borrow code never changed.

## Fix

Drop the invalid generic annotation and narrow the subject with `if (!$borrow instanceof Borrow) { return; }` — idiomatic, matches the project's `instanceof` preference, and resolves all three errors.

## Verification

- `make phpstan` → **No errors**
- `tests/EventListener/BorrowApprovedListenerTest.php` → 3/3 pass

Unblocks #695 (and any other branch) from a red `develop` PHPStan.