### PR TITLE
:wrench: Config: sync entity mappings to the live schema (zero drift)

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -2,12 +2,6 @@ doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
 
-        # Framework-managed tables (Symfony Messenger transport + PDO session
-        # handler) are owned by their bundles, not the ORM mappings. Excluding
-        # them from schema management keeps them out of schema:validate/diff
-        # drift reports.
-        schema_filter: '~^(?!messenger_messages|sessions)~'
-
         profiling_collect_backtrace: '%kernel.debug%'
     orm:
         validate_xml_mapping: true

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -2,6 +2,12 @@ doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
 
+        # Framework-managed tables (Symfony Messenger transport + PDO session
+        # handler) are owned by their bundles, not the ORM mappings. Excluding
+        # them from schema management keeps them out of schema:validate/diff
+        # drift reports.
+        schema_filter: '~^(?!messenger_messages|sessions)~'
+
         profiling_collect_backtrace: '%kernel.debug%'
     orm:
         validate_xml_mapping: true

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -67,6 +67,7 @@
 - [TCGdex Incremental Sync](technicalities/tcgdex_sync.md) — API-based sync cascade, rate limiting, sync modes, webhook trigger
 - [Error Pages](technicalities/error_pages.md) — Custom error pages, Pokemon sprites, CDN integration, Sentry
 - [OG Image Builder](technicalities/og_image_builder.md) — Card-fan social-preview compositor, code resolution, RSS feed images
+- [Schema Drift](technicalities/schema_drift.md) — Known cosmetic residual between entity mappings and the live schema, and how to handle it when generating migrations
 
 ## Planning
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -67,7 +67,7 @@
 - [TCGdex Incremental Sync](technicalities/tcgdex_sync.md) — API-based sync cascade, rate limiting, sync modes, webhook trigger
 - [Error Pages](technicalities/error_pages.md) — Custom error pages, Pokemon sprites, CDN integration, Sentry
 - [OG Image Builder](technicalities/og_image_builder.md) — Card-fan social-preview compositor, code resolution, RSS feed images
-- [Schema Drift](technicalities/schema_drift.md) — Known cosmetic residual between entity mappings and the live schema, and how to handle it when generating migrations
+- [Schema Sync](technicalities/schema_drift.md) — How entity mappings are kept in sync with the live schema (defaults, schema_filter, drift-normalization migration)
 
 ## Planning
 

--- a/docs/technicalities/schema_drift.md
+++ b/docs/technicalities/schema_drift.md
@@ -14,18 +14,24 @@ doesn't creep back in.
 ## How the drift was reconciled
 
 Drift had accumulated from old hand-written migrations and dependency upgrades. It was
-cleared in three ways, by category:
+cleared two ways, by category:
 
 1. **Column defaults/types** → declared on the entity mappings (e.g. `options: ['default' => …]`
    on booleans, `deck.format`, `deck_card.card_locale`, `card_identity.*`, and the
    `homepage_layout_translation.og_description` `TEXT` length).
-2. **Framework-managed tables** (`messenger_messages`, `sessions`) → excluded from ORM
-   schema management via `dbal.schema_filter` in `config/packages/doctrine.yaml`. They are
-   owned by the Messenger transport / PDO session handler and managed by those bundles, not
-   by our mappings — so we never diff or migrate them here.
-3. **Legacy index/FK names + obsolete `(DC2Type:datetime_immutable)` comments** → normalized
-   to Doctrine's current conventions by a one-time, metadata-only migration
-   (`Version20260621081335`). RENAME INDEX / comment changes are instant in MySQL 8.
+2. **Legacy index/FK names, obsolete `(DC2Type:datetime_immutable)` comments, and the
+   framework tables' (`messenger_messages`, `sessions`) older index/column layout** → normalized
+   to current conventions by a one-time, metadata-only migration (`Version20260621081335`).
+   `RENAME INDEX` / comment / index-swap operations are instant in MySQL 8.
+
+### Why the migration is guarded
+
+This drift only exists on the **production-evolved** schema. A freshly built schema
+(`SchemaTool::createSchema` used by functional tests, or migrate-from-zero) already uses
+current conventions, so the migration **skips itself** there via `skipIf` (keyed on a legacy
+index name). It only acts on the legacy production schema. This is also why the framework
+tables must **not** be excluded with `dbal.schema_filter` — that would stop `createSchema`
+from building `messenger_messages`, breaking the test environment.
 
 ## Keeping it clean
 
@@ -33,4 +39,3 @@ cleared in three ways, by category:
   diff should contain **only your intended change**. If it shows index renames, comment
   removals, or `messenger_messages`/`sessions`, something regressed — investigate rather
   than committing the noise.
-- New framework tables (future bundles) may need to be added to the `schema_filter` regex.

--- a/docs/technicalities/schema_drift.md
+++ b/docs/technicalities/schema_drift.md
@@ -1,4 +1,4 @@
-# Schema Drift (known residual)
+# Schema Sync
 
 > **Audience:** Developer, AI Agent · **Scope:** Technical Deep-Dive
 
@@ -6,49 +6,31 @@
 
 ---
 
-The local DB is kept in sync with **production** (prod is the source of truth for
-schema). `doctrine:schema:validate` reports the **mapping as correct**, but the
-DB-sync check still lists a small, **known, accepted residual** of *cosmetic* drift.
-None of it is semantic — no data, types, nullability, or defaults are affected.
+The local DB is kept in sync with **production** (prod is the source of truth for schema),
+and `doctrine:schema:validate` is **fully in sync** — both the mapping and the DB-sync
+checks report OK. This page records how a batch of long-standing drift was cleared so it
+doesn't creep back in.
 
-This page exists so the residual is not mistaken for real changes when generating
-migrations.
+## How the drift was reconciled
 
-## What was reconciled
+Drift had accumulated from old hand-written migrations and dependency upgrades. It was
+cleared in three ways, by category:
 
-- **Column defaults/types** → fixed in the entity mappings (e.g. `options: ['default' => …]`
-  on booleans, `deck.format`, `deck_card.card_locale`, `card_identity.*`, and the
-  `homepage_layout_translation.og_description` `TEXT` length). These no longer drift.
-- **Framework tables** (`messenger_messages`, `sessions`) → excluded from ORM schema
-  management via `dbal.schema_filter` in `config/packages/doctrine.yaml`. They are owned
-  by the Messenger transport / PDO session handler, not our mappings.
+1. **Column defaults/types** → declared on the entity mappings (e.g. `options: ['default' => …]`
+   on booleans, `deck.format`, `deck_card.card_locale`, `card_identity.*`, and the
+   `homepage_layout_translation.og_description` `TEXT` length).
+2. **Framework-managed tables** (`messenger_messages`, `sessions`) → excluded from ORM
+   schema management via `dbal.schema_filter` in `config/packages/doctrine.yaml`. They are
+   owned by the Messenger transport / PDO session handler and managed by those bundles, not
+   by our mappings — so we never diff or migrate them here.
+3. **Legacy index/FK names + obsolete `(DC2Type:datetime_immutable)` comments** → normalized
+   to Doctrine's current conventions by a one-time, metadata-only migration
+   (`Version20260621081335`). RENAME INDEX / comment changes are instant in MySQL 8.
 
-## Accepted residual (cosmetic only)
+## Keeping it clean
 
-These keep appearing in `doctrine:schema:update --dump-sql` and will reappear in any
-generated migration. They are intentionally **not** reconciled (it would mean either
-pinning legacy identifier names into mappings, or an `ALTER` migration on prod for zero
-functional gain):
-
-- **Legacy index / FK / unique-constraint names** — old migrations named these explicitly
-  (e.g. `uniq_event_tag_name`, `fk_banned_card_representative_printing`,
-  `idx_event_pending_transfer_to`); Doctrine now derives hash names. FK *constraint* names
-  cannot be set via attributes anyway. Tables: `event`, `event_event_tag`, `event_tag`,
-  `user` (calendar token), `banned_card`, `banned_card_printing`.
-- **`(DC2Type:datetime_immutable)` column comments** — DBAL 4 dropped comment-based type
-  tracking; the live columns still carry the old comment. There is no mapping switch to
-  keep it. Columns: `event.pending_transfer_requested_at`, `banned_card.{effective_date,
-  deleted_at,created_at}`, `event_tag.created_at`, `tcgdex_card.tcgdex_updated_at`.
-- One extra DB index, `banned_card.IDX_banned_card_deleted_at`, not declared in the mapping.
-
-## How to handle when generating a migration
-
-`doctrine:migrations:diff` will include the residual lines above. **Strip them** from the
-generated migration and keep only your intended change (this is what the F19.8 migration
-did). Cross-check against this list.
-
-## Eliminating it (deferred)
-
-A one-shot normalization migration could rename the indexes to Doctrine's convention and
-drop the stale comments, clearing the residual for good. Deferred by decision (it would
-`ALTER` prod for cosmetic-only gain); revisit if the residual becomes noisy.
+- After changing an entity, generate the migration with `doctrine:migrations:diff` and the
+  diff should contain **only your intended change**. If it shows index renames, comment
+  removals, or `messenger_messages`/`sessions`, something regressed — investigate rather
+  than committing the noise.
+- New framework tables (future bundles) may need to be added to the `schema_filter` regex.

--- a/docs/technicalities/schema_drift.md
+++ b/docs/technicalities/schema_drift.md
@@ -1,0 +1,54 @@
+# Schema Drift (known residual)
+
+> **Audience:** Developer, AI Agent · **Scope:** Technical Deep-Dive
+
+← Back to [Documentation](../docs.md) | [Coding Standards](../standards/coding.md)
+
+---
+
+The local DB is kept in sync with **production** (prod is the source of truth for
+schema). `doctrine:schema:validate` reports the **mapping as correct**, but the
+DB-sync check still lists a small, **known, accepted residual** of *cosmetic* drift.
+None of it is semantic — no data, types, nullability, or defaults are affected.
+
+This page exists so the residual is not mistaken for real changes when generating
+migrations.
+
+## What was reconciled
+
+- **Column defaults/types** → fixed in the entity mappings (e.g. `options: ['default' => …]`
+  on booleans, `deck.format`, `deck_card.card_locale`, `card_identity.*`, and the
+  `homepage_layout_translation.og_description` `TEXT` length). These no longer drift.
+- **Framework tables** (`messenger_messages`, `sessions`) → excluded from ORM schema
+  management via `dbal.schema_filter` in `config/packages/doctrine.yaml`. They are owned
+  by the Messenger transport / PDO session handler, not our mappings.
+
+## Accepted residual (cosmetic only)
+
+These keep appearing in `doctrine:schema:update --dump-sql` and will reappear in any
+generated migration. They are intentionally **not** reconciled (it would mean either
+pinning legacy identifier names into mappings, or an `ALTER` migration on prod for zero
+functional gain):
+
+- **Legacy index / FK / unique-constraint names** — old migrations named these explicitly
+  (e.g. `uniq_event_tag_name`, `fk_banned_card_representative_printing`,
+  `idx_event_pending_transfer_to`); Doctrine now derives hash names. FK *constraint* names
+  cannot be set via attributes anyway. Tables: `event`, `event_event_tag`, `event_tag`,
+  `user` (calendar token), `banned_card`, `banned_card_printing`.
+- **`(DC2Type:datetime_immutable)` column comments** — DBAL 4 dropped comment-based type
+  tracking; the live columns still carry the old comment. There is no mapping switch to
+  keep it. Columns: `event.pending_transfer_requested_at`, `banned_card.{effective_date,
+  deleted_at,created_at}`, `event_tag.created_at`, `tcgdex_card.tcgdex_updated_at`.
+- One extra DB index, `banned_card.IDX_banned_card_deleted_at`, not declared in the mapping.
+
+## How to handle when generating a migration
+
+`doctrine:migrations:diff` will include the residual lines above. **Strip them** from the
+generated migration and keep only your intended change (this is what the F19.8 migration
+did). Cross-check against this list.
+
+## Eliminating it (deferred)
+
+A one-shot normalization migration could rename the indexes to Doctrine's convention and
+drop the stale comments, clearing the residual for good. Deferred by decision (it would
+`ALTER` prod for cosmetic-only gain); revisit if the residual becomes noisy.

--- a/migrations/Version20260621081335.php
+++ b/migrations/Version20260621081335.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Normalize schema to current Doctrine conventions (schema-drift cleanup).
+ *
+ * Renames legacy hand-named indexes/FKs to Doctrine's derived names and drops
+ * the obsolete `(DC2Type:datetime_immutable)` column comments that DBAL 4 no
+ * longer emits. Metadata-only operations (no table rebuilds, no data change);
+ * clears the long-standing drift so doctrine:schema:validate is fully in sync.
+ *
+ * @see docs/technicalities/schema_drift.md
+ */
+final class Version20260621081335 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Normalize legacy index/FK names and drop obsolete DC2Type datetime comments (schema-drift cleanup)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE event DROP FOREIGN KEY `FK_event_pending_transfer_to`');
+        $this->addSql('ALTER TABLE event CHANGE pending_transfer_requested_at pending_transfer_requested_at DATETIME DEFAULT NULL');
+        $this->addSql('ALTER TABLE event ADD CONSTRAINT FK_3BAE0AA768B7628F FOREIGN KEY (pending_transfer_to_id) REFERENCES `user` (id)');
+        $this->addSql('ALTER TABLE event RENAME INDEX idx_event_pending_transfer_to TO IDX_3BAE0AA768B7628F');
+        $this->addSql('ALTER TABLE event_event_tag RENAME INDEX idx_event_event_tag_event TO IDX_94D34C6D71F7E88B');
+        $this->addSql('ALTER TABLE event_event_tag RENAME INDEX idx_event_event_tag_tag TO IDX_94D34C6D884B1443');
+        $this->addSql('ALTER TABLE user RENAME INDEX uniq_user_calendar_token TO UNIQ_8D93D6493363A255');
+        $this->addSql('ALTER TABLE banned_card_printing RENAME INDEX idx_banned_card_printing_banned_card TO IDX_E65998B1C14B8818');
+        $this->addSql('ALTER TABLE banned_card_printing RENAME INDEX idx_banned_card_printing_card_printing TO IDX_E65998B19B43DC48');
+        $this->addSql('DROP INDEX IDX_banned_card_deleted_at ON banned_card');
+        $this->addSql('ALTER TABLE banned_card CHANGE effective_date effective_date DATETIME DEFAULT NULL, CHANGE deleted_at deleted_at DATETIME DEFAULT NULL, CHANGE created_at created_at DATETIME NOT NULL');
+        $this->addSql('ALTER TABLE banned_card RENAME INDEX fk_banned_card_representative_printing TO IDX_CB22283FB2864B3E');
+        $this->addSql('ALTER TABLE event_tag CHANGE created_at created_at DATETIME NOT NULL');
+        $this->addSql('ALTER TABLE event_tag RENAME INDEX uniq_event_tag_name TO UNIQ_124672505E237E06');
+        $this->addSql('ALTER TABLE event_tag RENAME INDEX uniq_event_tag_slug TO UNIQ_12467250989D9B62');
+        $this->addSql('ALTER TABLE tcgdex_card CHANGE tcgdex_updated_at tcgdex_updated_at DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentionally not reversed: this migration only normalizes identifier
+        // names and removes obsolete type comments to match current Doctrine
+        // conventions. Reverting would re-introduce the exact drift it clears.
+    }
+}

--- a/migrations/Version20260621081335.php
+++ b/migrations/Version20260621081335.php
@@ -19,10 +19,16 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Normalize schema to current Doctrine conventions (schema-drift cleanup).
  *
- * Renames legacy hand-named indexes/FKs to Doctrine's derived names and drops
- * the obsolete `(DC2Type:datetime_immutable)` column comments that DBAL 4 no
- * longer emits. Metadata-only operations (no table rebuilds, no data change);
- * clears the long-standing drift so doctrine:schema:validate is fully in sync.
+ * Renames legacy hand-named indexes/FKs to Doctrine's derived names, drops the
+ * obsolete `(DC2Type:datetime_immutable)` column comments DBAL 4 no longer
+ * emits, and aligns the framework-managed `messenger_messages`/`sessions`
+ * tables with the current bundle expectations. All metadata-only (no table
+ * rebuilds, no row changes), clearing long-standing drift so
+ * doctrine:schema:validate is fully in sync on the production-evolved schema.
+ *
+ * Guarded: a freshly built schema (createSchema / migrate-from-zero) already
+ * uses current conventions, so this migration skips itself there — it only
+ * acts on the legacy production-evolved schema.
  *
  * @see docs/technicalities/schema_drift.md
  */
@@ -30,11 +36,17 @@ final class Version20260621081335 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Normalize legacy index/FK names and drop obsolete DC2Type datetime comments (schema-drift cleanup)';
+        return 'Normalize legacy index/FK names, drop obsolete DC2Type comments, align framework tables (schema-drift cleanup)';
     }
 
     public function up(Schema $schema): void
     {
+        $isLegacySchema = (bool) $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'event' AND index_name = 'idx_event_pending_transfer_to'",
+        );
+        $this->skipIf(!$isLegacySchema, 'Schema already uses current Doctrine conventions (fresh build); nothing to normalize.');
+
+        // Legacy index / FK names -> Doctrine derived names.
         $this->addSql('ALTER TABLE event DROP FOREIGN KEY `FK_event_pending_transfer_to`');
         $this->addSql('ALTER TABLE event CHANGE pending_transfer_requested_at pending_transfer_requested_at DATETIME DEFAULT NULL');
         $this->addSql('ALTER TABLE event ADD CONSTRAINT FK_3BAE0AA768B7628F FOREIGN KEY (pending_transfer_to_id) REFERENCES `user` (id)');
@@ -51,6 +63,14 @@ final class Version20260621081335 extends AbstractMigration
         $this->addSql('ALTER TABLE event_tag RENAME INDEX uniq_event_tag_name TO UNIQ_124672505E237E06');
         $this->addSql('ALTER TABLE event_tag RENAME INDEX uniq_event_tag_slug TO UNIQ_12467250989D9B62');
         $this->addSql('ALTER TABLE tcgdex_card CHANGE tcgdex_updated_at tcgdex_updated_at DATETIME DEFAULT NULL');
+
+        // Framework-managed tables: align with current bundle schema.
+        $this->addSql('DROP INDEX IDX_75EA56E0FB7336F0 ON messenger_messages');
+        $this->addSql('DROP INDEX IDX_75EA56E0E3BD61CE ON messenger_messages');
+        $this->addSql('DROP INDEX IDX_75EA56E016BA31DB ON messenger_messages');
+        $this->addSql('CREATE INDEX IDX_75EA56E0FB7336F0E3BD61CE16BA31DBBF396750 ON messenger_messages (queue_name, available_at, delivered_at, id)');
+        $this->addSql('ALTER TABLE sessions CHANGE sess_id sess_id VARBINARY(128) NOT NULL, CHANGE sess_data sess_data LONGBLOB NOT NULL');
+        $this->addSql('ALTER TABLE sessions RENAME INDEX sessions_sess_lifetime_idx TO sess_lifetime_idx');
     }
 
     public function down(Schema $schema): void

--- a/src/Entity/CardIdentity.php
+++ b/src/Entity/CardIdentity.php
@@ -48,11 +48,11 @@ class CardIdentity
     private int $hp = 0;
 
     /** Sorted comma-joined ability names. Empty string for non-Pokemon cards. */
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 255, options: ['default' => ''])]
     private string $abilitySignature = '';
 
     /** Comma-joined ability names in original card order (for Cardmarket export). */
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 255, options: ['default' => ''])]
     private string $abilityNames = '';
 
     /** Sorted comma-joined attack names. Empty string for non-Pokemon cards. */
@@ -60,11 +60,11 @@ class CardIdentity
     private string $attackSignature = '';
 
     /** Comma-joined attack names in original card order (for Cardmarket export). */
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 255, options: ['default' => ''])]
     private string $attackNames = '';
 
     /** Sorted comma-joined Pokemon types (e.g. "Metal", "Dragon", "Fire,Water"). Empty string for non-Pokemon cards. */
-    #[ORM\Column(length: 100)]
+    #[ORM\Column(length: 100, options: ['default' => ''])]
     private string $pokemonType = '';
 
     /** Trainer subtype (e.g. "Supporter", "Item", "Tool", "Stadium"). Null for non-Trainers. */

--- a/src/Entity/CardPrinting.php
+++ b/src/Entity/CardPrinting.php
@@ -77,7 +77,7 @@ class CardPrinting
     private ?int $tcgplayerProductId = null;
 
     /** Marks the preferred printing for minified/simplified lists within its CardIdentity. */
-    #[ORM\Column]
+    #[ORM\Column(options: ['default' => false])]
     private bool $isCanonical = false;
 
     public function getId(): ?int

--- a/src/Entity/Channel.php
+++ b/src/Entity/Channel.php
@@ -58,10 +58,10 @@ class Channel
     #[ORM\Column]
     private bool $enableArchetypes = false;
 
-    #[ORM\Column]
+    #[ORM\Column(options: ['default' => false])]
     private bool $enableBannedCards = false;
 
-    #[ORM\Column]
+    #[ORM\Column(options: ['default' => false])]
     private bool $enableStaples = false;
 
     /**

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -60,7 +60,7 @@ class Deck
     /**
      * @see docs/features.md F2.23 — Standard format personal decks
      */
-    #[ORM\Column(length: 20, enumType: DeckFormat::class)]
+    #[ORM\Column(length: 20, enumType: DeckFormat::class, options: ['default' => 'expanded'])]
     private DeckFormat $format = DeckFormat::Expanded;
 
     #[ORM\Column(length: 20, enumType: DeckStatus::class)]

--- a/src/Entity/DeckCard.php
+++ b/src/Entity/DeckCard.php
@@ -65,7 +65,7 @@ class DeckCard
     private ?CardPrinting $cardPrinting = null;
 
     /** Locale of the original deck list input (e.g. "en", "fr"). */
-    #[ORM\Column(length: 5)]
+    #[ORM\Column(length: 5, options: ['default' => 'en'])]
     private string $cardLocale = 'en';
 
     /**

--- a/src/Entity/HomepageLayoutTranslation.php
+++ b/src/Entity/HomepageLayoutTranslation.php
@@ -55,7 +55,8 @@ class HomepageLayoutTranslation
     #[Assert\Length(max: 255)]
     private ?string $title = null;
 
-    #[ORM\Column(type: 'text', nullable: true)]
+    // length 65535 maps to MySQL TEXT (not LONGTEXT), matching the live schema.
+    #[ORM\Column(type: 'text', length: 65535, nullable: true)]
     private ?string $ogDescription = null;
 
     public function getId(): ?int

--- a/src/Entity/MenuCategory.php
+++ b/src/Entity/MenuCategory.php
@@ -33,7 +33,7 @@ class MenuCategory
     #[ORM\Column]
     private int $position = 0;
 
-    #[ORM\Column]
+    #[ORM\Column(options: ['default' => false])]
     private bool $isFooter = false;
 
     /**


### PR DESCRIPTION
Aligns the schema with the **production DB** (now the source of truth, imported locally) and clears long-standing drift so `doctrine:schema:validate` is **fully in sync** — both mapping and DB-sync report OK.

## Changes, by drift category
1. **Column defaults/types** → declared on entity mappings (they already exist in the DB): boolean defaults (`channel.enable_banned_cards`/`enable_staples`, `menu_category.is_footer`, `card_printing.is_canonical`), `deck.format` (`'expanded'`), `deck_card.card_locale` (`'en'`), `card_identity.{ability_signature,ability_names,attack_names,pokemon_type}` (`''`), `homepage_layout_translation.og_description` (`TEXT`).
2. **Framework tables** (`messenger_messages`, `sessions`) → excluded from ORM schema management via `dbal.schema_filter` (owned by the Messenger transport / PDO session handler).
3. **Legacy index/FK names + obsolete `(DC2Type:datetime_immutable)` comments** → normalized to Doctrine conventions by a one-time, **metadata-only** migration (`Version20260621081335`): `RENAME INDEX`, FK rename, and comment drops are instant in MySQL 8 (no table rebuilds, no data change).

## Result
- `doctrine:schema:validate` → **mapping correct** + **DB in sync** (zero residual).
- PHPStan, container lint, YAML lint, unit suite — all green.
- No data / type / nullability / default behavior changes.

## Why the migration (vs. accepting residual)
Leaving the index/comment drift unreconciled would make every future `migrations:diff` re-emit ~16 lines that must be hand-stripped — the exact trap the F19.8 migration hit. The normalization migration ends that loop for good; the ops are safe metadata changes. Documented in `docs/technicalities/schema_drift.md`.