### PR TITLE
:bug: fix: repair banned-card announcement links

### DIFF
--- a/scripts/backfill_banned_card_source_urls.sql
+++ b/scripts/backfill_banned_card_source_urls.sql
@@ -1,0 +1,122 @@
+-- Converge banned_card.source_url on the correct announcement link per ban wave.
+--
+-- Two separate problems are fixed here.
+--
+-- 1. Production still links 17 bans to the generic pokemon.com banned-card
+--    list page instead of the announcement that introduced them. An older
+--    BannedCardsSyncService stamped every ban it provisioned with that generic
+--    URL. Commit 01e7677 replaced the stamping with BannedCardSeedData, which
+--    carries the specific per-expansion announcement URL, but
+--    BannedCardSeedData::fillIfNull() only writes source_url when it is NULL --
+--    by design, so that admin edits survive re-running app:banned-cards:seed.
+--    Rows created before 01e7677 were never NULL, so the seed has skipped them
+--    ever since.
+--
+-- 2. pokemon.com has retired every banned-list announcement older than the Mega
+--    Evolution era. Seven of the ten waves are affected and now point at the
+--    Internet Archive, matching the constants in
+--    src/Service/BannedCardSeedData.php.
+--
+--    Each timestamp is pinned to the newest capture verified to contain the
+--    announcement text. This matters: for several of these the most recent
+--    captures archived pokemon.com's Imperva bot-challenge page rather than the
+--    article, so neither the newest snapshot nor a timestamp-less /web/<url>
+--    redirect reliably lands on readable content.
+--
+-- Three waves keep their live links and get no statement below:
+--   2015-06-15  Lysandre's Trump Card, Bulbanews (predates pokemon.com's own
+--               ban coverage; different domain, still live)
+--   2025-10-10  Mega Evolution
+--   2026-04-10  Mega Evolution: Perfect Order
+--
+-- Liveness was established by opening each URL in a browser, not from a script.
+-- pokemon.com sits behind Imperva, which answers 200 with a challenge page even
+-- for paths that do not exist, so HTTP status from a client proves nothing in
+-- either direction.
+--
+-- Keyed on effective_date rather than card_name: one announcement covers all
+-- the cards banned on its date, whereas card_name is ambiguous -- Unown is
+-- banned on two separate dates under two different announcements, and several
+-- names exist in both straight- and curly-apostrophe spellings
+-- (Lt. Surge's / Lt. Surge’s, Maxie's / Maxie’s).
+--
+-- Every statement guards on the specific stale values it expects to replace --
+-- the generic list URL and the retired live URL -- so the script is idempotent,
+-- safe to run against either database or twice, and unable to overwrite an
+-- admin edit made after it was written.
+--
+-- Deliberately NOT filtered on deleted_at IS NULL. No ban is soft-deleted
+-- today, and correcting one that is means it comes back with a working link
+-- rather than a stale one if it is ever restored.
+--
+-- DATE(effective_date) is safe: every row stores exact midnight and the column
+-- has no NULLs. The function call defeats the index, which is irrelevant
+-- against 27 rows.
+--
+-- Rows affected: 24 of the 27 bans, on production and on any database seeded
+-- before these URL changes. Both converge on the same final state.
+--
+-- @see docs/features.md F6.14 -- Banned cards public page
+
+-- Sun & Moon—Burning Shadows, 2 cards: Archeops, Forest of Giant Plants.
+UPDATE banned_card
+SET source_url = 'https://web.archive.org/web/20251009150613/https://www.pokemon.com/us/sun-moon-burning-shadows-banned-list-and-rule-changes-quarterly-announcement/'
+WHERE DATE(effective_date) = '2017-08-18'
+  AND source_url IN (
+    'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list',
+    'https://www.pokemon.com/us/sun-moon-burning-shadows-banned-list-and-rule-changes-quarterly-announcement/'
+  );
+
+-- Sun & Moon—Celestial Storm, 3 cards: Ghetsis, Hex Maniac, Puzzle of Time.
+UPDATE banned_card
+SET source_url = 'https://web.archive.org/web/20260107021812/https://www.pokemon.com/us/sun-moon-celestial-storm-banned-list-and-rule-changes-quarterly-announcement/'
+WHERE DATE(effective_date) = '2018-08-17'
+  AND source_url IN (
+    'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list',
+    'https://www.pokemon.com/us/sun-moon-celestial-storm-banned-list-and-rule-changes-quarterly-announcement/'
+  );
+
+-- Sun & Moon—Team Up, 3 cards: Delinquent, Maxie's Hidden Ball Trick, Unown DAMAGE.
+UPDATE banned_card
+SET source_url = 'https://web.archive.org/web/20251127005634/https://www.pokemon.com/us/sun-moon-team-up-banned-list-and-rule-changes-quarterly-announcement/'
+WHERE DATE(effective_date) = '2019-02-15'
+  AND source_url IN (
+    'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list',
+    'https://www.pokemon.com/us/sun-moon-team-up-banned-list-and-rule-changes-quarterly-announcement/'
+  );
+
+-- Sun & Moon—Cosmic Eclipse, 10 cards, the largest single ban wave.
+UPDATE banned_card
+SET source_url = 'https://web.archive.org/web/20260510162917/https://www.pokemon.com/us/sun-moon-cosmic-eclipse-banned-list-and-rule-changes-announcement/'
+WHERE DATE(effective_date) = '2019-11-15'
+  AND source_url IN (
+    'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list',
+    'https://www.pokemon.com/us/sun-moon-cosmic-eclipse-banned-list-and-rule-changes-announcement/'
+  );
+
+-- Sword & Shield—Vivid Voltage, 4 cards: Milotic, Oranguru, Sableye, Shaymin-EX.
+UPDATE banned_card
+SET source_url = 'https://web.archive.org/web/20260207042335/https://www.pokemon.com/us/sword-shield-vivid-voltage-banned-list-and-rule-changes-announcement/'
+WHERE DATE(effective_date) = '2020-11-27'
+  AND source_url IN (
+    'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list',
+    'https://www.pokemon.com/us/sword-shield-vivid-voltage-banned-list-and-rule-changes-announcement/'
+  );
+
+-- Scarlet & Violet—Paldean Fates, 1 card: Scoop Up Net.
+UPDATE banned_card
+SET source_url = 'https://web.archive.org/web/20251204063553/https://www.pokemon.com/us/play-pokemon/about/scarlet-violet-paldean-fates-banned-list-and-rule-changes-announcement'
+WHERE DATE(effective_date) = '2024-02-09'
+  AND source_url IN (
+    'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list',
+    'https://www.pokemon.com/us/play-pokemon/about/scarlet-violet-paldean-fates-banned-list-and-rule-changes-announcement'
+  );
+
+-- Scarlet & Violet—Stellar Crown, 1 card: Duskull.
+UPDATE banned_card
+SET source_url = 'https://web.archive.org/web/20260117133609/https://www.pokemon.com/us/play-pokemon/about/scarlet-violet-stellar-crown-banned-list-and-rule-changes-announcement'
+WHERE DATE(effective_date) = '2024-09-27'
+  AND source_url IN (
+    'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list',
+    'https://www.pokemon.com/us/play-pokemon/about/scarlet-violet-stellar-crown-banned-list-and-rule-changes-announcement'
+  );

--- a/src/Service/BannedCardSeedData.php
+++ b/src/Service/BannedCardSeedData.php
@@ -41,13 +41,25 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 final readonly class BannedCardSeedData
 {
-    private const string COSMIC_ECLIPSE_BURNING_SHADOWS_URL = 'https://www.pokemon.com/us/sun-moon-burning-shadows-banned-list-and-rule-changes-quarterly-announcement/';
-    private const string CELESTIAL_STORM_URL = 'https://www.pokemon.com/us/sun-moon-celestial-storm-banned-list-and-rule-changes-quarterly-announcement/';
-    private const string TEAM_UP_URL = 'https://www.pokemon.com/us/sun-moon-team-up-banned-list-and-rule-changes-quarterly-announcement/';
-    private const string COSMIC_ECLIPSE_URL = 'https://www.pokemon.com/us/sun-moon-cosmic-eclipse-banned-list-and-rule-changes-announcement/';
-    private const string VIVID_VOLTAGE_URL = 'https://www.pokemon.com/us/sword-shield-vivid-voltage-banned-list-and-rule-changes-announcement/';
-    private const string PALDEAN_FATES_URL = 'https://www.pokemon.com/us/play-pokemon/about/scarlet-violet-paldean-fates-banned-list-and-rule-changes-announcement';
-    private const string STELLAR_CROWN_URL = 'https://www.pokemon.com/us/play-pokemon/about/scarlet-violet-stellar-crown-banned-list-and-rule-changes-announcement';
+    // pokemon.com has retired every banned-list announcement older than the
+    // Mega Evolution era, so all of those point at the Internet Archive.
+    //
+    // Each timestamp is pinned to the newest capture verified to hold the
+    // announcement text itself. This matters: for several of these the most
+    // recent captures archived pokemon.com's bot-challenge page rather than the
+    // article, so neither "latest capture" nor a timestamp-less
+    // /web/<url> redirect reliably lands on readable content.
+    //
+    // Only three links below are still live: the two Mega Evolution
+    // announcements and the Bulbanews article for Lysandre's Trump Card (which
+    // predates pokemon.com covering bans on its own site).
+    private const string BURNING_SHADOWS_URL = 'https://web.archive.org/web/20251009150613/https://www.pokemon.com/us/sun-moon-burning-shadows-banned-list-and-rule-changes-quarterly-announcement/';
+    private const string CELESTIAL_STORM_URL = 'https://web.archive.org/web/20260107021812/https://www.pokemon.com/us/sun-moon-celestial-storm-banned-list-and-rule-changes-quarterly-announcement/';
+    private const string TEAM_UP_URL = 'https://web.archive.org/web/20251127005634/https://www.pokemon.com/us/sun-moon-team-up-banned-list-and-rule-changes-quarterly-announcement/';
+    private const string COSMIC_ECLIPSE_URL = 'https://web.archive.org/web/20260510162917/https://www.pokemon.com/us/sun-moon-cosmic-eclipse-banned-list-and-rule-changes-announcement/';
+    private const string VIVID_VOLTAGE_URL = 'https://web.archive.org/web/20260207042335/https://www.pokemon.com/us/sword-shield-vivid-voltage-banned-list-and-rule-changes-announcement/';
+    private const string PALDEAN_FATES_URL = 'https://web.archive.org/web/20251204063553/https://www.pokemon.com/us/play-pokemon/about/scarlet-violet-paldean-fates-banned-list-and-rule-changes-announcement';
+    private const string STELLAR_CROWN_URL = 'https://web.archive.org/web/20260117133609/https://www.pokemon.com/us/play-pokemon/about/scarlet-violet-stellar-crown-banned-list-and-rule-changes-announcement';
     private const string MEGA_EVOLUTION_URL = 'https://www.pokemon.com/us/play-pokemon/about/mega-evolution/mega-evolution-banned-list-and-rule-changes-announcement';
     private const string PERFECT_ORDER_URL = 'https://www.pokemon.com/us/play-pokemon/about/mega-evolution/mega-evolution-perfect-order-banned-list-and-rule-changes-announcement';
     private const string LYSANDRE_BULBANEWS_URL = 'https://bulbanews.bulbagarden.net/wiki/Lysandre%27s_Trump_Card_banned_from_TCG_competitive_play';
@@ -86,7 +98,7 @@ final readonly class BannedCardSeedData
     private const array SEEDS = [
         'Archeops' => [
             'effectiveDate' => '2017-08-18',
-            'sourceUrl' => self::COSMIC_ECLIPSE_BURNING_SHADOWS_URL,
+            'sourceUrl' => self::BURNING_SHADOWS_URL,
             'explanation' => "The existence of **Archeops**'s **Ancient Power** Ability has a very negative effect on decks that rely on evolved Pokémon. There are ways to combat it—**Hex Maniac**, **Evosoda**, or **Wobbuffet** are a few examples—but decks that focus on evolved Pokémon are forced to use these cards just to evolve their Pokémon. The combination of **Maxie's Hidden Ball Trick** with **Archeops** can stop Evolution before the opponent ever gets a chance to evolve their Pokémon, which limits the number of viable strategies.",
         ],
         'Chip-Chip Ice Axe' => [
@@ -116,7 +128,7 @@ final readonly class BannedCardSeedData
         ],
         'Forest of Giant Plants' => [
             'effectiveDate' => '2017-08-18',
-            'sourceUrl' => self::COSMIC_ECLIPSE_BURNING_SHADOWS_URL,
+            'sourceUrl' => self::BURNING_SHADOWS_URL,
             'explanation' => "The **Forest of Giant Plants** Stadium card enables many dangerous strategies with Grass-type Pokémon in the Expanded format. These strategies can range from locking down the opponent's options to winning the game on the first turn, and all of them can happen before the opponent ever gets a chance to play. No single strategy was powerful enough to ban this Stadium card, but so many of them existing at the same time gave sufficient cause to ban it.",
         ],
         'Ghetsis' => [


### PR DESCRIPTION
Fixes the source links on the public banned-cards page (F6.14). Two distinct problems.

## 1. Production pointed 17 bans at the generic list page

An older `BannedCardsSyncService` stamped every ban it provisioned with the generic `pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list` page. Commit 01e7677 replaced that stamping with `BannedCardSeedData`, which carries the specific per-expansion announcement URL — but `BannedCardSeedData::fillIfNull()` only writes `source_url` when it is `NULL`, by design, so that admin edits survive re-running `app:banned-cards:seed`.

Rows created before 01e7677 were never `NULL`, so the seed has silently skipped them ever since. Local was rebuilt from scratch after that commit and so looked correct, which is why this went unnoticed.

## 2. pokemon.com retired seven of the ten announcements

Every banned-list announcement older than the Mega Evolution era now 404s. Those seven waves point at the Internet Archive instead.

Each timestamp is pinned to the newest capture **verified to contain the announcement text**. This is load-bearing: for several of these the most recent captures archived pokemon.com's Imperva bot-challenge page rather than the article, so neither the latest snapshot nor a timestamp-less `/web/<url>` redirect reliably lands on readable content.

| effective_date | rows | announcement | link |
|---|---:|---|---|
| 2015-06-15 | 1 | Lysandre's Trump Card (Bulbanews) | live |
| 2017-08-18 | 2 | Burning Shadows | archive 2025-10-09 |
| 2018-08-17 | 3 | Celestial Storm | archive 2026-01-07 |
| 2019-02-15 | 3 | Team Up | archive 2025-11-27 |
| 2019-11-15 | 10 | Cosmic Eclipse | archive 2026-05-10 |
| 2020-11-27 | 4 | Vivid Voltage | archive 2026-02-07 |
| 2024-02-09 | 1 | Paldean Fates | archive 2025-12-04 |
| 2024-09-27 | 1 | Stellar Crown | archive 2026-01-17 |
| 2025-10-10 | 1 | Mega Evolution | live |
| 2026-04-10 | 1 | Mega Evolution: Perfect Order | live |

Liveness was established by opening each URL in a browser, **not** from a script: pokemon.com answers `200` with a challenge page even for paths that do not exist, so HTTP status proves nothing in either direction. A control request to a deliberately bogus path confirmed this.

## Repair script

`scripts/backfill_banned_card_source_urls.sql` follows the convention of the existing `scripts/backfill_archetype_last_published_at.sql`. It is keyed on `effective_date` rather than `card_name`, because one announcement covers a whole ban wave while `card_name` is ambiguous — `Unown` is banned on two separate dates under two different announcements, and several names exist in both straight- and curly-apostrophe spellings.

Each statement guards on the two stale values it expects (the generic list URL and the retired live URL), so the script is idempotent, safe to run against either database, and unable to overwrite an admin edit made after it was written. 24 of the 27 rows change; both databases converge on the same state.

A data migration was considered and rejected: local was already correct, a database rebuilt from migrations plus seed is already correct, and the sync service no longer plants the generic URL on new rows. This is a one-time repair, not a recurring defect.

## Also

Renames `COSMIC_ECLIPSE_BURNING_SHADOWS_URL` to `BURNING_SHADOWS_URL` — the constant holds the Burning Shadows announcement and has nothing to do with Cosmic Eclipse.

## Verification

- All seven captures fetched independently and confirmed to contain their own banned cards' names (45–64 KB each, zero bot-wall markers)
- Constants cross-checked against database values in both directions: 10 constants, 10 distinct values, no orphans
- Script re-run leaves the database byte-identical (idempotent)
- **Production applied.** Prod and local produce identical MD5 hashes for both the distinct-URL set and the full `effective_date → source_url` mapping. Prod still reads 27 rows / 0 null explanations / 0 null URLs / 0 soft-deletes
- `make cs-fix` 0 fixes · `make phpstan` no errors · full suite green (2656 tests, 7854 assertions, 29 pre-existing skips)
- Longest URL 159 chars against a `varchar(255)` column

## Note for later

Pinned archive links are stable, but they snapshot pages Pokémon has deleted — there is no upstream to fall back to if the Internet Archive ever loses a capture. Mega Evolution is the only era pokemon.com still hosts, so the two remaining live links will likely need the same treatment eventually.