### PR TITLE
:rocket: Release: 1.14.9

### DIFF
--- a/assets/admin-menu-category-list.ts
+++ b/assets/admin-menu-category-list.ts
@@ -15,6 +15,7 @@
  */
 
 import Sortable from 'sortablejs';
+import { csrfHeader } from './csrf';
 
 function getCategoryIds(tbody: HTMLTableSectionElement): number[] {
     return Array.from(tbody.querySelectorAll<HTMLTableRowElement>('tr[data-category-id]'))
@@ -31,7 +32,7 @@ function persistOrder(tbody: HTMLTableSectionElement): void {
 
     fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...csrfHeader() },
         body: JSON.stringify(categoryIds),
     }).catch((error) => {
         console.error('Reorder failed:', error);

--- a/assets/admin-page-list.ts
+++ b/assets/admin-page-list.ts
@@ -15,6 +15,7 @@
  */
 
 import Sortable from 'sortablejs';
+import { csrfHeader } from './csrf';
 
 function getPageIds(tbody: HTMLTableSectionElement): number[] {
     return Array.from(tbody.querySelectorAll<HTMLTableRowElement>('tr[data-page-id]'))
@@ -31,7 +32,7 @@ function persistOrder(tbody: HTMLTableSectionElement): void {
 
     fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...csrfHeader() },
         body: JSON.stringify(pageIds),
     }).catch((error) => {
         console.error('Reorder failed:', error);

--- a/assets/components/HomepageEditor.tsx
+++ b/assets/components/HomepageEditor.tsx
@@ -18,6 +18,7 @@ import Sortable from 'sortablejs';
 import { useEffect, useRef } from 'react';
 import BlockEditModal from './BlockEditModal';
 import ImageUrlField from './ImageUrlField';
+import { csrfHeader } from '../csrf';
 
 interface BlockTypeInfo {
     value: string;
@@ -215,7 +216,7 @@ export default function HomepageEditor({
         try {
             const response = await fetch(saveUrl, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 'Content-Type': 'application/json', ...csrfHeader() },
                 body: JSON.stringify({ blocks, translations, channelCode, ogImage, meta }),
             });
             if (response.ok) {

--- a/assets/components/MarkdownEditor.tsx
+++ b/assets/components/MarkdownEditor.tsx
@@ -17,6 +17,7 @@ import { FileHandler } from '@tiptap/extension-file-handler';
 import StarterKit from '@tiptap/starter-kit';
 import { Table, TableRow, TableHeader, TableCell } from '@tiptap/extension-table';
 import { IconCards, IconFloatCenter, IconFloatLeft, IconFloatNone, IconFloatRight, IconPhoto, IconStack2, IconSword } from '@tabler/icons-react';
+import { csrfHeader } from '../csrf';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — tiptap-markdown types conflict with tiptap v3 private class properties
 import { Markdown } from 'tiptap-markdown';
@@ -68,6 +69,7 @@ async function uploadAndInsertImage(file: File, editor: Editor, position?: numbe
     try {
         const response = await fetch('/api/editor/upload-image', {
             method: 'POST',
+            headers: csrfHeader(),
             body: formData,
         });
 

--- a/assets/components/NotificationBell.tsx
+++ b/assets/components/NotificationBell.tsx
@@ -21,6 +21,7 @@ import {
     UnstyledButton,
 } from '@mantine/core';
 import { IconBell, IconCheck, IconChecks } from '@tabler/icons-react';
+import { csrfHeader } from '../csrf';
 
 /**
  * @see docs/features.md F8.4 — In-app notification center
@@ -117,7 +118,7 @@ export default function NotificationBell({
         e.stopPropagation();
         const url = markReadUrlTemplate.replace('__ID__', String(id));
         try {
-            const res = await fetch(url, { method: 'POST' });
+            const res = await fetch(url, { method: 'POST', headers: csrfHeader() });
             if (!res.ok) return;
             const data = await res.json();
             setUnreadCount(data.unreadCount);
@@ -131,7 +132,7 @@ export default function NotificationBell({
 
     const markAllRead = async () => {
         try {
-            const res = await fetch(markAllReadUrl, { method: 'POST' });
+            const res = await fetch(markAllReadUrl, { method: 'POST', headers: csrfHeader() });
             if (!res.ok) return;
             setUnreadCount(0);
             setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
@@ -214,7 +215,7 @@ export default function NotificationBell({
                                         if (!n.isRead) {
                                             const url = markReadUrlTemplate.replace('__ID__', String(n.id));
                                             try {
-                                                await fetch(url, { method: 'POST' });
+                                                await fetch(url, { method: 'POST', headers: csrfHeader() });
                                             } catch {
                                                 // Best-effort — navigate anyway
                                             }

--- a/assets/components/OgImageBuilder.tsx
+++ b/assets/components/OgImageBuilder.tsx
@@ -14,6 +14,7 @@
 import { useState, useCallback } from 'react';
 import { Badge, Button, CopyButton, Group, Image, Stack, Text, Textarea } from '@mantine/core';
 import { IconCheck, IconCopy, IconPhoto } from '@tabler/icons-react';
+import { csrfHeader } from '../csrf';
 
 interface ResolvedCard {
     code: string;
@@ -57,7 +58,7 @@ export default function OgImageBuilder({ generateUrl, labels }: OgImageBuilderPr
         try {
             const response = await fetch(generateUrl, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 'Content-Type': 'application/json', ...csrfHeader() },
                 body: JSON.stringify({ codes }),
             });
 

--- a/assets/csrf.ts
+++ b/assets/csrf.ts
@@ -1,0 +1,23 @@
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Read the per-session CSRF token rendered for authenticated users in
+ * `<meta name="csrf-token">` (see base.html.twig). Sent as the `X-CSRF-Token`
+ * header on state-changing fetch() calls and validated server-side with the
+ * `ajax` token id (see AjaxCsrfTrait).
+ */
+export const csrfToken = (): string =>
+    document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+
+/**
+ * Header object to spread into a fetch() `headers` for authenticated,
+ * state-changing requests: `headers: { ...csrfHeader(), ... }`.
+ */
+export const csrfHeader = (): Record<string, string> => ({ 'X-CSRF-Token': csrfToken() });

--- a/assets/event-sync.ts
+++ b/assets/event-sync.ts
@@ -7,6 +7,8 @@
  * file that was distributed with this source code.
  */
 
+import { csrfHeader } from './csrf';
+
 /**
  * Event sync: fetches event data from the Pokemon event page via backend
  * proxy and prefills the event form fields.
@@ -60,7 +62,7 @@ async function handleSync(btn: HTMLButtonElement): Promise<void> {
     try {
         const response = await fetch(syncUrl, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', ...csrfHeader() },
             body: JSON.stringify({ tournamentId }),
         });
 

--- a/assets/shared/sortable-table.ts
+++ b/assets/shared/sortable-table.ts
@@ -22,6 +22,7 @@
  */
 
 import Sortable from 'sortablejs';
+import { csrfHeader } from '../csrf';
 
 export function initSortableTable(tbodyId: string, idAttribute: string): void {
     const tbody = document.getElementById(tbodyId) as HTMLTableSectionElement | null;
@@ -41,7 +42,7 @@ export function initSortableTable(tbodyId: string, idAttribute: string): void {
 
         fetch(url, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', ...csrfHeader() },
             body: JSON.stringify(getIds()),
         }).catch((error) => {
             console.error('Reorder failed:', error);

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,22 @@ Items marked *(partial)* have scaffolding or basic functionality but are not yet
 
 ---
 
+## [1.14.9] — 2026-07-03
+
+Patch release: security hardening from a source-level audit — fixes a stored XSS in the search results page and adds CSRF protection to authenticated AJAX endpoints — plus test-coverage backfill.
+
+### Bug Fixes
+
+- **Stored XSS in search results** — Search result titles and excerpts were rendered with Twig's `|raw` filter to preserve Meilisearch `<mark>` highlight tags, but the underlying field values were never HTML-escaped. Because a deck name is an indexed field that any registered user can set, a crafted name (e.g. `<img src=x onerror=…>`) rendered as live markup on the public search page for any visitor whose query matched it. Sanitization now happens at the single `SearchResult::fromHit` choke point: the snippet is escaped and only Meilisearch's own `<mark>` tags are restored, neutralising every other tag while keeping highlighting. Benign titles are unchanged. ([#729](https://github.com/jbourdin/expandedDecks/pull/729))
+- **Missing CSRF protection on authenticated AJAX endpoints** — Several state-changing endpoints consumed JSON or multipart bodies via hand-rolled `fetch()` handlers and bypassed the Symfony form component, so they had no CSRF protection: notification mark-read/read-all, homepage save/preview, archetype/menu-category/page/staple reorder, editor image upload, OG-image generate, and event sync. A shared per-session token is now rendered as `<meta name="csrf-token">` (for logged-in users only, so anonymous pages stay cacheable), read by a small `assets/csrf.ts` helper and sent as the `X-CSRF-Token` header; server-side `AjaxCsrfTrait` validates it and returns 403 on failure. Form-based endpoints were already protected by the form component and are unchanged. ([#730](https://github.com/jbourdin/expandedDecks/pull/730))
+
+### Testing & Quality
+
+- **CSRF enforcement tests** — Added missing-token → 403 rejection tests across every guarded AJAX endpoint (including a new `AdminStapleCardControllerTest`), verifying CSRF is genuinely enforced rather than only that valid tokens pass. ([#730](https://github.com/jbourdin/expandedDecks/pull/730))
+- **Coverage backfill for least-covered classes** — Added unit tests for `StapleCardImageResolver` (was 0.95% line coverage — the staple image fallback chain was entirely untested) and `KeyValueTransformer`, covering the full fallback chain (direct URL, TCGdex CDN, PokemonTCG.io, upstream set-code, rarity ordering) and the key-value transform/reverse logic. ([#731](https://github.com/jbourdin/expandedDecks/pull/731))
+
+---
+
 ## [1.14.8] — 2026-06-21
 
 Patch release: SEO/GSO audit follow-ups — meta descriptions on every indexable page, baseline security/trust response headers, and a favicon-crawlability fix.

--- a/src/Controller/AdminArchetypeController.php
+++ b/src/Controller/AdminArchetypeController.php
@@ -51,6 +51,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[IsGranted('ROLE_ARCHETYPE_EDITOR')]
 class AdminArchetypeController extends AbstractAppController
 {
+    use AjaxCsrfTrait;
+
     private const array SUPPORTED_LOCALES = ['en', 'fr'];
 
     public function __construct(
@@ -189,6 +191,10 @@ class AdminArchetypeController extends AbstractAppController
     #[Route('/reorder', name: 'app_admin_archetype_reorder', methods: ['POST'])]
     public function reorder(Request $request, ArchetypeRepository $archetypeRepository): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         /** @var list<int> $ids */
         $ids = json_decode($request->getContent(), true) ?? [];
 
@@ -212,6 +218,10 @@ class AdminArchetypeController extends AbstractAppController
     #[Route('/{id}/variants/reorder', name: 'app_admin_archetype_variant_reorder', methods: ['POST'], requirements: ['id' => '\d+'])]
     public function reorderVariants(Request $request, Archetype $archetype, DeckRepository $deckRepository): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         /** @var list<int> $ids */
         $ids = json_decode($request->getContent(), true) ?? [];
 

--- a/src/Controller/AdminHomepageController.php
+++ b/src/Controller/AdminHomepageController.php
@@ -34,6 +34,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[IsGranted('ROLE_CMS_EDITOR')]
 class AdminHomepageController extends AbstractAppController
 {
+    use AjaxCsrfTrait;
+
     // Fallback when no channel is resolved (e.g. legacy null-channel layouts).
     // The editor and save endpoints normally use `Channel::getLocales()` so
     // each channel only edits the languages it actually serves.
@@ -101,6 +103,10 @@ class AdminHomepageController extends AbstractAppController
     #[Route('/save', name: 'app_admin_homepage_save', methods: ['POST'])]
     public function save(Request $request, ChannelRepository $channelRepository): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         /** @var array{blocks: list<array<string, mixed>>, translations: array<string, array<int|string, array<string, mixed>>>, channelCode?: string, ogImage?: string|null, meta?: array<string, array{title?: string|null, ogDescription?: string|null}>} $payload */
         $payload = json_decode((string) $request->getContent(), true);
 
@@ -159,6 +165,10 @@ class AdminHomepageController extends AbstractAppController
     #[Route('/preview', name: 'app_admin_homepage_preview', methods: ['POST'])]
     public function preview(Request $request, HomepageRenderer $homepageRenderer): Response
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         /** @var array{blocks: list<array<string, mixed>>, translations: array<string, array<int|string, array<string, mixed>>>} $payload */
         $payload = json_decode((string) $request->getContent(), true);
 

--- a/src/Controller/AdminMenuCategoryController.php
+++ b/src/Controller/AdminMenuCategoryController.php
@@ -36,6 +36,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[IsGranted('ROLE_CMS_EDITOR')]
 class AdminMenuCategoryController extends AbstractAppController
 {
+    use AjaxCsrfTrait;
+
     public function __construct(
         TranslatorInterface $translator,
         private readonly EntityManagerInterface $em,
@@ -76,6 +78,10 @@ class AdminMenuCategoryController extends AbstractAppController
     #[Route('/reorder', name: 'app_admin_menu_category_reorder', methods: ['POST'])]
     public function reorder(Request $request, MenuCategoryRepository $repository): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         /** @var list<int> $categoryIds */
         $categoryIds = json_decode((string) $request->getContent(), true);
         $repository->reorderCategories($categoryIds);

--- a/src/Controller/AdminPageController.php
+++ b/src/Controller/AdminPageController.php
@@ -40,6 +40,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[IsGranted('ROLE_CMS_EDITOR')]
 class AdminPageController extends AbstractAppController
 {
+    use AjaxCsrfTrait;
+
     private const int PER_PAGE_CATEGORY = 50;
 
     public function __construct(
@@ -141,6 +143,10 @@ class AdminPageController extends AbstractAppController
     #[Route('/reorder', name: 'app_admin_page_reorder', methods: ['POST'])]
     public function reorder(Request $request, PageRepository $pageRepository, MenuRuntime $menuRuntime): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         $payload = json_decode($request->getContent(), true);
 
         if (!\is_array($payload)) {

--- a/src/Controller/AdminStapleCardController.php
+++ b/src/Controller/AdminStapleCardController.php
@@ -38,6 +38,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[IsGranted('ROLE_ARCHETYPE_EDITOR')]
 class AdminStapleCardController extends AbstractAppController
 {
+    use AjaxCsrfTrait;
+
     public function __construct(
         TranslatorInterface $translator,
         private readonly EntityManagerInterface $entityManager,
@@ -167,6 +169,10 @@ class AdminStapleCardController extends AbstractAppController
     #[Route('/reorder/{bucket}', name: 'app_admin_staple_card_reorder', methods: ['POST'])]
     public function reorder(Request $request, string $bucket): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         if (!StapleCardBucket::isValid($bucket)) {
             return new JsonResponse(['ok' => false, 'error' => 'invalid_bucket'], 400);
         }

--- a/src/Controller/AjaxCsrfTrait.php
+++ b/src/Controller/AjaxCsrfTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Shared CSRF validation for authenticated AJAX/fetch endpoints.
+ *
+ * These endpoints receive JSON or multipart bodies that are decoded wholesale,
+ * so the token cannot live in the body. Instead the browser sends the shared
+ * per-session token (rendered as `<meta name="csrf-token">` in base.html.twig,
+ * token id `ajax`) via the `X-CSRF-Token` header, read by `assets/csrf.ts`.
+ *
+ * Intended for controllers extending {@see \Symfony\Bundle\FrameworkBundle\Controller\AbstractController},
+ * which provides `isCsrfTokenValid()`.
+ */
+trait AjaxCsrfTrait
+{
+    /**
+     * Returns a 403 JSON response when the AJAX CSRF token is missing or
+     * invalid, or null when the request is authentic.
+     */
+    private function invalidAjaxCsrfResponse(Request $request): ?JsonResponse
+    {
+        if ($this->isCsrfTokenValid('ajax', $request->headers->get('X-CSRF-Token', ''))) {
+            return null;
+        }
+
+        return new JsonResponse(['error' => 'Invalid CSRF token.'], Response::HTTP_FORBIDDEN);
+    }
+}

--- a/src/Controller/EditorUploadController.php
+++ b/src/Controller/EditorUploadController.php
@@ -34,6 +34,8 @@ use Symfony\Component\Uid\Uuid;
  */
 class EditorUploadController extends AbstractController
 {
+    use AjaxCsrfTrait;
+
     private const int MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
     private const int CACHE_MAX_AGE = 86400 * 30; // 30 days
 
@@ -53,6 +55,10 @@ class EditorUploadController extends AbstractController
     #[IsGranted(new Expression("is_granted('ROLE_CMS_EDITOR') or is_granted('ROLE_ARCHETYPE_EDITOR')"))]
     public function upload(Request $request): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         $file = $request->files->get('file');
 
         if (!$file instanceof UploadedFile) {

--- a/src/Controller/EventSyncController.php
+++ b/src/Controller/EventSyncController.php
@@ -28,10 +28,16 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  */
 class EventSyncController extends AbstractController
 {
+    use AjaxCsrfTrait;
+
     #[Route('/api/event/sync', name: 'app_event_sync', methods: ['POST'])]
     #[IsGranted('ROLE_ORGANIZER')]
     public function sync(Request $request, PokemonEventSyncService $syncService): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         /** @var array<string, mixed> $payload */
         $payload = json_decode($request->getContent(), true) ?? [];
         $tournamentId = isset($payload['tournamentId']) && \is_string($payload['tournamentId'])

--- a/src/Controller/NotificationController.php
+++ b/src/Controller/NotificationController.php
@@ -31,6 +31,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[IsGranted('ROLE_USER')]
 class NotificationController extends AbstractAppController
 {
+    use AjaxCsrfTrait;
+
     public function __construct(
         TranslatorInterface $translator,
         private readonly NotificationRepository $notificationRepository,
@@ -55,8 +57,12 @@ class NotificationController extends AbstractAppController
     }
 
     #[Route('/api/notifications/{id}/read', name: 'app_notification_api_mark_read', methods: ['POST'])]
-    public function apiMarkRead(Notification $notification): JsonResponse
+    public function apiMarkRead(Notification $notification, Request $request): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         /** @var User $user */
         $user = $this->getUser();
 
@@ -76,8 +82,12 @@ class NotificationController extends AbstractAppController
     }
 
     #[Route('/api/notifications/read-all', name: 'app_notification_api_mark_all_read', methods: ['POST'])]
-    public function apiMarkAllRead(): JsonResponse
+    public function apiMarkAllRead(Request $request): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         /** @var User $user */
         $user = $this->getUser();
 

--- a/src/Controller/OgImageBuilderController.php
+++ b/src/Controller/OgImageBuilderController.php
@@ -40,6 +40,8 @@ use Symfony\Component\Uid\Uuid;
 #[IsGranted(new Expression("is_granted('ROLE_CMS_EDITOR') or is_granted('ROLE_ARCHETYPE_EDITOR')"))]
 class OgImageBuilderController extends AbstractController
 {
+    use AjaxCsrfTrait;
+
     private const int MIN_CARDS = 2;
     private const int MAX_CARDS = 6;
 
@@ -65,6 +67,10 @@ class OgImageBuilderController extends AbstractController
     #[Route('/admin/og-image-builder/generate', name: 'app_admin_og_image_builder_generate', methods: ['POST'])]
     public function generate(Request $request): JsonResponse
     {
+        if ($response = $this->invalidAjaxCsrfResponse($request)) {
+            return $response;
+        }
+
         /** @var array{codes?: mixed} $payload */
         $payload = json_decode($request->getContent(), true) ?? [];
         $codes = $payload['codes'] ?? null;

--- a/src/Controller/SearchApiController.php
+++ b/src/Controller/SearchApiController.php
@@ -61,7 +61,11 @@ class SearchApiController extends AbstractController
 
             foreach ($items as $result) {
                 $group['items'][] = [
-                    'title' => strip_tags($result->title),
+                    // $result->title is pre-sanitised HTML (only <mark> tags are
+                    // real markup); strip them and decode entities back to plain
+                    // text for the JSON payload, which the navbar renders as a
+                    // React text node.
+                    'title' => html_entity_decode(strip_tags($result->title), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
                     'type' => $result->type,
                     'url' => $this->buildResultUrl($result, $locale, $urlGenerator),
                     'secondary' => $result->secondaryInfo,

--- a/src/Service/Search/SearchResult.php
+++ b/src/Service/Search/SearchResult.php
@@ -41,11 +41,37 @@ final readonly class SearchResult
 
         return new self(
             type: $type,
-            title: self::extractTitle($hit, $formatted),
-            excerpt: self::extractExcerpt($formatted, $type),
+            title: self::sanitizeHighlight(self::extractTitle($hit, $formatted)),
+            excerpt: self::sanitizeHighlight(self::extractExcerpt($formatted, $type)),
             slug: self::extractSlug($hit, $type),
             secondaryInfo: self::extractSecondaryInfo($hit, $type),
             archetypeSlug: \is_string($hit['archetypeSlug'] ?? null) ? $hit['archetypeSlug'] : null,
+        );
+    }
+
+    /**
+     * Escape a Meilisearch highlighted snippet for safe rendering as HTML.
+     *
+     * The results template prints `title`/`excerpt` with the `|raw` filter to
+     * keep Meilisearch's `<mark>` highlight tags. Meilisearch returns the rest
+     * of the matched field verbatim, so any HTML in the underlying value (for
+     * example a user-chosen deck name) would otherwise render as live markup —
+     * a stored XSS vector. We escape the whole snippet, then restore only the
+     * highlight tags, neutralising every other tag while keeping highlighting.
+     *
+     * @see docs/features.md F18.2 — Global search results page
+     */
+    private static function sanitizeHighlight(string $value): string
+    {
+        $escaped = htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+
+        return str_replace(
+            [
+                htmlspecialchars(SearchService::HIGHLIGHT_PRE_TAG, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+                htmlspecialchars(SearchService::HIGHLIGHT_POST_TAG, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+            ],
+            [SearchService::HIGHLIGHT_PRE_TAG, SearchService::HIGHLIGHT_POST_TAG],
+            $escaped,
         );
     }
 

--- a/src/Service/Search/SearchService.php
+++ b/src/Service/Search/SearchService.php
@@ -28,6 +28,16 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  */
 class SearchService
 {
+    /**
+     * Tags Meilisearch wraps around matched terms in `_formatted` fields.
+     *
+     * These are the only HTML that {@see SearchResult::sanitizeHighlight()} is
+     * allowed to preserve when escaping highlighted snippets, so both sides of
+     * that contract must reference these constants rather than literals.
+     */
+    public const string HIGHLIGHT_PRE_TAG = '<mark>';
+    public const string HIGHLIGHT_POST_TAG = '</mark>';
+
     private const int QUICK_SEARCH_LIMIT = 3;
     private const int FULL_SEARCH_LIMIT = 20;
     private const float RANKING_SCORE_THRESHOLD = 0.3;
@@ -168,8 +178,8 @@ class SearchService
             'limit' => $limit,
             'offset' => $offset,
             'attributesToHighlight' => ['*'],
-            'highlightPreTag' => '<mark>',
-            'highlightPostTag' => '</mark>',
+            'highlightPreTag' => self::HIGHLIGHT_PRE_TAG,
+            'highlightPostTag' => self::HIGHLIGHT_POST_TAG,
             'rankingScoreThreshold' => self::RANKING_SCORE_THRESHOLD,
         ];
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,6 +11,12 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        {# CSRF token for authenticated AJAX/fetch endpoints. Read by assets/csrf.ts and
+         # sent as the X-CSRF-Token header; validated server-side with token id 'ajax'.
+         # Only rendered for logged-in users so anonymous (cacheable) pages stay identical. #}
+        {% if app.user %}
+            <meta name="csrf-token" content="{{ csrf_token('ajax') }}">
+        {% endif %}
         {{ include('_partials/theme_color_scheme_script.html.twig') }}
         <title>{% block title %}{{ channel_param('brand_name', 'Expanded Decks') }}{% endblock %}</title>
         {% if channel_theme() == 'expandedtalks' %}

--- a/templates/search/results.html.twig
+++ b/templates/search/results.html.twig
@@ -100,6 +100,8 @@
                                 <a href="{{ resultUrl }}" class="list-group-item list-group-item-action">
                                     <div class="d-flex justify-content-between align-items-start">
                                         <div>
+                                            {# title/excerpt are pre-sanitised in SearchResult::sanitizeHighlight — #}
+                                            {# only Meilisearch <mark> highlight tags survive as HTML, so |raw is safe here. #}
                                             <h6 class="mb-1">{{ result.title|raw }}</h6>
                                             {% if result.excerpt %}
                                                 <p class="mb-1 text-secondary small">{{ result.excerpt|raw }}</p>

--- a/tests/Controller/EditorUploadControllerTest.php
+++ b/tests/Controller/EditorUploadControllerTest.php
@@ -159,22 +159,44 @@ final class EditorUploadControllerTest extends TestCase
         return (string) $content;
     }
 
+    public function testUploadRejectsInvalidCsrfToken(): void
+    {
+        $storage = $this->createStub(FilesystemOperator::class);
+        $controller = new EditorUploadController($storage);
+        $controller->setContainer($this->createContainerWithRouter(csrfValid: false));
+
+        $file = $this->createTempUploadedFile('test.png', 'image/png', $this->createMinimalPng());
+        $request = new Request(files: ['file' => $file]);
+        $response = $controller->upload($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('Invalid CSRF token', (string) $response->getContent());
+    }
+
     /**
-     * Creates a minimal DI container with a router stub for AbstractController::generateUrl.
+     * Creates a minimal DI container with a router stub for AbstractController::generateUrl
+     * and a CSRF token manager stub whose validity is controlled by $csrfValid.
      */
-    private function createContainerWithRouter(): \Psr\Container\ContainerInterface
+    private function createContainerWithRouter(bool $csrfValid = true): \Psr\Container\ContainerInterface
     {
         $router = $this->createStub(\Symfony\Component\Routing\RouterInterface::class);
         $router->method('generate')->willReturnCallback(
             static fn (string $route, array $parameters): string => '/api/editor/image/'.$parameters['filename'],
         );
 
+        $tokenManager = $this->createStub(\Symfony\Component\Security\Csrf\CsrfTokenManagerInterface::class);
+        $tokenManager->method('isTokenValid')->willReturn($csrfValid);
+
         $container = $this->createStub(\Psr\Container\ContainerInterface::class);
         $container->method('has')->willReturnCallback(
-            static fn (string $id): bool => 'router' === $id,
+            static fn (string $id): bool => \in_array($id, ['router', 'security.csrf.token_manager'], true),
         );
         $container->method('get')->willReturnCallback(
-            static fn (string $id) => 'router' === $id ? $router : null,
+            static fn (string $id) => match ($id) {
+                'router' => $router,
+                'security.csrf.token_manager' => $tokenManager,
+                default => null,
+            },
         );
 
         return $container;

--- a/tests/Form/DataTransformer/KeyValueTransformerTest.php
+++ b/tests/Form/DataTransformer/KeyValueTransformerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Form\DataTransformer;
+
+use App\Form\DataTransformer\KeyValueTransformer;
+use PHPUnit\Framework\TestCase;
+
+class KeyValueTransformerTest extends TestCase
+{
+    public function testTransformMapsAssociativeArrayToPairs(): void
+    {
+        $transformer = new KeyValueTransformer();
+
+        self::assertSame(
+            [
+                ['key' => 'brand_name', 'value' => 'Expanded Decks'],
+                ['key' => 'tagline', 'value' => 'Play more'],
+            ],
+            $transformer->transform(['brand_name' => 'Expanded Decks', 'tagline' => 'Play more']),
+        );
+    }
+
+    public function testTransformReturnsEmptyListForEmptyMap(): void
+    {
+        $transformer = new KeyValueTransformer();
+
+        self::assertSame([], $transformer->transform([]));
+    }
+
+    public function testReverseTransformMapsPairsBackToAssociativeArray(): void
+    {
+        $transformer = new KeyValueTransformer();
+
+        self::assertSame(
+            ['brand_name' => 'Expanded Decks', 'tagline' => 'Play more'],
+            $transformer->reverseTransform([
+                ['key' => 'brand_name', 'value' => 'Expanded Decks'],
+                ['key' => 'tagline', 'value' => 'Play more'],
+            ]),
+        );
+    }
+
+    public function testReverseTransformTrimsKeysAndSkipsBlankKeys(): void
+    {
+        $transformer = new KeyValueTransformer();
+
+        self::assertSame(
+            ['brand_name' => 'Expanded Decks'],
+            $transformer->reverseTransform([
+                ['key' => '  brand_name  ', 'value' => 'Expanded Decks'],
+                ['key' => '   ', 'value' => 'dropped — blank key'],
+            ]),
+        );
+    }
+
+    public function testReverseTransformSkipsNonArrayEntriesAndMissingKeys(): void
+    {
+        $transformer = new KeyValueTransformer();
+
+        self::assertSame(
+            ['ok' => 'kept'],
+            $transformer->reverseTransform([
+                'not-an-array',
+                ['value' => 'no key present'],
+                ['key' => 'ok', 'value' => 'kept'],
+            ]),
+        );
+    }
+
+    public function testReverseTransformReturnsEmptyArrayWhenValueIsNotArray(): void
+    {
+        $transformer = new KeyValueTransformer();
+
+        self::assertSame([], $transformer->reverseTransform(null));
+    }
+}

--- a/tests/Functional/AbstractFunctionalTest.php
+++ b/tests/Functional/AbstractFunctionalTest.php
@@ -70,6 +70,39 @@ abstract class AbstractFunctionalTest extends WebTestCase
         ]);
     }
 
+    /**
+     * The shared `ajax` CSRF token, to send as the X-CSRF-Token header on POSTs
+     * to authenticated AJAX endpoints guarded by {@see \App\Controller\AjaxCsrfTrait}.
+     * Requires a session — call after a GET (e.g. loginAs()).
+     */
+    protected function ajaxCsrfToken(): string
+    {
+        $session = $this->client->getSession();
+        $session->start();
+
+        /** @var \Symfony\Component\HttpFoundation\RequestStack $requestStack */
+        $requestStack = static::getContainer()->get('request_stack');
+
+        $syntheticRequest = new \Symfony\Component\HttpFoundation\Request();
+        $syntheticRequest->setSession($session);
+        $requestStack->push($syntheticRequest);
+
+        try {
+            /** @var \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface $tokenManager */
+            $tokenManager = static::getContainer()->get('security.csrf.token_manager');
+
+            $token = $tokenManager->getToken('ajax')->getValue();
+
+            // Persist the token into the client's session storage so the token
+            // survives to the next request, where the controller validates it.
+            $session->save();
+
+            return $token;
+        } finally {
+            $requestStack->pop();
+        }
+    }
+
     private function initializeDatabase(): void
     {
         /** @var EntityManagerInterface $em */

--- a/tests/Functional/AdminArchetypeControllerTest.php
+++ b/tests/Functional/AdminArchetypeControllerTest.php
@@ -798,4 +798,30 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
 
         self::fail(\sprintf('Variant "%s" not found for archetype "%s".', $name, $archetype->getName()));
     }
+
+    public function testReorderRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('POST', '/admin/archetypes/reorder', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '[]');
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('Invalid CSRF token', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testReorderVariantsRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $archetype = $this->getArchetype('Regidrago');
+
+        $this->client->request('POST', '/admin/archetypes/'.$archetype->getId().'/variants/reorder', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '[]');
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('Invalid CSRF token', (string) $this->client->getResponse()->getContent());
+    }
 }

--- a/tests/Functional/AdminArchetypeControllerTest.php
+++ b/tests/Functional/AdminArchetypeControllerTest.php
@@ -511,6 +511,7 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/archetypes/reorder', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], (string) json_encode($reversed));
 
         self::assertResponseIsSuccessful();
@@ -548,6 +549,7 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/archetypes/'.$archetype->getId().'/variants/reorder', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], (string) json_encode($reversed));
 
         self::assertResponseIsSuccessful();
@@ -578,6 +580,7 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/archetypes/'.$archetype->getId().'/variants/reorder', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], (string) json_encode($reversed));
 
         self::assertResponseIsSuccessful();
@@ -610,6 +613,7 @@ class AdminArchetypeControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/archetypes/reorder', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], '[1,2,3]');
 
         self::assertResponseStatusCodeSame(403);

--- a/tests/Functional/AdminHomepageControllerTest.php
+++ b/tests/Functional/AdminHomepageControllerTest.php
@@ -227,4 +227,28 @@ class AdminHomepageControllerTest extends AbstractFunctionalTest
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('.hero-pokemon', 'Preview Hero');
     }
+
+    public function testSaveRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('POST', '/admin/homepage/save', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], (string) json_encode(['blocks' => [], 'translations' => ['en' => [], 'fr' => []]]));
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('Invalid CSRF token', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testPreviewRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('POST', '/admin/homepage/preview', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], (string) json_encode(['blocks' => [], 'translations' => ['en' => [], 'fr' => []]]));
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('Invalid CSRF token', (string) $this->client->getResponse()->getContent());
+    }
 }

--- a/tests/Functional/AdminHomepageControllerTest.php
+++ b/tests/Functional/AdminHomepageControllerTest.php
@@ -39,6 +39,7 @@ class AdminHomepageControllerTest extends AbstractFunctionalTest
     {
         $this->client->request('POST', '/admin/homepage/save', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], json_encode(['blocks' => [], 'translations' => ['en' => [], 'fr' => []]]));
 
         self::assertResponseRedirects();
@@ -65,6 +66,7 @@ class AdminHomepageControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/homepage/save', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], $payload);
 
         self::assertResponseIsSuccessful();
@@ -89,6 +91,7 @@ class AdminHomepageControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/homepage/save', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], $payload);
 
         self::assertResponseIsSuccessful();
@@ -130,6 +133,7 @@ class AdminHomepageControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/homepage/save', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], $payload);
 
         self::assertResponseIsSuccessful();
@@ -172,6 +176,7 @@ class AdminHomepageControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/homepage/save', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], $payload);
 
         self::assertResponseIsSuccessful();
@@ -192,6 +197,7 @@ class AdminHomepageControllerTest extends AbstractFunctionalTest
     {
         $this->client->request('POST', '/admin/homepage/preview', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], json_encode(['blocks' => [], 'translations' => ['en' => [], 'fr' => []]]));
 
         self::assertResponseRedirects();
@@ -215,6 +221,7 @@ class AdminHomepageControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/homepage/preview', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], $payload);
 
         self::assertResponseIsSuccessful();

--- a/tests/Functional/AdminMenuCategoryControllerCoverageTest.php
+++ b/tests/Functional/AdminMenuCategoryControllerCoverageTest.php
@@ -299,4 +299,21 @@ class AdminMenuCategoryControllerCoverageTest extends AbstractFunctionalTest
 
         return $category;
     }
+
+    public function testReorderRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request(
+            'POST',
+            '/admin/menu-categories/reorder',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '[]',
+        );
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('Invalid CSRF token', (string) $this->client->getResponse()->getContent());
+    }
 }

--- a/tests/Functional/AdminMenuCategoryControllerCoverageTest.php
+++ b/tests/Functional/AdminMenuCategoryControllerCoverageTest.php
@@ -67,7 +67,7 @@ class AdminMenuCategoryControllerCoverageTest extends AbstractFunctionalTest
             '/admin/menu-categories/reorder',
             [],
             [],
-            ['CONTENT_TYPE' => 'application/json'],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken()],
             (string) json_encode([$rules->getId(), $news->getId()]),
         );
 

--- a/tests/Functional/AdminPageControllerCoverageTest.php
+++ b/tests/Functional/AdminPageControllerCoverageTest.php
@@ -335,4 +335,21 @@ class AdminPageControllerCoverageTest extends AbstractFunctionalTest
 
         return $category;
     }
+
+    public function testReorderRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request(
+            'POST',
+            '/admin/pages/reorder',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '[]',
+        );
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('Invalid CSRF token', (string) $this->client->getResponse()->getContent());
+    }
 }

--- a/tests/Functional/AdminPageControllerCoverageTest.php
+++ b/tests/Functional/AdminPageControllerCoverageTest.php
@@ -80,7 +80,7 @@ class AdminPageControllerCoverageTest extends AbstractFunctionalTest
             '/admin/pages/reorder',
             [],
             [],
-            ['CONTENT_TYPE' => 'application/json'],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken()],
             (string) json_encode([$welcome->getId()]),
         );
 
@@ -100,7 +100,7 @@ class AdminPageControllerCoverageTest extends AbstractFunctionalTest
             '/admin/pages/reorder',
             [],
             [],
-            ['CONTENT_TYPE' => 'application/json'],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken()],
             '"not-an-array"',
         );
 

--- a/tests/Functional/AdminStapleCardControllerTest.php
+++ b/tests/Functional/AdminStapleCardControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+/**
+ * @see docs/features.md F6.15 — Staple cards
+ */
+class AdminStapleCardControllerTest extends AbstractFunctionalTest
+{
+    public function testReorderRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('POST', '/admin/staple-cards/reorder/pokemon', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '[]');
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('Invalid CSRF token', (string) $this->client->getResponse()->getContent());
+    }
+}

--- a/tests/Functional/EventSyncControllerTest.php
+++ b/tests/Functional/EventSyncControllerTest.php
@@ -26,6 +26,7 @@ class EventSyncControllerTest extends AbstractFunctionalTest
     {
         $this->client->request('POST', '/api/event/sync', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], json_encode(['tournamentId' => 'test-123']));
 
         self::assertResponseRedirects('/login');
@@ -38,6 +39,7 @@ class EventSyncControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/api/event/sync', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], json_encode(['tournamentId' => 'test-123']));
 
         self::assertResponseStatusCodeSame(403);
@@ -63,6 +65,7 @@ class EventSyncControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/api/event/sync', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], json_encode(['tournamentId' => 'test-123']));
 
         self::assertResponseIsSuccessful();
@@ -90,6 +93,7 @@ class EventSyncControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/api/event/sync', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], json_encode(['tournamentId' => '']));
 
         self::assertResponseStatusCodeSame(400);
@@ -113,6 +117,7 @@ class EventSyncControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/api/event/sync', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], json_encode(['tournamentId' => 'nonexistent']));
 
         self::assertResponseStatusCodeSame(404);
@@ -136,6 +141,7 @@ class EventSyncControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/api/event/sync', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], json_encode(['tournamentId' => 'broken']));
 
         self::assertResponseStatusCodeSame(502);
@@ -159,6 +165,7 @@ class EventSyncControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/api/event/sync', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], json_encode([]));
 
         self::assertResponseStatusCodeSame(400);

--- a/tests/Functional/EventSyncControllerTest.php
+++ b/tests/Functional/EventSyncControllerTest.php
@@ -175,4 +175,16 @@ class EventSyncControllerTest extends AbstractFunctionalTest
 
         self::assertSame('missing_id', $data['code']);
     }
+
+    public function testSyncRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('organizer@example.com');
+
+        $this->client->request('POST', '/api/event/sync', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['tournamentId' => 'test-123']));
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('Invalid CSRF token', (string) $this->client->getResponse()->getContent());
+    }
 }

--- a/tests/Functional/NotificationControllerTest.php
+++ b/tests/Functional/NotificationControllerTest.php
@@ -95,7 +95,9 @@ class NotificationControllerTest extends AbstractFunctionalTest
         $notification = $this->createNotification($em, $user, 'To be read');
         $em->flush();
 
-        $this->client->request('POST', '/api/notifications/'.$notification->getId().'/read');
+        $this->client->request('POST', '/api/notifications/'.$notification->getId().'/read', [], [], [
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
+        ]);
 
         self::assertResponseIsSuccessful();
         $data = json_decode($this->client->getResponse()->getContent(), true);
@@ -116,7 +118,9 @@ class NotificationControllerTest extends AbstractFunctionalTest
         $notification = $this->createNotification($em, $admin, 'Admin notification');
         $em->flush();
 
-        $this->client->request('POST', '/api/notifications/'.$notification->getId().'/read');
+        $this->client->request('POST', '/api/notifications/'.$notification->getId().'/read', [], [], [
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
+        ]);
 
         self::assertResponseStatusCodeSame(403);
     }
@@ -133,12 +137,42 @@ class NotificationControllerTest extends AbstractFunctionalTest
         $this->createNotification($em, $user, 'Notif 2');
         $em->flush();
 
-        $this->client->request('POST', '/api/notifications/read-all');
+        $this->client->request('POST', '/api/notifications/read-all', [], [], [
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
+        ]);
 
         self::assertResponseIsSuccessful();
         $data = json_decode($this->client->getResponse()->getContent(), true);
 
         self::assertSame(0, $data['unreadCount']);
+    }
+
+    public function testApiMarkReadRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUser('admin@example.com');
+
+        $notification = $this->createNotification($em, $user, 'Own notification');
+        $em->flush();
+
+        // No X-CSRF-Token header: the authenticated request must be rejected.
+        $this->client->request('POST', '/api/notifications/'.$notification->getId().'/read');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testApiMarkAllReadRejectsInvalidCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('POST', '/api/notifications/read-all', [], [], [
+            'HTTP_X_CSRF_TOKEN' => 'not-a-valid-token',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
     }
 
     public function testListPageRequiresAuthentication(): void

--- a/tests/Functional/OgImageBuilderControllerTest.php
+++ b/tests/Functional/OgImageBuilderControllerTest.php
@@ -48,6 +48,7 @@ class OgImageBuilderControllerTest extends AbstractFunctionalTest
         $this->loginAs('borrower@example.com');
         $this->client->request('POST', '/admin/og-image-builder/generate', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], (string) json_encode(['codes' => ['LOR-093', 'LOR-094']]));
 
         self::assertResponseStatusCodeSame(403);
@@ -70,6 +71,7 @@ class OgImageBuilderControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/og-image-builder/generate', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], (string) json_encode(['codes' => ['LOR-093', 'XXX-999']]));
 
         self::assertResponseIsSuccessful();
@@ -95,6 +97,7 @@ class OgImageBuilderControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/og-image-builder/generate', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], (string) json_encode(['codes' => ['XXX-998', 'XXX-999']]));
 
         self::assertResponseStatusCodeSame(422);
@@ -112,6 +115,7 @@ class OgImageBuilderControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/og-image-builder/generate', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], (string) json_encode(['codes' => ['LOR-093']]));
 
         self::assertResponseStatusCodeSame(422);
@@ -129,6 +133,7 @@ class OgImageBuilderControllerTest extends AbstractFunctionalTest
         $codes = array_map(static fn (int $index): string => 'LOR-09'.$index, range(0, 6));
         $this->client->request('POST', '/admin/og-image-builder/generate', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], (string) json_encode(['codes' => $codes]));
 
         self::assertResponseStatusCodeSame(422);
@@ -140,6 +145,7 @@ class OgImageBuilderControllerTest extends AbstractFunctionalTest
 
         $this->client->request('POST', '/admin/og-image-builder/generate', [], [], [
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => $this->ajaxCsrfToken(),
         ], (string) json_encode(['codes' => 'not-an-array']));
 
         self::assertResponseStatusCodeSame(400);

--- a/tests/Functional/OgImageBuilderControllerTest.php
+++ b/tests/Functional/OgImageBuilderControllerTest.php
@@ -174,4 +174,16 @@ class OgImageBuilderControllerTest extends AbstractFunctionalTest
 
         return $data;
     }
+
+    public function testGenerateRejectsMissingCsrfToken(): void
+    {
+        $this->loginAs('admin@example.com');
+
+        $this->client->request('POST', '/admin/og-image-builder/generate', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], (string) json_encode(['codes' => ['LOR-093']]));
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('Invalid CSRF token', (string) $this->client->getResponse()->getContent());
+    }
 }

--- a/tests/Service/Search/SearchResultTest.php
+++ b/tests/Service/Search/SearchResultTest.php
@@ -171,6 +171,80 @@ class SearchResultTest extends TestCase
         self::assertSame('unknown', $result->type);
     }
 
+    public function testFromHitNeutralisesHtmlInTitle(): void
+    {
+        $hit = [
+            'type' => 'deck',
+            'name' => '<img src=x onerror=alert(1)> My <mark>Regidrago</mark>',
+            'shortTag' => 'ABC123',
+            '_formatted' => [
+                'name' => '<img src=x onerror=alert(1)> My <mark>Regidrago</mark>',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        // The attacker <img> tag is escaped; only the <mark> highlight survives as HTML.
+        self::assertStringNotContainsString('<img', $result->title);
+        self::assertStringContainsString('&lt;img src=x onerror=alert(1)&gt;', $result->title);
+        self::assertStringContainsString('<mark>Regidrago</mark>', $result->title);
+    }
+
+    public function testFromHitNeutralisesHtmlInExcerpt(): void
+    {
+        $hit = [
+            'type' => 'page',
+            'title' => 'Payload',
+            'slug' => 'payload',
+            'content' => '<script>alert(1)</script>',
+            '_formatted' => [
+                'title' => 'Payload',
+                'content' => 'Intro <mark>match</mark> <script>alert(1)</script>',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertStringNotContainsString('<script>', $result->excerpt);
+        self::assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $result->excerpt);
+        self::assertStringContainsString('<mark>match</mark>', $result->excerpt);
+    }
+
+    public function testFromHitEscapesAmpersandsAndQuotes(): void
+    {
+        $hit = [
+            'type' => 'deck',
+            'name' => 'Fire & Ice "Deck"',
+            'shortTag' => 'DEF456',
+            '_formatted' => [
+                'name' => 'Fire & Ice "Deck"',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        self::assertStringContainsString('Fire &amp; Ice', $result->title);
+        self::assertStringContainsString('&quot;Deck&quot;', $result->title);
+    }
+
+    public function testFromHitLeavesBenignHighlightUnchanged(): void
+    {
+        $hit = [
+            'type' => 'archetype',
+            'name' => 'Regidrago',
+            'slug' => 'regidrago',
+            '_formatted' => [
+                'name' => '<mark>Regidrago</mark>',
+                'description' => 'A powerful <mark>dragon</mark> archetype.',
+            ],
+        ];
+
+        $result = SearchResult::fromHit($hit);
+
+        // No dangerous characters means the highlighted snippet is untouched.
+        self::assertSame('<mark>Regidrago</mark>', $result->title);
+    }
+
     public function testExcerptTruncatesLongContent(): void
     {
         $longText = str_repeat('word ', 100);

--- a/tests/Service/StapleCardImageResolverTest.php
+++ b/tests/Service/StapleCardImageResolverTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Expanded Decks project.
+ *
+ * (c) Expanded Decks contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service;
+
+use App\Entity\CardPrinting;
+use App\Entity\StapleCard;
+use App\Entity\StapleCardPrinting;
+use App\Entity\TcgdexCard;
+use App\Entity\TcgdexSerie;
+use App\Entity\TcgdexSet;
+use App\Repository\TcgdexSetRepository;
+use App\Service\StapleCardImageResolver;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see docs/features.md F6.15 — Staple cards
+ */
+class StapleCardImageResolverTest extends TestCase
+{
+    public function testReturnsNullWhenStapleHasNoRepresentativeAndNoPrintings(): void
+    {
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertNull($resolver->resolveForStaple(new StapleCard()));
+    }
+
+    public function testRepresentativePrintingDirectImageUrlWins(): void
+    {
+        $printing = $this->buildCardPrinting(imageUrl: 'https://images.example.com/foo.png');
+
+        $staple = new StapleCard();
+        $staple->setRepresentativePrinting($printing);
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.example.com/foo.png',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testRepresentativePrintingDirectImageUrlIsNormalizedForTcgdexCdn(): void
+    {
+        $printing = $this->buildCardPrinting(
+            imageUrl: 'https://assets.tcgdex.net/en/sm/sm3.5/7/high.webp',
+        );
+
+        $staple = new StapleCard();
+        $staple->setRepresentativePrinting($printing);
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        // Dotted set ID gets stripped to match TCGdex CDN paths.
+        self::assertSame(
+            'https://assets.tcgdex.net/en/sm/sm35/7/high.webp',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testRepresentativePrintingFallsThroughToTcgdexCdnFromTcgdexCard(): void
+    {
+        $printing = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: $this->buildTcgdexCard('sm', 'sm11.5', '42'),
+        );
+
+        $staple = new StapleCard();
+        $staple->setRepresentativePrinting($printing);
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/fr/sm/sm115/42/high.webp',
+            $resolver->resolveForStaple($staple, 'fr'),
+        );
+    }
+
+    public function testRepresentativePrintingFallsThroughToTcgdexCdnFromParsedTcgdexId(): void
+    {
+        $printing = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: null,
+            tcgdexId: 'swsh4-100',
+        );
+
+        $staple = new StapleCard();
+        $staple->setRepresentativePrinting($printing);
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/en/swsh/swsh4/100/high.webp',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testRepresentativePrintingFallsThroughToPokemontcgioWhenSerieGuessFails(): void
+    {
+        // Set ID prefix doesn't match any guessable serie -> CDN is null,
+        // PokemonTCG.io takes over.
+        $printing = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: null,
+            tcgdexId: 'mc1-3',
+        );
+
+        $staple = new StapleCard();
+        $staple->setRepresentativePrinting($printing);
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.pokemontcg.io/mc1/3_hires.png',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testRepresentativePrintingFinalFallbackUsesUpstreamSetCodeViaTcgdexSet(): void
+    {
+        // No dash -> parseTcgdexId returns null -> CDN + pokemontcg.io fail,
+        // so the resolver falls back to the upstream set-code lookup.
+        $printingNoTcgdex = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: null,
+            tcgdexId: 'nodash',
+        );
+
+        $staple = new StapleCard();
+        $staple->setRepresentativePrinting($printingNoTcgdex);
+        $staple->addPrinting($this->buildStaplePrinting('LOT', '90', $printingNoTcgdex));
+
+        $set = $this->buildTcgdexSet('sm', 'sm11.5');
+        $resolver = new StapleCardImageResolver($this->buildSetRepository($set));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/en/sm/sm115/90/high.webp',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testRepresentativePrintingFailsThenWalksChildPrintingsByRarity(): void
+    {
+        // Representative resolves to nothing.
+        $representative = $this->buildCardPrinting(
+            imageUrl: null,
+            tcgdexCard: null,
+            tcgdexId: 'nodash',
+        );
+
+        // Two child printings: high-rarity tier first in collection, but the
+        // resolver should pick the lowest rarity tier.
+        $rare = $this->buildCardPrinting(
+            imageUrl: 'https://images.example.com/rare.png',
+            rarityTier: 5,
+        );
+        $common = $this->buildCardPrinting(
+            imageUrl: 'https://images.example.com/common.png',
+            rarityTier: 1,
+        );
+
+        $staple = new StapleCard();
+        $staple->setRepresentativePrinting($representative);
+        $staple->addPrinting($this->buildStaplePrinting('LOT', '90', $rare));
+        $staple->addPrinting($this->buildStaplePrinting('LOT', '91', $common));
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.example.com/common.png',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testChildWithoutCardPrintingFallsBackToUpstreamSetCode(): void
+    {
+        $set = $this->buildTcgdexSet('xy', 'xy7');
+
+        $staple = new StapleCard();
+        // StapleCardPrinting with null cardPrinting -> directly uses setCode lookup.
+        $staple->addPrinting($this->buildStaplePrinting('PHF', '99', null));
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository($set));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/en/xy/xy7/99/high.webp',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testChildWithoutCardPrintingReturnsNullWhenSetCodeUnknown(): void
+    {
+        $staple = new StapleCard();
+        $staple->addPrinting($this->buildStaplePrinting('UNKNOWN', '1', null));
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertNull($resolver->resolveForStaple($staple));
+    }
+
+    public function testNullPrintingsSortedAfterPrintingsWithCardPrintingByMaxIntTier(): void
+    {
+        // A child without CardPrinting has rarity tier PHP_INT_MAX in the sort,
+        // so a child with a CardPrinting wins even when its tier is the default 6.
+        $rare = $this->buildCardPrinting(
+            imageUrl: 'https://images.example.com/rare.png',
+            rarityTier: 6,
+        );
+
+        $staple = new StapleCard();
+        $staple->addPrinting($this->buildStaplePrinting('LOT', '90', null));
+        $staple->addPrinting($this->buildStaplePrinting('LOT', '91', $rare));
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.example.com/rare.png',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testNonTcgdexCdnImageUrlIsReturnedUnchanged(): void
+    {
+        // normalizeTcgdexCdnUrl only mutates URLs starting with the TCGdex CDN base.
+        $printing = $this->buildCardPrinting(
+            imageUrl: 'https://images.pokemontcg.io/sm115/42_hires.png',
+        );
+
+        $staple = new StapleCard();
+        $staple->setRepresentativePrinting($printing);
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://images.pokemontcg.io/sm115/42_hires.png',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testEmptyImageUrlSkipsDirectAndFallsThrough(): void
+    {
+        $printing = $this->buildCardPrinting(
+            imageUrl: '',
+            tcgdexCard: $this->buildTcgdexCard('bw', 'bw1', '10'),
+        );
+
+        $staple = new StapleCard();
+        $staple->setRepresentativePrinting($printing);
+
+        $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+        self::assertSame(
+            'https://assets.tcgdex.net/en/bw/bw1/10/high.webp',
+            $resolver->resolveForStaple($staple),
+        );
+    }
+
+    public function testGuessSerieIdSupportsAllKnownPrefixes(): void
+    {
+        $cases = [
+            ['sv8-1', 'sv', 'sv8'],
+            ['swsh10-2', 'swsh', 'swsh10'],
+            ['sm9-3', 'sm', 'sm9'],
+            ['xy3-4', 'xy', 'xy3'],
+            ['bw5-6', 'bw', 'bw5'],
+        ];
+
+        foreach ($cases as [$tcgdexId, $expectedSerie, $expectedSet]) {
+            $printing = $this->buildCardPrinting(
+                imageUrl: null,
+                tcgdexCard: null,
+                tcgdexId: $tcgdexId,
+            );
+
+            $staple = new StapleCard();
+            $staple->setRepresentativePrinting($printing);
+
+            $resolver = new StapleCardImageResolver($this->buildSetRepository(null));
+
+            $expected = \sprintf(
+                'https://assets.tcgdex.net/en/%s/%s/%s/high.webp',
+                $expectedSerie,
+                $expectedSet,
+                explode('-', $tcgdexId)[1],
+            );
+
+            self::assertSame($expected, $resolver->resolveForStaple($staple), "tcgdexId $tcgdexId");
+        }
+    }
+
+    private function buildSetRepository(?TcgdexSet $set): TcgdexSetRepository
+    {
+        $repository = $this->createStub(TcgdexSetRepository::class);
+        $repository->method('findByPtcgCode')->willReturn($set);
+
+        return $repository;
+    }
+
+    private function buildCardPrinting(
+        ?string $imageUrl = null,
+        ?TcgdexCard $tcgdexCard = null,
+        string $tcgdexId = 'sm1-1',
+        int $rarityTier = 6,
+    ): CardPrinting {
+        $printing = $this->createStub(CardPrinting::class);
+        $printing->method('getImageUrl')->willReturn($imageUrl);
+        $printing->method('getTcgdexCard')->willReturn($tcgdexCard);
+        $printing->method('getTcgdexId')->willReturn($tcgdexId);
+        $printing->method('getRarityTier')->willReturn($rarityTier);
+
+        return $printing;
+    }
+
+    private function buildTcgdexCard(string $serieId, string $setId, string $localId): TcgdexCard
+    {
+        $set = $this->buildTcgdexSet($serieId, $setId);
+
+        $tcgdexCard = $this->createStub(TcgdexCard::class);
+        $tcgdexCard->method('getSet')->willReturn($set);
+        $tcgdexCard->method('getLocalId')->willReturn($localId);
+
+        return $tcgdexCard;
+    }
+
+    private function buildTcgdexSet(string $serieId, string $setId): TcgdexSet
+    {
+        $serie = $this->createStub(TcgdexSerie::class);
+        $serie->method('getId')->willReturn($serieId);
+
+        $set = $this->createStub(TcgdexSet::class);
+        $set->method('getId')->willReturn($setId);
+        $set->method('getSerie')->willReturn($serie);
+
+        return $set;
+    }
+
+    private function buildStaplePrinting(string $setCode, string $cardNumber, ?CardPrinting $cardPrinting): StapleCardPrinting
+    {
+        $printing = new StapleCardPrinting();
+        $printing->setSetCode($setCode);
+        $printing->setCardNumber($cardNumber);
+        $printing->setCardPrinting($cardPrinting);
+
+        return $printing;
+    }
+}


### PR DESCRIPTION
## Summary

Release **1.14.9** — patch release with security hardening from a source-level audit, plus test-coverage backfill. See `docs/changelog.md` for full details.

### Bug Fixes
- **Stored XSS in search results** ([#729](https://github.com/jbourdin/expandedDecks/pull/729)) — search titles/excerpts are now HTML-escaped before rendering, preserving only Meilisearch `<mark>` highlights.
- **CSRF on authenticated AJAX endpoints** ([#730](https://github.com/jbourdin/expandedDecks/pull/730)) — shared per-session token + `X-CSRF-Token` header validated by `AjaxCsrfTrait`.

### Testing & Quality
- CSRF enforcement (403) tests across every guarded endpoint ([#730](https://github.com/jbourdin/expandedDecks/pull/730)).
- Coverage backfill for `StapleCardImageResolver` (0.95% → covered) and `KeyValueTransformer` ([#731](https://github.com/jbourdin/expandedDecks/pull/731)).