### PR TITLE
:sparkles: Feature: derive SEO locale signals from channel locales (F19.4)

### DIFF
--- a/src/Controller/RobotsTxtController.php
+++ b/src/Controller/RobotsTxtController.php
@@ -62,11 +62,12 @@ class RobotsTxtController extends AbstractController
     private function buildDirectives(Channel $channel, string $sitemapUrl): array
     {
         $lines = ['User-agent: *', 'Crawl-delay: 1'];
+        $locales = $channel->getLocales();
 
         if ($channel->getEnableArchetypes()) {
-            $lines = [...$lines, ...$this->buildContentChannelRules()];
+            $lines = [...$lines, ...$this->buildContentChannelRules($locales)];
         } else {
-            $lines = [...$lines, ...$this->buildAppChannelRules()];
+            $lines = [...$lines, ...$this->buildAppChannelRules($locales)];
         }
 
         $lines[] = '';
@@ -76,20 +77,29 @@ class RobotsTxtController extends AbstractController
     }
 
     /**
+     * @param list<string> $locales
+     *
      * @return list<string>
      */
-    private function buildContentChannelRules(): array
+    private function buildContentChannelRules(array $locales): array
     {
+        $allow = ['Allow: /'];
+
+        foreach ($locales as $locale) {
+            $allow[] = 'Allow: /'.$locale.'/pages/';
+        }
+
+        foreach ($locales as $locale) {
+            $allow[] = 'Allow: /'.$locale.'/archetypes';
+        }
+
+        // Public-read endpoint for editor-uploaded images (carousel
+        // slides, CMS page banners, OG images). Longest-match wins over
+        // `Disallow: /api/` below, so only this sub-path is crawlable.
+        $allow[] = 'Allow: /api/editor/image/*';
+
         return [
-            'Allow: /',
-            'Allow: /en/pages/',
-            'Allow: /fr/pages/',
-            'Allow: /en/archetypes',
-            'Allow: /fr/archetypes',
-            // Public-read endpoint for editor-uploaded images (carousel
-            // slides, CMS page banners, OG images). Longest-match wins over
-            // `Disallow: /api/` below, so only this sub-path is crawlable.
-            'Allow: /api/editor/image/*',
+            ...$allow,
             '',
             'Disallow: /admin/',
             'Disallow: /api/',
@@ -98,27 +108,39 @@ class RobotsTxtController extends AbstractController
     }
 
     /**
+     * @param list<string> $locales
+     *
      * @return list<string>
      */
-    private function buildAppChannelRules(): array
+    private function buildAppChannelRules(array $locales): array
     {
+        $allow = ['Allow: /'];
+
+        foreach ($locales as $locale) {
+            $allow[] = 'Allow: /'.$locale.'/pages/';
+        }
+
+        $allow[] = 'Allow: /deck/';
+        $allow[] = 'Allow: /event';
+        // Public-read endpoint for editor-uploaded images (carousel
+        // slides, CMS page banners, OG images). Longest-match wins over
+        // `Disallow: /api/` below, so only this sub-path is crawlable.
+        $allow[] = 'Allow: /api/editor/image/*';
+
+        // Archetypes are not served on the app channel; block the unprefixed
+        // redirect target plus every locale-prefixed path the channel exposes.
+        $archetypeDisallow = ['Disallow: /archetypes'];
+        foreach ($locales as $locale) {
+            $archetypeDisallow[] = 'Disallow: /'.$locale.'/archetypes';
+        }
+
         return [
-            'Allow: /',
-            'Allow: /en/pages/',
-            'Allow: /fr/pages/',
-            'Allow: /deck/',
-            'Allow: /event',
-            // Public-read endpoint for editor-uploaded images (carousel
-            // slides, CMS page banners, OG images). Longest-match wins over
-            // `Disallow: /api/` below, so only this sub-path is crawlable.
-            'Allow: /api/editor/image/*',
+            ...$allow,
             '',
             'Disallow: /admin/',
             'Disallow: /api/',
             'Disallow: /build/',
-            'Disallow: /archetypes',
-            'Disallow: /en/archetypes',
-            'Disallow: /fr/archetypes',
+            ...$archetypeDisallow,
             'Disallow: /borrow',
             'Disallow: /borrows',
             'Disallow: /confirm-deletion/',

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -2540,6 +2540,8 @@ PTCG;
             ->setEnableBannedCards(true)
             ->setEnableStaples(true)
             ->setThemeName('expandedtalks')
+            // English-only content for now; add 'fr' once French translations exist (F19.4).
+            ->setLocales(['en'])
             ->setParameters(['brand_name' => 'Expanded Talks']);
 
         $manager->persist($appChannel);

--- a/src/Service/Sitemap/SitemapGenerator.php
+++ b/src/Service/Sitemap/SitemapGenerator.php
@@ -33,9 +33,6 @@ readonly class SitemapGenerator
 {
     private const MAX_ENTRIES_PER_SITEMAP = 50_000;
 
-    /** @var list<string> */
-    private const array SUPPORTED_LOCALES = ['en', 'fr'];
-
     public function __construct(
         private PageRepository $pageRepository,
         private ArchetypeRepository $archetypeRepository,
@@ -121,7 +118,7 @@ readonly class SitemapGenerator
      */
     public function needsIndex(Channel $channel): bool
     {
-        $localeCount = \count(self::SUPPORTED_LOCALES);
+        $localeCount = \count($channel->getLocales());
 
         // Homepage + pages + archetypes are locale-multiplied; decks and events are not
         $count = $localeCount; // homepage entries
@@ -174,7 +171,7 @@ readonly class SitemapGenerator
     {
         $xml = '';
 
-        foreach (self::SUPPORTED_LOCALES as $locale) {
+        foreach ($channel->getLocales() as $locale) {
             $xml .= $this->buildUrlEntry(
                 $this->buildAbsoluteUrl($channel, 'app_home_localized', ['_locale' => $locale]),
                 null,
@@ -192,7 +189,7 @@ readonly class SitemapGenerator
         $xml = '';
 
         foreach ($pages as $page) {
-            foreach (self::SUPPORTED_LOCALES as $locale) {
+            foreach ($channel->getLocales() as $locale) {
                 $xml .= $this->buildUrlEntry(
                     $this->buildAbsoluteUrl($channel, 'app_page_show', ['slug' => $page['slug'], '_locale' => $locale]),
                     $page['updatedAt'] ?? $page['createdAt'],
@@ -211,7 +208,7 @@ readonly class SitemapGenerator
         $xml = '';
 
         foreach ($archetypes as $archetype) {
-            foreach (self::SUPPORTED_LOCALES as $locale) {
+            foreach ($channel->getLocales() as $locale) {
                 $xml .= $this->buildUrlEntry(
                     $this->buildAbsoluteUrl($channel, 'app_archetype_show', ['slug' => $archetype['slug'], '_locale' => $locale]),
                     $archetype['updatedAt'] ?? $archetype['createdAt'],

--- a/templates/_partials/opengraph.html.twig
+++ b/templates/_partials/opengraph.html.twig
@@ -15,12 +15,13 @@
 {% endif %}
 <meta property="og:url" content="{{ og_url }}">
 <meta property="og:type" content="{{ og_type|default('website') }}">
-<meta property="og:locale" content="{{ app.request.locale == 'fr' ? 'fr_FR' : 'en_US' }}">
-{% if app.request.locale == 'fr' %}
-    <meta property="og:locale:alternate" content="en_US">
-{% else %}
-    <meta property="og:locale:alternate" content="fr_FR">
-{% endif %}
+{# og:locale signals derive from the channel's configured locales (F19.4),
+ # so single-locale channels emit no false alternate. #}
+{% set og_locale_map = {en: 'en_US', fr: 'fr_FR'} %}
+<meta property="og:locale" content="{{ og_locale_map[app.request.locale]|default('en_US') }}">
+{% for locale in current_channel().locales|filter(locale => locale != app.request.locale) %}
+    <meta property="og:locale:alternate" content="{{ og_locale_map[locale]|default('en_US') }}">
+{% endfor %}
 <meta property="og:site_name" content="{{ channel_param('brand_name', 'Expanded Decks') }}">
 {% if og_image is defined and og_image %}
     <meta property="og:image" content="{{ channel_absolute_url(og_image) }}">

--- a/tests/Controller/RobotsTxtControllerTest.php
+++ b/tests/Controller/RobotsTxtControllerTest.php
@@ -34,7 +34,8 @@ final class RobotsTxtControllerTest extends TestCase
             ->setDomain('expandeddecks.wip')
             ->setEnableDecks(true)
             ->setEnableEvents(true)
-            ->setEnableArchetypes(false);
+            ->setEnableArchetypes(false)
+            ->setLocales(['en', 'fr']);
 
         $response = $this->invokeController($channel);
 
@@ -61,7 +62,8 @@ final class RobotsTxtControllerTest extends TestCase
             ->setDomain('expandedtalks.wip')
             ->setEnableArchetypes(true)
             ->setEnableDecks(false)
-            ->setEnableEvents(false);
+            ->setEnableEvents(false)
+            ->setLocales(['en', 'fr']);
 
         $response = $this->invokeController($channel);
 
@@ -74,6 +76,44 @@ final class RobotsTxtControllerTest extends TestCase
         self::assertStringNotContainsString('Allow: /event', $body);
         self::assertStringContainsString('Disallow: /admin/', $body);
         self::assertStringContainsString('Sitemap: https://expandedtalks.wip/sitemap.xml', $body);
+    }
+
+    public function testContentChannelWithSingleLocaleOmitsFrenchPaths(): void
+    {
+        $channel = (new Channel())
+            ->setCode('content')
+            ->setDomain('expandedtalks.wip')
+            ->setEnableArchetypes(true)
+            ->setEnableDecks(false)
+            ->setEnableEvents(false)
+            ->setLocales(['en']);
+
+        $body = (string) $this->invokeController($channel)->getContent();
+
+        self::assertStringContainsString('Allow: /en/archetypes', $body);
+        self::assertStringContainsString('Allow: /en/pages/', $body);
+        self::assertStringNotContainsString('/fr/archetypes', $body);
+        self::assertStringNotContainsString('/fr/pages/', $body);
+    }
+
+    public function testAppChannelWithSingleLocaleOmitsFrenchPaths(): void
+    {
+        $channel = (new Channel())
+            ->setCode('app')
+            ->setDomain('expandeddecks.wip')
+            ->setEnableDecks(true)
+            ->setEnableEvents(true)
+            ->setEnableArchetypes(false)
+            ->setLocales(['en']);
+
+        $body = (string) $this->invokeController($channel)->getContent();
+
+        self::assertStringContainsString('Allow: /en/pages/', $body);
+        self::assertStringNotContainsString('/fr/pages/', $body);
+        // Unprefixed archetype redirect target stays blocked; only the en-prefixed path is added.
+        self::assertStringContainsString('Disallow: /archetypes', $body);
+        self::assertStringContainsString('Disallow: /en/archetypes', $body);
+        self::assertStringNotContainsString('Disallow: /fr/archetypes', $body);
     }
 
     public function testCrawlDelayIsPresent(): void

--- a/tests/Service/Sitemap/SitemapGeneratorTest.php
+++ b/tests/Service/Sitemap/SitemapGeneratorTest.php
@@ -40,7 +40,8 @@ final class SitemapGeneratorTest extends TestCase
             ->setEnableRegister(true)
             ->setEnableEvents(true)
             ->setEnableBorrows(true)
-            ->setEnableArchetypes(false);
+            ->setEnableArchetypes(false)
+            ->setLocales(['en', 'fr']);
 
         $this->contentChannel = (new Channel())
             ->setCode('content')
@@ -49,7 +50,8 @@ final class SitemapGeneratorTest extends TestCase
             ->setEnableRegister(false)
             ->setEnableEvents(false)
             ->setEnableBorrows(false)
-            ->setEnableArchetypes(true);
+            ->setEnableArchetypes(true)
+            ->setLocales(['en', 'fr']);
     }
 
     public function testAvailableSectionsForAppChannel(): void
@@ -230,6 +232,38 @@ final class SitemapGeneratorTest extends TestCase
         $urls = $document->getElementsByTagName('url');
         // (homepage + 2 pages + 1 archetype) × 2 locales = 8
         self::assertSame(8, $urls->length);
+    }
+
+    public function testSingleLocaleChannelEmitsOnlyThatLocale(): void
+    {
+        $this->contentChannel->setLocales(['en']);
+
+        $pageRepository = $this->createStub(PageRepository::class);
+        $pageRepository->method('findPublishedForSitemap')->willReturn([
+            ['slug' => 'about', 'updatedAt' => new \DateTimeImmutable('2026-04-01'), 'createdAt' => new \DateTimeImmutable('2026-01-01')],
+        ]);
+
+        $archetypeRepository = $this->createStub(ArchetypeRepository::class);
+        $archetypeRepository->method('findPublishedForSitemap')->willReturn([
+            ['slug' => 'lugia-vstar', 'updatedAt' => null, 'createdAt' => new \DateTimeImmutable('2026-03-15')],
+        ]);
+
+        $generator = $this->createGenerator(
+            pageRepository: $pageRepository,
+            archetypeRepository: $archetypeRepository,
+        );
+
+        $xml = $generator->generateCombined($this->contentChannel);
+
+        self::assertStringContainsString('https://expandedtalks.wip/en/', $xml);
+        self::assertStringContainsString('https://expandedtalks.wip/en/pages/about', $xml);
+        self::assertStringContainsString('https://expandedtalks.wip/en/archetypes/lugia-vstar', $xml);
+        self::assertStringNotContainsString('/fr/', $xml);
+
+        $document = new \DOMDocument();
+        self::assertTrue($document->loadXML($xml));
+        // (homepage + 1 page + 1 archetype) × 1 locale = 3
+        self::assertSame(3, $document->getElementsByTagName('url')->length);
     }
 
     public function testGenerateIndexProducesValidXml(): void


### PR DESCRIPTION
Closes #695 · Audit finding **H1** (`docs/seo_gso_audit.md`)

## Problem

The content channel (dowsingmachine.com) serves **English-only** content, but several signals advertised French as if it existed:

- `/fr/*` URLs returned **byte-identical English** (canonical → `/en/`), yet **42 of 86 sitemap URLs (~50%)** were `/fr/` duplicates.
- `og:locale:alternate` was hardcoded to `fr_FR` regardless of channel.
- robots.txt hardcoded `/fr/` allow/disallow rules.

Canonical tags prevented a duplicate-content penalty, but ~half the crawl budget was wasted and the locale signals contradicted each other. Root cause: `SitemapGenerator` and the OG partial hardcoded `['en','fr']`, ignoring the channel's real `Channel::getLocales()` (which hreflang already honored correctly).

## Change

Drive **all** locale-dependent SEO signals from `Channel::getLocales()`:

- **`SitemapGenerator`** — homepage/page/archetype locale loops + `needsIndex` use the channel's locales (removed the hardcoded `SUPPORTED_LOCALES`).
- **`_partials/opengraph.html.twig`** — `og:locale:alternate` iterates the channel's *other* locales (none on a single-locale channel).
- **`RobotsTxtController`** — locale-prefixed allow/disallow lines derived per channel.
- **`DevFixtures`** — content channel made explicitly English-only (`setLocales(['en'])`), documenting intent.

Net effect: a single-locale channel emits only its own locale (content-channel sitemap drops ~50% to canonical-only URLs); adding `'fr'` to the channel later — **no code change** — reactivates every French signal. `hreflang` and the locale switcher already keyed off `Channel::getLocales()`, so they're unchanged.

## Tests

- `make phpstan` → No errors
- 25/25 sitemap + robots controller/service tests pass, including **new single-locale coverage** (`testSingleLocaleChannelEmitsOnlyThatLocale`, `testContentChannelWithSingleLocaleOmitsFrenchPaths`, `testAppChannelWithSingleLocaleOmitsFrenchPaths`).
- `lint:twig` clean.

## Decision recorded

Did **not** add a `/fr → /en` 301 on single-locale channels: the canonical already consolidates the duplicates, and a hard redirect would have to be removed once French is enabled. Removing the false advertisement (sitemap/OG/robots) is the high-value part.