### PR TITLE
:bug: fix: prevent stored XSS in search result highlighting

### DIFF
--- a/src/Controller/SearchApiController.php
+++ b/src/Controller/SearchApiController.php
@@ -61,7 +61,11 @@ class SearchApiController extends AbstractController
 
             foreach ($items as $result) {
                 $group['items'][] = [
-                    'title' => strip_tags($result->title),
+                    // $result->title is pre-sanitised HTML (only <mark> tags are
+                    // real markup); strip them and decode entities back to plain
+                    // text for the JSON payload, which the navbar renders as a
+                    // React text node.
+                    'title' => html_entity_decode(strip_tags($result->title), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
                     'type' => $result->type,
                     'url' => $this->buildResultUrl($result, $locale, $urlGenerator),
                     'secondary' => $result->secondaryInfo,

--- a/src/Service/Search/SearchResult.php
+++ b/src/Service/Search/SearchResult.php
@@ -41,11 +41,37 @@ final readonly class SearchResult
 
         return new self(
             type: $type,
-            title: self::extractTitle($hit, $formatted),
-            excerpt: self::extractExcerpt($formatted, $type),
+            title: self::sanitizeHighlight(self::extractTitle($hit, $formatted)),
+            excerpt: self::sanitizeHighlight(self::extractExcerpt($formatted, $type)),
             slug: self::extractSlug($hit, $type),
             secondaryInfo: self::extractSecondaryInfo($hit, $type),
             archetypeSlug: \is_string($hit['archetypeSlug'] ?? null) ? $hit['archetypeSlug'] : null,
+        );
+    }
+
+    /**
+     * Escape a Meilisearch highlighted snippet for safe rendering as HTML.
+     *
+     * The results template prints `title`/`excerpt` with the `|raw` filter to
+     * keep Meilisearch's `<mark>` highlight tags. Meilisearch returns the rest
+     * of the matched field verbatim, so any HTML in the underlying value (for
+     * example a user-chosen deck name) would otherwise render as live markup —
+     * a stored XSS vector. We escape the whole snippet, then restore only the
+     * highlight tags, neutralising every other tag while keeping highlighting.
+     *
+     * @see docs/features.md F18.2 — Global search results page
+     */
+    private static function sanitizeHighlight(string $value): string
+    {
+        $escaped = htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+
+        return str_replace(
+            [
+                htmlspecialchars(SearchService::HIGHLIGHT_PRE_TAG, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+                htmlspecialchars(SearchService::HIGHLIGHT_POST_TAG, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+            ],
+            [SearchService::HIGHLIGHT_PRE_TAG, SearchService::HIGHLIGHT_POST_TAG],
+            $escaped,
         );
     }
 

--- a/src/Service/Search/SearchService.php
+++ b/src/Service/Search/SearchService.php
@@ -28,6 +28,16 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  */
 class SearchService
 {
+    /**
+     * Tags Meilisearch wraps around matched terms in `_formatted` fields.
+     *
+     * These are the only HTML that {@see SearchResult::sanitizeHighlight()} is
+     * allowed to preserve when escaping highlighted snippets, so both sides of
+     * that contract must reference these constants rather than literals.
+     */
+    public const string HIGHLIGHT_PRE_TAG = '<mark>';
+    public const string HIGHLIGHT_POST_TAG = '</mark>';
+
     private const int QUICK_SEARCH_LIMIT = 3;
     private const int FULL_SEARCH_LIMIT = 20;
     private const float RANKING_SCORE_THRESHOLD = 0.3;
@@ -168,8 +178,8 @@ class SearchService
             'limit' => $limit,
             'offset' => $offset,
             'attributesToHighlight' => ['*'],
-            'highlightPreTag' => '<mark>',
-            'highlightPostTag' => '</mark>',
+            'highlightPreTag' => self::HIGHLIGHT_PRE_TAG,
+            'highlightPostTag' => self::HIGHLIGHT_POST_TAG,
             'rankingScoreThreshold' => self::RANKING_SCORE_THRESHOLD,
         ];
 

--- a/templates/search/results.html.twig
+++ b/templates/search/results.html.twig
@@ -100,6 +100,8 @@
                                 <a href="{{ resultUrl }}" class="list-group-item list-group-item-action">
                                     <div class="d-flex justify-content-between align-items-start">
                                         <div>
+                                            {# title/excerpt are pre-sanitised in SearchResult::sanitizeHighlight — #}
+                                            {# only Meilisearch <mark> highlight tags survive as HTML, so |raw is safe here. #}
                                             <h6 class="mb-1">{{ result.title|raw }}</h6>
                                             {% if result.excerpt %}
                                                 <p class="mb-1 text-secondary small">{{ result.excerpt|raw }}</p>

--- a/tests/Service/Search/SearchResultTest.php
+++ b/tests/Service/Search/SearchResultTest.php
@@ -171,6 +171,80 @@ class SearchResultTest extends TestCase
         self::assertSame('unknown', $result->type);
     }
 
+    public function testFromHitNeutralisesHtmlInTitle(): void
+    {
+        $hit = [
+            'type' => 'deck',
+            'name' => '<img src=x onerror=alert(1)> My <mark>Regidrago</mark>',
+            'shortTag' => 'ABC123',
+            '_formatted' => [
+                'name' => '<img src=x onerror=alert(1)> My <mark>Regidrago</mark>',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        // The attacker <img> tag is escaped; only the <mark> highlight survives as HTML.
+        self::assertStringNotContainsString('<img', $result->title);
+        self::assertStringContainsString('&lt;img src=x onerror=alert(1)&gt;', $result->title);
+        self::assertStringContainsString('<mark>Regidrago</mark>', $result->title);
+    }
+
+    public function testFromHitNeutralisesHtmlInExcerpt(): void
+    {
+        $hit = [
+            'type' => 'page',
+            'title' => 'Payload',
+            'slug' => 'payload',
+            'content' => '<script>alert(1)</script>',
+            '_formatted' => [
+                'title' => 'Payload',
+                'content' => 'Intro <mark>match</mark> <script>alert(1)</script>',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertStringNotContainsString('<script>', $result->excerpt);
+        self::assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $result->excerpt);
+        self::assertStringContainsString('<mark>match</mark>', $result->excerpt);
+    }
+
+    public function testFromHitEscapesAmpersandsAndQuotes(): void
+    {
+        $hit = [
+            'type' => 'deck',
+            'name' => 'Fire & Ice "Deck"',
+            'shortTag' => 'DEF456',
+            '_formatted' => [
+                'name' => 'Fire & Ice "Deck"',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertStringContainsString('Fire &amp; Ice', $result->title);
+        self::assertStringContainsString('&quot;Deck&quot;', $result->title);
+    }
+
+    public function testFromHitLeavesBenignHighlightUnchanged(): void
+    {
+        $hit = [
+            'type' => 'archetype',
+            'name' => 'Regidrago',
+            'slug' => 'regidrago',
+            '_formatted' => [
+                'name' => '<mark>Regidrago</mark>',
+                'description' => 'A powerful <mark>dragon</mark> archetype.',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        // No dangerous characters means the highlighted snippet is untouched.
+        self::assertSame('<mark>Regidrago</mark>', $result->title);
+    }
+
     public function testExcerptTruncatesLongContent(): void
     {
         $longText = str_repeat('word ', 100);


### PR DESCRIPTION
## Summary

Fixes a **stored XSS** on the public search results page (finding SEC-01 from the security audit).

Search result titles and excerpts are rendered with Twig's `|raw` filter to preserve Meilisearch `<mark>` highlight tags. But the underlying field values were never HTML-escaped, and Meilisearch returns matched field content verbatim. Because **deck name** is an indexed field that **any registered user** can set, a user could name a public deck `<img src=x onerror=…>` and have it execute as live markup for any visitor — including admins — whose search matched it. The results page (`/{_locale}/search`) has no access control.

## Fix

Sanitization is applied at the single choke point where raw index data becomes a display value, `SearchResult::fromHit`:

- **`SearchResult::sanitizeHighlight()`** (new) — escapes the whole snippet, then restores *only* Meilisearch's `<mark>`/`</mark>` highlight tags. Every other tag/attribute is neutralised into inert entities. Applied to both `title` and `excerpt`.
- **`SearchService`** — highlight tags promoted to shared constants (`HIGHLIGHT_PRE_TAG` / `HIGHLIGHT_POST_TAG`) so the Meili query config and the sanitizer reference the same contract and can't drift.
- **`SearchApiController`** — quick-search API decodes entities back to plain text for its JSON payload (rendered as a React text node in the navbar, so still safe).
- **Template** — kept `|raw` (now justified) with a comment pointing to the sanitizer.

Benign highlighted titles (e.g. `<mark>Regidrago</mark>`) pass through unchanged, so existing behaviour and tests hold; escaping only takes effect on dangerous input.

## Testing

- `SearchResultTest` — 4 new tests proving the exploit is neutralised (dangerous `<img>`/`<script>` escaped, `<mark>` preserved, ampersands/quotes escaped) + 9 existing — **13/13 pass**
- `SearchServiceTest` — **20/20 pass**
- PHPStan (level 10), PHP-CS-Fixer, `lint:twig`, Twig-CS-Fixer — all clean
- Functional search tests need the Docker DB/Meilisearch running — please verify locally as part of manual testing

## Manual test

1. Create a public deck named e.g. `<img src=x onerror=alert(1)> Regidrago`
2. Search for `Regidrago` at `/en/search`
3. Confirm the title renders as literal text (no alert), with `Regidrago` still highlighted
4. Confirm the navbar quick-search dropdown shows the name as plain text