### PR TITLE
:white_check_mark: Tests: cover F19.8 authorship + exclude fixtures from coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -49,6 +49,11 @@
             <directory>src</directory>
         </include>
 
+        <exclude>
+            <!-- Dev seed data, not production logic — run by fixture loads, not unit tests. -->
+            <directory>src/DataFixtures</directory>
+        </exclude>
+
         <deprecationTrigger>
             <method>Doctrine\Deprecations\Deprecation::trigger</method>
             <method>Doctrine\Deprecations\Deprecation::delegateTriggerToBackend</method>

--- a/tests/Entity/DeckTest.php
+++ b/tests/Entity/DeckTest.php
@@ -474,4 +474,22 @@ class DeckTest extends TestCase
         $deck->setLatestSet(null);
         self::assertNull($deck->getLatestSet());
     }
+
+    public function testResolveAuthorPrefersExplicitAuthorThenOwner(): void
+    {
+        // Variant (owner-less) with an explicit editorial author.
+        $author = new User();
+        $variant = (new Deck())->setArchetype(new Archetype())->setAuthor($author);
+        self::assertSame($author, $variant->getAuthor());
+        self::assertSame($author, $variant->resolveAuthor());
+
+        // Owner-owned deck with no explicit author resolves to its owner.
+        $owner = new User();
+        $owned = (new Deck())->setOwner($owner);
+        self::assertNull($owned->getAuthor());
+        self::assertSame($owner, $owned->resolveAuthor());
+
+        // Neither set resolves to null.
+        self::assertNull((new Deck())->resolveAuthor());
+    }
 }

--- a/tests/Entity/UserCoverageTest.php
+++ b/tests/Entity/UserCoverageTest.php
@@ -84,4 +84,67 @@ class UserCoverageTest extends TestCase
         self::assertSame('test@example.com', $user->getEmail());
         self::assertSame('hashed-password', $user->getPassword());
     }
+
+    public function testPublicAuthorProfileGettersAndSetters(): void
+    {
+        $user = new User();
+        self::assertFalse($user->isPublicAuthor());
+        self::assertNull($user->getCredential());
+        self::assertNull($user->getBio());
+        self::assertSame([], $user->getSameAs());
+        self::assertNull($user->getAvatarUrl());
+        self::assertNull($user->getPrimaryUrl());
+        self::assertNull($user->getPublicSlug());
+
+        $user->setIsPublicAuthor(true);
+        $user->setCredential('Specialist');
+        $user->setBio('Bio text.');
+        $user->setAvatarUrl('https://example.test/a.png');
+        $user->setPrimaryUrl('https://example.test/me');
+        $user->setPublicSlug('handle');
+
+        self::assertTrue($user->isPublicAuthor());
+        self::assertSame('Specialist', $user->getCredential());
+        self::assertSame('Bio text.', $user->getBio());
+        self::assertSame('https://example.test/a.png', $user->getAvatarUrl());
+        self::assertSame('https://example.test/me', $user->getPrimaryUrl());
+        self::assertSame('handle', $user->getPublicSlug());
+    }
+
+    public function testSetSameAsFiltersBlankEntriesAndNullClears(): void
+    {
+        $user = new User();
+
+        $user->setSameAs(['https://a.test', '  ', '', 'https://b.test']);
+        self::assertSame(['https://a.test', 'https://b.test'], $user->getSameAs());
+
+        $user->setSameAs(null);
+        self::assertSame([], $user->getSameAs());
+    }
+
+    public function testAnonymizeClearsPublicAuthorProfile(): void
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setScreenName('Player');
+        $user->setIsPublicAuthor(true);
+        $user->setCredential('Specialist');
+        $user->setBio('Bio.');
+        $user->setSameAs(['https://a.test']);
+        $user->setAvatarUrl('https://example.test/a.png');
+        $user->setPrimaryUrl('https://example.test/me');
+        $user->setPublicSlug('handle');
+        $ref = new \ReflectionProperty(User::class, 'id');
+        $ref->setValue($user, 1);
+
+        $user->anonymize();
+
+        self::assertFalse($user->isPublicAuthor());
+        self::assertNull($user->getCredential());
+        self::assertNull($user->getBio());
+        self::assertSame([], $user->getSameAs());
+        self::assertNull($user->getAvatarUrl());
+        self::assertNull($user->getPrimaryUrl());
+        self::assertNull($user->getPublicSlug());
+    }
 }

--- a/tests/Functional/AdminUserControllerCoverageTest.php
+++ b/tests/Functional/AdminUserControllerCoverageTest.php
@@ -123,6 +123,65 @@ class AdminUserControllerCoverageTest extends AbstractFunctionalTest
         self::assertResponseIsSuccessful();
     }
 
+    /**
+     * An editor can save a user's public author profile; sameAs splits per line.
+     *
+     * @see docs/features.md F19.8 — Author assignment
+     */
+    public function testUpdateAuthorProfileSavesPublicProfile(): void
+    {
+        $this->loginAs('admin@example.com');
+        $userId = $this->getUserId('lender@example.com');
+
+        $crawler = $this->client->request('GET', '/admin/users/'.$userId);
+        self::assertResponseIsSuccessful();
+        $token = $crawler->filter('form[action$="/author"] input[name="_token"]')->attr('value');
+        self::assertNotNull($token);
+
+        $this->client->request('POST', '/admin/users/'.$userId.'/author', [
+            '_token' => $token,
+            'is_public_author' => '1',
+            'credential' => 'Format specialist',
+            'bio' => 'A short bio.',
+            'same_as' => "https://a.test\n  \nhttps://b.test",
+            'avatar_url' => 'https://example.test/a.png',
+            'primary_url' => 'https://example.test/me',
+            'public_slug' => 'lender-author',
+        ]);
+
+        self::assertResponseRedirects('/admin/users/'.$userId);
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager->clear();
+        /** @var User $user */
+        $user = $entityManager->find(User::class, $userId);
+        self::assertTrue($user->isPublicAuthor());
+        self::assertSame('Format specialist', $user->getCredential());
+        self::assertSame('A short bio.', $user->getBio());
+        self::assertSame(['https://a.test', 'https://b.test'], $user->getSameAs());
+        self::assertSame('https://example.test/me', $user->getPrimaryUrl());
+        self::assertSame('lender-author', $user->getPublicSlug());
+    }
+
+    /**
+     * Invalid CSRF on the author-profile update redirects with a danger flash.
+     */
+    public function testUpdateAuthorProfileInvalidCsrfRedirects(): void
+    {
+        $this->loginAs('admin@example.com');
+        $userId = $this->getUserId('staff1@example.com');
+
+        $this->client->request('POST', '/admin/users/'.$userId.'/author', [
+            '_token' => 'invalid-token',
+            'is_public_author' => '1',
+        ]);
+
+        self::assertResponseRedirects('/admin/users/'.$userId);
+        $this->client->followRedirect();
+        self::assertSelectorExists('.alert-danger');
+    }
+
     private function getUserId(string $email): int
     {
         /** @var EntityManagerInterface $entityManager */

--- a/tests/Functional/ArchetypeCatalogControllerTest.php
+++ b/tests/Functional/ArchetypeCatalogControllerTest.php
@@ -234,6 +234,11 @@ class ArchetypeCatalogControllerTest extends AbstractFunctionalTest
         foreach ($xml->channel->item as $item) {
             // dc:creator is the variant's resolved author (the fixture content author).
             self::assertSame('AceTrainer', (string) $item->children('http://purl.org/dc/elements/1.1/')->creator);
+
+            // atom:author carries the name and (for public authors) the profile URI (F19.8).
+            $atom = $item->children('http://www.w3.org/2005/Atom');
+            self::assertSame('AceTrainer', (string) $atom->author->name);
+            self::assertSame('https://github.com/jbourdin', (string) $atom->author->uri);
         }
     }
 

--- a/tests/Functional/ProfileControllerCoverageTest.php
+++ b/tests/Functional/ProfileControllerCoverageTest.php
@@ -53,6 +53,41 @@ class ProfileControllerCoverageTest extends AbstractFunctionalTest
     }
 
     /**
+     * Saving the public author profile through the self-service form persists
+     * the fields and splits sameAs one URL per line (F19.8).
+     *
+     * @see docs/features.md F19.8 — Author assignment
+     */
+    public function testProfileEditSavesPublicAuthorProfile(): void
+    {
+        $this->loginAs('staff2@example.com');
+
+        $crawler = $this->client->request('GET', '/profile');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Save')->form();
+        $form['profile_form[isPublicAuthor]']->tick();
+        $form['profile_form[credential]'] = 'Format specialist';
+        $form['profile_form[bio]'] = 'Bio from profile form.';
+        $form['profile_form[sameAs]'] = "https://x.test\nhttps://y.test\n";
+        $form['profile_form[primaryUrl]'] = 'https://example.test/me';
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/profile');
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager->clear();
+        /** @var User $user */
+        $user = $entityManager->getRepository(User::class)->findOneBy(['email' => 'staff2@example.com']);
+        self::assertTrue($user->isPublicAuthor());
+        self::assertSame('Format specialist', $user->getCredential());
+        self::assertSame('Bio from profile form.', $user->getBio());
+        self::assertSame(['https://x.test', 'https://y.test'], $user->getSameAs());
+        self::assertSame('https://example.test/me', $user->getPrimaryUrl());
+    }
+
+    /**
      * Data export for a user with decks, borrows, and engagements should
      * include all sections with data.
      */


### PR DESCRIPTION
Addresses the recurring `codecov/patch` failures on the F19.8 release PRs (#710, #713) by covering the genuinely-untested authorship logic and removing a structural drag.

## New/extended tests
- **`UserCoverageTest`** — public-author profile accessors, `setSameAs()` blank-filtering, and `anonymize()` clearing the whole author profile.
- **`DeckTest`** — `resolveAuthor()` (explicit author → owner fallback → null).
- **`AdminUserControllerCoverageTest`** — `updateAuthorProfile` saves the profile (with `sameAs` line-splitting) + invalid-CSRF redirect.
- **`ProfileControllerCoverageTest`** — self-service profile save, exercising `ProfileFormType` end-to-end including the one-URL-per-line `sameAs` model transformer.
- **`ArchetypeCatalogControllerTest`** — feed now asserts `atom:author` name + profile `uri`, covering the RSS template and the `authorUrl` controller branch.

## Coverage config
- Exclude **`src/DataFixtures`** from coverage (`phpunit.xml.dist`): dev seed data, executed by fixture loads not unit tests. The F19.8 author-seed additions there were counting as uncovered and dragging patch coverage. (Migrations are already outside `src/`.)

## Verification
- New entity tests: 50 pass. Functional: 33 pass (incl. the new author-profile + feed cases). PHPStan + style clean.

The remaining F19.8 code (StructuredDataBuilder, ContentAuthorListener, entity author/translator accessors, variant author data) is already executed/asserted by existing tests.