### PR TITLE
:sparkles: Feature: content authorship model + attribution (F19.8, PR 1/2)

### DIFF
--- a/migrations/Version20260620214220.php
+++ b/migrations/Version20260620214220.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * F19.8 — Author/translator attribution.
+ *
+ * Adds the public author/contributor profile columns to `user`, plus
+ * nullable author FKs on archetype, deck, and page, and translator FKs on
+ * the archetype/page translation rows. All content FKs ON DELETE SET NULL so
+ * removing a user never deletes content.
+ */
+final class Version20260620214220 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'F19.8: author/translator attribution fields on user, archetype, deck, page, and translations';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE archetype ADD author_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE archetype ADD CONSTRAINT FK_E1D5BCE3F675F31B FOREIGN KEY (author_id) REFERENCES `user` (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_E1D5BCE3F675F31B ON archetype (author_id)');
+        $this->addSql('ALTER TABLE archetype_translation ADD translator_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE archetype_translation ADD CONSTRAINT FK_143B1B685370E40B FOREIGN KEY (translator_id) REFERENCES `user` (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_143B1B685370E40B ON archetype_translation (translator_id)');
+        $this->addSql('ALTER TABLE deck ADD author_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE deck ADD CONSTRAINT FK_4FAC3637F675F31B FOREIGN KEY (author_id) REFERENCES `user` (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_4FAC3637F675F31B ON deck (author_id)');
+        $this->addSql('ALTER TABLE page ADD author_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE page ADD CONSTRAINT FK_140AB620F675F31B FOREIGN KEY (author_id) REFERENCES `user` (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_140AB620F675F31B ON page (author_id)');
+        $this->addSql('ALTER TABLE page_translation ADD translator_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE page_translation ADD CONSTRAINT FK_A3D51B1D5370E40B FOREIGN KEY (translator_id) REFERENCES `user` (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_A3D51B1D5370E40B ON page_translation (translator_id)');
+        $this->addSql('ALTER TABLE `user` ADD is_public_author TINYINT DEFAULT 0 NOT NULL, ADD credential VARCHAR(150) DEFAULT NULL, ADD bio LONGTEXT DEFAULT NULL, ADD same_as JSON DEFAULT NULL, ADD avatar_url VARCHAR(255) DEFAULT NULL, ADD primary_url VARCHAR(255) DEFAULT NULL, ADD public_slug VARCHAR(100) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649E3C0D9B3 ON `user` (public_slug)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE archetype DROP FOREIGN KEY FK_E1D5BCE3F675F31B');
+        $this->addSql('DROP INDEX IDX_E1D5BCE3F675F31B ON archetype');
+        $this->addSql('ALTER TABLE archetype DROP author_id');
+        $this->addSql('ALTER TABLE archetype_translation DROP FOREIGN KEY FK_143B1B685370E40B');
+        $this->addSql('DROP INDEX IDX_143B1B685370E40B ON archetype_translation');
+        $this->addSql('ALTER TABLE archetype_translation DROP translator_id');
+        $this->addSql('ALTER TABLE deck DROP FOREIGN KEY FK_4FAC3637F675F31B');
+        $this->addSql('DROP INDEX IDX_4FAC3637F675F31B ON deck');
+        $this->addSql('ALTER TABLE deck DROP author_id');
+        $this->addSql('ALTER TABLE page DROP FOREIGN KEY FK_140AB620F675F31B');
+        $this->addSql('DROP INDEX IDX_140AB620F675F31B ON page');
+        $this->addSql('ALTER TABLE page DROP author_id');
+        $this->addSql('ALTER TABLE page_translation DROP FOREIGN KEY FK_A3D51B1D5370E40B');
+        $this->addSql('DROP INDEX IDX_A3D51B1D5370E40B ON page_translation');
+        $this->addSql('ALTER TABLE page_translation DROP translator_id');
+        $this->addSql('DROP INDEX UNIQ_8D93D649E3C0D9B3 ON `user`');
+        $this->addSql('ALTER TABLE `user` DROP is_public_author, DROP credential, DROP bio, DROP same_as, DROP avatar_url, DROP primary_url, DROP public_slug');
+    }
+}

--- a/migrations/Version20260620220009.php
+++ b/migrations/Version20260620220009.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * F19.8 — Backfill author attribution for pre-existing content.
+ *
+ * Attributes existing, unattributed editorial content by the channel it
+ * belongs to:
+ *  - expandeddecks.app pages -> the "Sylf" user (the app/tool developer);
+ *  - all other content (archetypes, archetype variants, content-channel
+ *    pages) -> the "Luby" user (the content writer).
+ *
+ * Each target is resolved by screen name via a subquery; when the user does
+ * not exist the subquery yields NULL and the row is left unattributed
+ * (a no-op, since only NULL authors are touched). Idempotent and data-only.
+ */
+final class Version20260620220009 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'F19.8: backfill author attribution for existing content (content->Luby, expandeddecks.app->Sylf)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Archetypes live on the content channel -> Luby.
+        $this->addSql("UPDATE archetype SET author_id = (SELECT id FROM `user` WHERE screen_name = 'Luby' LIMIT 1) WHERE author_id IS NULL");
+
+        // Archetype variants (owner-less editorial decklists) -> Luby.
+        $this->addSql("UPDATE deck SET author_id = (SELECT id FROM `user` WHERE screen_name = 'Luby' LIMIT 1) WHERE author_id IS NULL AND owner_id IS NULL AND archetype_id IS NOT NULL");
+
+        // Pages on the app channel -> Sylf.
+        $this->addSql("UPDATE page p JOIN channel c ON p.channel_id = c.id SET p.author_id = (SELECT id FROM `user` WHERE screen_name = 'Sylf' LIMIT 1) WHERE p.author_id IS NULL AND c.domain = 'expandeddecks.app'");
+
+        // Pages on any other channel -> Luby.
+        $this->addSql("UPDATE page p JOIN channel c ON p.channel_id = c.id SET p.author_id = (SELECT id FROM `user` WHERE screen_name = 'Luby' LIMIT 1) WHERE p.author_id IS NULL AND c.domain <> 'expandeddecks.app'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Data backfill: not reversed (clearing author_id would also discard
+        // attributions set legitimately after this migration ran).
+    }
+}

--- a/src/DataFixtures/DevFixtures.php
+++ b/src/DataFixtures/DevFixtures.php
@@ -49,6 +49,13 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class DevFixtures extends Fixture
 {
+    /**
+     * Editorial content author for fixtures — the "Editor" user. Mirrors the
+     * production backfill (content attributed to its writer) so dev shows real
+     * bylines (F19.8).
+     */
+    private ?User $contentAuthor = null;
+
     public function __construct(
         private readonly UserPasswordHasherInterface $passwordHasher,
         private readonly DeckListParser $deckListParser,
@@ -65,7 +72,7 @@ class DevFixtures extends Fixture
         $staff1 = $this->createStaff1($manager);
         $staff2 = $this->createStaff2($manager);
         $lender = $this->createLender($manager);
-        $this->createEditor($manager);
+        $this->contentAuthor = $this->createEditor($manager);
         $this->createUnverifiedUser($manager);
         $todayEvent = $this->createEventToday($manager, $admin, $borrower, $staff1);
         $futureEvent = $this->createEventInTwoMonths($manager, $admin, $lender, $staff1, $staff2);
@@ -604,6 +611,8 @@ MARKDOWN;
             $this->backdatePublication($archetype, $firstPublishedAt, $lastPublishedAt);
         }
 
+        $archetype->setAuthor($this->contentAuthor);
+
         $manager->persist($archetype);
 
         return $archetype;
@@ -759,6 +768,10 @@ MARKDOWN);
         $third->setPokemonSlugs(['dragapult']);
         $third->setNotes('A lightweight Regidrago build focused on speed.');
         $manager->persist($third);
+
+        foreach ([$canonical, $alternate, $third] as $variant) {
+            $variant->setAuthor($this->contentAuthor);
+        }
     }
 
     /**
@@ -2157,6 +2170,15 @@ MD);
         MD);
         $legalNoticePage->addTranslation($legalNoticeFr);
         $manager->persist($legalNoticeFr);
+
+        // Attribute every fixture page to the content author (F19.8) — dev's
+        // analogue of the production backfill.
+        foreach ([
+            $welcomePage, $news1, $news2, $news3, $news4, $news5, $news6, $news7, $news8,
+            $rulesPage, $draftPage, $philosophyPage, $teamPage, $legalNoticePage,
+        ] as $page) {
+            $page->setAuthor($this->contentAuthor);
+        }
     }
 
     private function createCharizardFlareonDeckVersion(ObjectManager $manager, Deck $deck): void

--- a/src/Entity/Archetype.php
+++ b/src/Entity/Archetype.php
@@ -94,6 +94,13 @@ class Archetype
     #[ORM\OneToMany(targetEntity: ArchetypeTranslation::class, mappedBy: 'archetype', cascade: ['persist', 'remove'], orphanRemoval: true)]
     private Collection $translations;
 
+    /**
+     * Public author credit for this archetype's analysis (F19.8).
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?User $author = null;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
@@ -103,6 +110,18 @@ class Archetype
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?User $author): static
+    {
+        $this->author = $author;
+
+        return $this;
     }
 
     public function getName(): string

--- a/src/Entity/ArchetypeTranslation.php
+++ b/src/Entity/ArchetypeTranslation.php
@@ -66,6 +66,15 @@ class ArchetypeTranslation
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $ogDescription = null;
 
+    /**
+     * Public translator credit for this locale (F19.8). Forward-compatible
+     * with the #612 translation-role epic, which will add workflow state and
+     * source-version tracking on the same row.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?User $translator = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -163,6 +172,18 @@ class ArchetypeTranslation
     public function setOgDescription(?string $ogDescription): static
     {
         $this->ogDescription = $ogDescription;
+
+        return $this;
+    }
+
+    public function getTranslator(): ?User
+    {
+        return $this->translator;
+    }
+
+    public function setTranslator(?User $translator): static
+    {
+        $this->translator = $translator;
 
         return $this;
     }

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -71,6 +71,14 @@ class Deck
     private ?Archetype $archetype = null;
 
     /**
+     * Public author credit for archetype-variant decklists (F19.8).
+     * Owner-owned decks use {@see getOwner()} as their author instead.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?User $author = null;
+
+    /**
      * The latest expansion set that defines the format boundary for this deck.
      * E.g. SV08 means the deck is built with cards up to and including SV08.
      *
@@ -217,6 +225,27 @@ class Deck
         $this->owner = $owner;
 
         return $this;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?User $author): static
+    {
+        $this->author = $author;
+
+        return $this;
+    }
+
+    /**
+     * Resolve the public author of this deck: the editorial author for an
+     * archetype variant, otherwise the owner (F19.8).
+     */
+    public function resolveAuthor(): ?User
+    {
+        return $this->author ?? $this->owner;
     }
 
     /**

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -79,6 +79,13 @@ class Page
     #[ORM\OneToMany(targetEntity: PageTranslation::class, mappedBy: 'page', cascade: ['persist', 'remove'], orphanRemoval: true)]
     private Collection $translations;
 
+    /**
+     * Public author credit for this page (F19.8).
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?User $author = null;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
@@ -88,6 +95,18 @@ class Page
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?User $author): static
+    {
+        $this->author = $author;
+
+        return $this;
     }
 
     public function getSlug(): string

--- a/src/Entity/PageTranslation.php
+++ b/src/Entity/PageTranslation.php
@@ -62,6 +62,15 @@ class PageTranslation
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $ogDescription = null;
 
+    /**
+     * Public translator credit for this locale (F19.8). Forward-compatible
+     * with the #612 translation-role epic, which will add workflow state and
+     * source-version tracking on the same row.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?User $translator = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -147,6 +156,18 @@ class PageTranslation
     public function setOgDescription(?string $ogDescription): static
     {
         $this->ogDescription = $ogDescription;
+
+        return $this;
+    }
+
+    public function getTranslator(): ?User
+    {
+        return $this->translator;
+    }
+
+    public function setTranslator(?User $translator): static
+    {
+        $this->translator = $translator;
 
         return $this;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -135,6 +135,45 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(options: ['default' => false])]
     private bool $showCardmarketExport = false;
 
+    /*
+     * Public author/contributor profile (F19.8).
+     *
+     * These fields surface publicly ONLY when the user is credited as the
+     * author or translator of published content. They MUST NOT expose login
+     * or legal-identity fields (email, firstName, lastName); the public byline
+     * uses screenName. See App\Service\Seo\StructuredDataBuilder::buildPerson().
+     */
+    #[ORM\Column(options: ['default' => false])]
+    private bool $isPublicAuthor = false;
+
+    #[ORM\Column(length: 150, nullable: true)]
+    #[Assert\Length(max: 150)]
+    private ?string $credential = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    #[Assert\Length(max: 2000)]
+    private ?string $bio = null;
+
+    /** @var list<string>|null */
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    #[Assert\All([new Assert\Url(), new Assert\Length(max: 255)])]
+    private ?array $sameAs = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    #[Assert\Url]
+    #[Assert\Length(max: 255)]
+    private ?string $avatarUrl = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    #[Assert\Url]
+    #[Assert\Length(max: 255)]
+    private ?string $primaryUrl = null;
+
+    #[ORM\Column(length: 100, unique: true, nullable: true)]
+    #[Assert\Length(max: 100)]
+    #[Assert\Regex(pattern: '/^[a-z0-9-]+$/', message: 'Invalid public slug format.')]
+    private ?string $publicSlug = null;
+
     /**
      * @see docs/features.md F3.14 — iCal agenda feed
      */
@@ -254,6 +293,97 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setYearOfBirth(?int $yearOfBirth): static
     {
         $this->yearOfBirth = $yearOfBirth;
+
+        return $this;
+    }
+
+    public function isPublicAuthor(): bool
+    {
+        return $this->isPublicAuthor;
+    }
+
+    public function setIsPublicAuthor(bool $isPublicAuthor): static
+    {
+        $this->isPublicAuthor = $isPublicAuthor;
+
+        return $this;
+    }
+
+    public function getCredential(): ?string
+    {
+        return $this->credential;
+    }
+
+    public function setCredential(?string $credential): static
+    {
+        $this->credential = $credential;
+
+        return $this;
+    }
+
+    public function getBio(): ?string
+    {
+        return $this->bio;
+    }
+
+    public function setBio(?string $bio): static
+    {
+        $this->bio = $bio;
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSameAs(): array
+    {
+        return $this->sameAs ?? [];
+    }
+
+    /**
+     * @param list<string>|null $sameAs
+     */
+    public function setSameAs(?array $sameAs): static
+    {
+        // Drop empty entries so a trailing blank line in the form never yields "".
+        $this->sameAs = null === $sameAs ? null : array_values(array_filter($sameAs, static fn (string $url): bool => '' !== trim($url)));
+
+        return $this;
+    }
+
+    public function getAvatarUrl(): ?string
+    {
+        return $this->avatarUrl;
+    }
+
+    public function setAvatarUrl(?string $avatarUrl): static
+    {
+        $this->avatarUrl = $avatarUrl;
+
+        return $this;
+    }
+
+    public function getPrimaryUrl(): ?string
+    {
+        return $this->primaryUrl;
+    }
+
+    public function setPrimaryUrl(?string $primaryUrl): static
+    {
+        $this->primaryUrl = $primaryUrl;
+
+        return $this;
+    }
+
+    public function getPublicSlug(): ?string
+    {
+        return $this->publicSlug;
+    }
+
+    public function setPublicSlug(?string $publicSlug): static
+    {
+        $this->publicSlug = $publicSlug;
 
         return $this;
     }
@@ -475,6 +605,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->deletionTokenExpiresAt = null;
         $this->notificationPreferences = null;
         $this->calendarToken = null;
+        // Clear the public author/contributor profile (F19.8) so no public
+        // identity data survives anonymization.
+        $this->isPublicAuthor = false;
+        $this->credential = null;
+        $this->bio = null;
+        $this->sameAs = null;
+        $this->avatarUrl = null;
+        $this->primaryUrl = null;
+        $this->publicSlug = null;
     }
 
     public function isAnonymized(): bool

--- a/src/EventListener/ContentAuthorListener.php
+++ b/src/EventListener/ContentAuthorListener.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\EventListener;
+
+use App\Entity\Archetype;
+use App\Entity\Deck;
+use App\Entity\Page;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Stamps editorial content with its creator at creation time (F19.8).
+ *
+ * Runs on `prePersist` only, so a later editor — including an admin — never
+ * acquires authorship merely by saving an edit. Skips when there is no
+ * authenticated user (CLI, fixtures, anonymous requests), leaving the author
+ * null, and never overwrites an author that is already set.
+ *
+ * Archetype variants (owner-less editorial decklists) are stamped; user-owned
+ * decks are not, as those are authored by their owner.
+ *
+ * @see docs/features.md F19.8 — Author assignment
+ */
+#[AsDoctrineListener(event: Events::prePersist)]
+final readonly class ContentAuthorListener
+{
+    public function __construct(
+        private Security $security,
+    ) {
+    }
+
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof Archetype && !$entity instanceof Page && !$entity instanceof Deck) {
+            return;
+        }
+
+        // User-owned decks are authored by their owner, not the creator.
+        if ($entity instanceof Deck && !$entity->isArchetypeVariant()) {
+            return;
+        }
+
+        if (null !== $entity->getAuthor()) {
+            return;
+        }
+
+        $user = $this->security->getUser();
+        if ($user instanceof User) {
+            $entity->setAuthor($user);
+        }
+    }
+}

--- a/src/Service/Seo/StructuredDataBuilder.php
+++ b/src/Service/Seo/StructuredDataBuilder.php
@@ -18,6 +18,7 @@ use App\Entity\Deck;
 use App\Entity\Event;
 use App\Entity\Page;
 use App\Entity\PageTranslation;
+use App\Entity\User;
 use App\Service\Channel\ChannelContext;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -80,6 +81,16 @@ final readonly class StructuredDataBuilder
             $data['datePublished'] = $published->format('c');
         }
 
+        $author = $page->getAuthor();
+        if ($author instanceof User) {
+            $data['author'] = $this->buildPerson($author);
+        }
+
+        $translator = $translation->getTranslator();
+        if ($translator instanceof User) {
+            $data['translator'] = $this->buildPerson($translator);
+        }
+
         return $data;
     }
 
@@ -94,6 +105,7 @@ final readonly class StructuredDataBuilder
     {
         $archetypeName = $archetype->getLocalizedName($locale);
         $genre = $this->translator->trans('app.seo.tcg_genre', locale: $locale);
+        $author = $archetype->getAuthor();
 
         $data = [
             '@context' => 'https://schema.org',
@@ -106,9 +118,14 @@ final readonly class StructuredDataBuilder
                 '@type' => 'Game',
                 'name' => $this->translator->trans('app.seo.tcg_game_name', locale: $locale),
             ],
-            'author' => $this->buildOrganization(),
+            'author' => $author instanceof User ? $this->buildPerson($author) : $this->buildOrganization(),
             'publisher' => $this->buildOrganization(),
         ];
+
+        $translator = $archetype->getTranslation($locale)?->getTranslator();
+        if ($translator instanceof User) {
+            $data['translator'] = $this->buildPerson($translator);
+        }
 
         $published = $archetype->getFirstPublishedAt() ?? $archetype->getCreatedAt();
         $modified = $archetype->getLastPublishedAt() ?? $archetype->getUpdatedAt() ?? $published;
@@ -194,11 +211,9 @@ final readonly class StructuredDataBuilder
             'dateCreated' => $deck->getCreatedAt()->format('c'),
         ];
 
-        if (null !== $deck->getOwner()) {
-            $data['author'] = [
-                '@type' => 'Person',
-                'name' => $deck->getOwner()->getScreenName(),
-            ];
+        $author = $deck->resolveAuthor();
+        if ($author instanceof User) {
+            $data['author'] = $this->buildPerson($author);
         }
 
         $lastModified = $deck->getUpdatedAt() ?? $deck->getCreatedAt();
@@ -254,14 +269,76 @@ final readonly class StructuredDataBuilder
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, mixed>
      */
     private function buildOrganization(): array
     {
-        return [
+        $channel = $this->channelContext->getChannel();
+
+        $organization = [
             '@type' => 'Organization',
             'name' => $this->getBrandName(),
             'url' => $this->getOrganizationUrl(),
         ];
+
+        $logo = $channel->getParameter('org_logo');
+        if ('' !== $logo) {
+            $organization['logo'] = [
+                '@type' => 'ImageObject',
+                'url' => str_starts_with($logo, 'http') ? $logo : $this->getOrganizationUrl().$logo,
+            ];
+        }
+
+        // org_same_as is a whitespace/comma-separated list of public profile URLs.
+        $sameAsRaw = $channel->getParameter('org_same_as');
+        if ('' !== $sameAsRaw) {
+            $sameAs = array_values(array_filter(
+                array_map(trim(...), preg_split('/[\s,]+/', $sameAsRaw) ?: []),
+                static fn (string $url): bool => '' !== $url,
+            ));
+            if ([] !== $sameAs) {
+                $organization['sameAs'] = $sameAs;
+            }
+        }
+
+        return $organization;
+    }
+
+    /**
+     * Build a schema.org Person from a user, exposing ONLY curated public
+     * fields. It MUST NOT emit email, first name, or last name; the public
+     * identity is the chosen screen name (F19.8).
+     *
+     * @return array<string, mixed>
+     */
+    private function buildPerson(User $user): array
+    {
+        $person = [
+            '@type' => 'Person',
+            'name' => $user->getScreenName(),
+        ];
+
+        // Rich profile signals are exposed only for opted-in public authors.
+        if (!$user->isPublicAuthor()) {
+            return $person;
+        }
+
+        if (null !== $user->getPrimaryUrl()) {
+            $person['url'] = $user->getPrimaryUrl();
+        }
+
+        if (null !== $user->getCredential()) {
+            $person['description'] = $user->getCredential();
+        }
+
+        if (null !== $user->getAvatarUrl()) {
+            $person['image'] = $user->getAvatarUrl();
+        }
+
+        if ([] !== $user->getSameAs()) {
+            $person['sameAs'] = $user->getSameAs();
+        }
+
+        return $person;
     }
 }

--- a/tests/EventListener/ContentAuthorListenerTest.php
+++ b/tests/EventListener/ContentAuthorListenerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\EventListener;
+
+use App\Entity\Archetype;
+use App\Entity\Deck;
+use App\Entity\Page;
+use App\Entity\User;
+use App\EventListener\ContentAuthorListener;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @see docs/features.md F19.8 — Author assignment
+ */
+final class ContentAuthorListenerTest extends TestCase
+{
+    public function testStampsNewArchetypeWithCurrentUser(): void
+    {
+        $user = new User();
+        $archetype = new Archetype();
+
+        $this->listenerFor($user)->prePersist($this->prePersistArgs($archetype));
+
+        self::assertSame($user, $archetype->getAuthor());
+    }
+
+    public function testStampsNewPageWithCurrentUser(): void
+    {
+        $user = new User();
+        $page = new Page();
+
+        $this->listenerFor($user)->prePersist($this->prePersistArgs($page));
+
+        self::assertSame($user, $page->getAuthor());
+    }
+
+    public function testStampsArchetypeVariantDeck(): void
+    {
+        $user = new User();
+        $variant = (new Deck())->setArchetype(new Archetype()); // owner stays null => variant
+
+        $this->listenerFor($user)->prePersist($this->prePersistArgs($variant));
+
+        self::assertSame($user, $variant->getAuthor());
+    }
+
+    public function testIgnoresOwnerOwnedDeck(): void
+    {
+        $user = new User();
+        $ownedDeck = (new Deck())->setOwner(new User());
+
+        $this->listenerFor($user)->prePersist($this->prePersistArgs($ownedDeck));
+
+        self::assertNull($ownedDeck->getAuthor());
+    }
+
+    public function testDoesNotOverwriteExistingAuthor(): void
+    {
+        $original = new User();
+        $archetype = (new Archetype())->setAuthor($original);
+
+        // A different "current user" (e.g. an admin editing) must not take over.
+        $this->listenerFor(new User())->prePersist($this->prePersistArgs($archetype));
+
+        self::assertSame($original, $archetype->getAuthor());
+    }
+
+    public function testSkipsWhenNoAuthenticatedUser(): void
+    {
+        $archetype = new Archetype();
+
+        $this->listenerFor(null)->prePersist($this->prePersistArgs($archetype));
+
+        self::assertNull($archetype->getAuthor());
+    }
+
+    private function listenerFor(?User $user): ContentAuthorListener
+    {
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        return new ContentAuthorListener($security);
+    }
+
+    private function prePersistArgs(object $entity): PrePersistEventArgs
+    {
+        return new PrePersistEventArgs($entity, $this->createStub(EntityManagerInterface::class));
+    }
+}


### PR DESCRIPTION
Part 1 of 2 for **F19.8 — machine-readable authorship** (#699, audit finding M1). This PR lands the **data model + attribution**; a follow-up PR adds the visible byline, RSS `dc:creator`, the profile/admin editing forms, and rendering tests.

## What's in this PR

### Data model
- **`User`** gains an opt-in public author/contributor profile: `isPublicAuthor`, `credential`, `bio`, `sameAs`, `avatarUrl`, `primaryUrl`, `publicSlug` — **cleared on GDPR anonymization**.
- Nullable **`author`** FK on `Archetype`, `Page`, and archetype-variant `Deck`; nullable **`translator`** FK on `ArchetypeTranslation`/`PageTranslation` (`ON DELETE SET NULL`). The translator FKs are deliberate groundwork for the #612 translation epic.

### Email-safe machine-readable output
- `StructuredDataBuilder` routes **all** authorship through one `buildPerson(User)` seam that exposes only curated public fields — **never `email`/`firstName`/`lastName`**. `Article`/`WebPage` emit a `Person` author (+ per-locale `translator`); `Organization` publisher gains `logo`+`sameAs` from channel params; `CreativeWork` uses `Deck::resolveAuthor()`.

### Attribution
- **`ContentAuthorListener`** stamps content with its **creator** on `prePersist` only — a later editor (including an admin) never acquires authorship by saving an edit; user-owned decks keep their owner; skips when unauthenticated.
- **Backfill migration** for existing content, by channel: content-channel archetypes/variants/pages → **Luby** (the writer); `expandeddecks.app` pages → **Sylf** (the developer). Resolved by screen name; unattributed if the user is absent.
- **Dev fixtures** attribute archetypes, variants, and pages to the `Editor` fixture user.

## Verification
- `make phpstan` clean; unit suite green (1417); `ContentAuthorListener` unit-tested (6 cases).
- Fixtures load (drop+recreate) attributes **8/8 archetypes, 3 variants, 14 pages, 0 owner-owned decks**.
- Schema migration was hand-trimmed to F19.8 changes only (the diff had swept in unrelated pre-existing schema drift — see commit notes).

## Deliberately deferred to PR 2/2
Visible byline (archetype/page), RSS `dc:creator`/`dc:contributor`, the profile + admin editing forms (with help text), seeding the public-author profile (credential/sameAs) + org logo/sameAs params, JSON-LD render tests (incl. the email-never-leaks assertion), and the `docs/features.md` / audit-doc updates.

## Note
A pre-existing schema-drift cleanup migration is **not** included here (kept this PR focused); flagged for a separate chore.